### PR TITLE
Player: Enable hit_from_inside on interact ray

### DIFF
--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -428,6 +428,7 @@ unique_name_in_owner = true
 position = Vector2(0, -24)
 target_position = Vector2(80, 0)
 collision_mask = 32
+hit_from_inside = true
 collide_with_areas = true
 collide_with_bodies = false
 script = ExtResource("3_qhqgy")


### PR DESCRIPTION
Previously, if the player is positioned such that its InteractRay starts inside an NPC's InteractArea, the ray would not be considered to have collided with the NPC so the interaction would not be offered. This can happen because we are faking perspective by giving NPCs (and the player) two hitboxes: one for collisions around the feet, and one for interactions in the player's line of sight.

Enable RayCast2D.hit_from_inside on the player's interact ray.