### PR TITLE
Add linting with gdlint and gdformat, run via pre-commit and CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,20 @@
+name: Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# Cancel any ongoing previous run if a PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    name: Linting and Formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: tox-dev/action-pre-commit-uv@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-added-large-files
+- repo: https://github.com/Scony/godot-gdscript-toolkit
+  rev: 4.3.3
+  hooks:
+  - id: gdlint
+  - id: gdformat
+exclude: |
+  (?x)^(
+    addons/(.*)
+  )$

--- a/scenes/interact_area.gd
+++ b/scenes/interact_area.gd
@@ -10,5 +10,6 @@ signal interaction_ended
 func start_interaction() -> void:
 	interaction_started.emit()
 
+
 func end_interaction() -> void:
 	interaction_ended.emit()

--- a/scenes/interact_label.gd
+++ b/scenes/interact_label.gd
@@ -6,11 +6,13 @@ extends PanelContainer
 
 @onready var label: Label = %Label
 
+
 func _set_label_text(new_text: String) -> void:
 	label_text = new_text
 	if not is_node_ready():
 		return
 	label.text = tr(new_text)
+
 
 func _ready() -> void:
 	_set_label_text(label_text)

--- a/scenes/interact_ray.gd
+++ b/scenes/interact_ray.gd
@@ -6,11 +6,13 @@ var _target_position_right: Vector2
 var _target_position_left: Vector2
 var interact_area: InteractArea
 
+
 func _ready() -> void:
 	_target_position_right = target_position
 	_target_position_left = target_position.reflect(Vector2.UP)
 	if not character and owner is CharacterBody2D:
 		character = owner
+
 
 func _process(_delta: float) -> void:
 	if not character:

--- a/scenes/interact_ray.gd
+++ b/scenes/interact_ray.gd
@@ -2,9 +2,9 @@ extends RayCast2D
 
 @export var character: CharacterBody2D
 
+var interact_area: InteractArea
 var _target_position_right: Vector2
 var _target_position_left: Vector2
-var interact_area: InteractArea
 
 
 func _ready() -> void:

--- a/scenes/npcs/npc.gd
+++ b/scenes/npcs/npc.gd
@@ -7,7 +7,9 @@ enum LOOK_AT_SIDE {
 	RIGHT = 1,
 }
 
-const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("res://scenes/npcs/sprite_frames/sprite_frame_01.tres")
+const DEFAULT_SPRITE_FRAME: SpriteFrames = preload(
+	"res://scenes/npcs/sprite_frames/sprite_frame_01.tres"
+)
 
 @export var look_at_side: LOOK_AT_SIDE = LOOK_AT_SIDE.LEFT:
 	set = _set_look_at_side
@@ -17,11 +19,13 @@ const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("res://scenes/npcs/sprite_fra
 
 @onready var animated_sprite_2d: AnimatedSprite2D = %AnimatedSprite2D
 
+
 func _set_look_at_side(new_look_at_side: LOOK_AT_SIDE) -> void:
 	look_at_side = new_look_at_side
 	if not is_node_ready():
 		return
 	animated_sprite_2d.flip_h = look_at_side == LOOK_AT_SIDE.LEFT
+
 
 func _set_sprite_frames(new_sprite_frames: SpriteFrames) -> void:
 	sprite_frames = new_sprite_frames
@@ -32,6 +36,7 @@ func _set_sprite_frames(new_sprite_frames: SpriteFrames) -> void:
 	animated_sprite_2d.sprite_frames = new_sprite_frames
 	if not Engine.is_editor_hint():
 		animated_sprite_2d.play(animated_sprite_2d.autoplay)
+
 
 func _ready() -> void:
 	_set_look_at_side(look_at_side)

--- a/scenes/npcs/npc.gd
+++ b/scenes/npcs/npc.gd
@@ -2,7 +2,7 @@
 class_name NPC
 extends CharacterBody2D
 
-enum LOOK_AT_SIDE {
+enum LookAtSide {
 	LEFT = -1,
 	RIGHT = 1,
 }
@@ -11,7 +11,7 @@ const DEFAULT_SPRITE_FRAME: SpriteFrames = preload(
 	"res://scenes/npcs/sprite_frames/sprite_frame_01.tres"
 )
 
-@export var look_at_side: LOOK_AT_SIDE = LOOK_AT_SIDE.LEFT:
+@export var look_at_side: LookAtSide = LookAtSide.LEFT:
 	set = _set_look_at_side
 
 @export var sprite_frames: SpriteFrames = DEFAULT_SPRITE_FRAME:
@@ -20,11 +20,11 @@ const DEFAULT_SPRITE_FRAME: SpriteFrames = preload(
 @onready var animated_sprite_2d: AnimatedSprite2D = %AnimatedSprite2D
 
 
-func _set_look_at_side(new_look_at_side: LOOK_AT_SIDE) -> void:
+func _set_look_at_side(new_look_at_side: LookAtSide) -> void:
 	look_at_side = new_look_at_side
 	if not is_node_ready():
 		return
-	animated_sprite_2d.flip_h = look_at_side == LOOK_AT_SIDE.LEFT
+	animated_sprite_2d.flip_h = look_at_side == LookAtSide.LEFT
 
 
 func _set_sprite_frames(new_sprite_frames: SpriteFrames) -> void:

--- a/scenes/npcs/talker/talker.gd
+++ b/scenes/npcs/talker/talker.gd
@@ -9,6 +9,7 @@ const DEFAULT_DIALOGUE: DialogueResource = preload("res://scenes/npcs/talker/def
 
 @onready var interact_area: InteractArea = %InteractArea
 
+
 func _ready() -> void:
 	super._ready()
 	if Engine.is_editor_hint():
@@ -16,8 +17,10 @@ func _ready() -> void:
 	interact_area.interaction_started.connect(_on_interaction_started)
 	DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
 
+
 func _on_interaction_started() -> void:
 	DialogueManager.show_dialogue_balloon(dialogue)
+
 
 func _on_dialogue_ended(_dialogue_resource: DialogueResource) -> void:
 	# This little wait is needed to avoid triggering another dialogue:

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -7,12 +7,13 @@ extends CharacterBody2D
 
 @onready var player_interaction: PlayerInteraction = %PlayerInteraction
 
+
 func _process(delta: float) -> void:
 	if player_interaction.is_interacting:
 		velocity = Vector2.ZERO
 		return
 
-	var axis:Vector2 = Vector2(
+	var axis: Vector2 = Vector2(
 		Input.get_axis(&"ui_left", &"ui_right"),
 		Input.get_axis(&"ui_up", &"ui_down"),
 	)

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -1,9 +1,9 @@
 extends CharacterBody2D
 
-@export_range(10, 100000, 10) var WALK_SPEED: float = 300.0
-@export_range(10, 100000, 10) var RUN_SPEED: float = 500.0
-@export_range(10, 100000, 10) var STOPPING_STEP: float = 1500.0
-@export_range(10, 100000, 10) var MOVING_STEP: float = 4000.0
+@export_range(10, 100000, 10) var walk_speed: float = 300.0
+@export_range(10, 100000, 10) var run_speed: float = 500.0
+@export_range(10, 100000, 10) var stopping_step: float = 1500.0
+@export_range(10, 100000, 10) var moving_step: float = 4000.0
 
 @onready var player_interaction: PlayerInteraction = %PlayerInteraction
 
@@ -20,15 +20,15 @@ func _process(delta: float) -> void:
 
 	var speed: float
 	if Input.is_action_pressed(&"running"):
-		speed = RUN_SPEED
+		speed = run_speed
 	else:
-		speed = WALK_SPEED
+		speed = walk_speed
 
 	var step: float
 	if axis.is_zero_approx():
-		step = STOPPING_STEP
+		step = stopping_step
 	else:
-		step = MOVING_STEP
+		step = moving_step
 
 	velocity = velocity.move_toward(axis * speed, step * delta)
 

--- a/scenes/player/player_interaction.gd
+++ b/scenes/player/player_interaction.gd
@@ -8,13 +8,16 @@ extends Node2D
 var is_interacting: bool:
 	get = _get_is_interacting
 
+
 func _get_is_interacting() -> bool:
 	return not interact_ray.enabled
+
 
 func _ready() -> void:
 	var current_scene: Node = Engine.get_main_loop().current_scene
 	var screen_overlay: CanvasLayer = current_scene.get_node("ScreenOverlay")
 	interact_label.reparent(screen_overlay)
+
 
 func _process(_delta: float) -> void:
 	if is_interacting:
@@ -22,7 +25,9 @@ func _process(_delta: float) -> void:
 	var interact_area: InteractArea = interact_ray.interact_area
 
 	var label_offset: Vector2 = Vector2(interact_label.size.x / 2, interact_label.size.y)
-	interact_label.position = interact_marker.get_global_transform_with_canvas().origin - label_offset
+	interact_label.position = (
+		interact_marker.get_global_transform_with_canvas().origin - label_offset
+	)
 
 	if not interact_area:
 		interact_label.visible = false

--- a/scenes/player/player_interaction.gd
+++ b/scenes/player/player_interaction.gd
@@ -1,12 +1,12 @@
 class_name PlayerInteraction
 extends Node2D
 
+var is_interacting: bool:
+	get = _get_is_interacting
+
 @onready var interact_ray: RayCast2D = %InteractRay
 @onready var interact_marker: Marker2D = $InteractMarker
 @onready var interact_label: InteractLabel = %InteractLabel
-
-var is_interacting: bool:
-	get = _get_is_interacting
 
 
 func _get_is_interacting() -> bool:

--- a/scenes/player/player_sprite.gd
+++ b/scenes/player/player_sprite.gd
@@ -2,9 +2,11 @@ extends AnimatedSprite2D
 
 @export var character: CharacterBody2D
 
+
 func _ready() -> void:
 	if not character and owner is CharacterBody2D:
 		character = owner
+
 
 func _process(_delta: float) -> void:
 	if not character:


### PR DESCRIPTION
This PR reformats the GDScript source files with `gdformat`, and adjusts some declarations to pass `gdlint` and match the [GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html). The diff is pleasingly small, perhaps because there's not much code yet.

It then adds a pre-commit config file to run these checks locally, and sets up a GitHub Actions workflow to run the pre-commit checks on pull requests.