### PR TITLE
MusicPuzzle: Don't listen to xylophone when running in editor

### DIFF
--- a/scenes/music_puzzle/music_puzzle.gd
+++ b/scenes/music_puzzle/music_puzzle.gd
@@ -19,7 +19,8 @@ var _position := 0
 
 
 func _ready() -> void:
-	xylophone.note_played.connect(_on_note_played)
+	if not Engine.is_editor_hint():
+		xylophone.note_played.connect(_on_note_played)
 
 
 func _debug(fmt: String, args: Array = []) -> void:


### PR DESCRIPTION
This is now a `@tool` script so that a configuration warning can be issued if the number of melodies doesn't match the number of bonfires. But as a result, opening this scene in the editor previously issued this warning:

    ERROR: res://scenes/music_puzzle/music_puzzle.gd:22 - Invalid access to property or key 'note_played' on a base object of type 'Node2D (MusicalRockXylophone)'.

This is because MusicalRockXylophone is not a `@tool`.

Guard the signal connection with Engine.is_editor_hint().