### PR TITLE
editorconfig: Configure *.gd files to use tabs for indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,7 @@ root = true
 
 [*]
 charset = utf-8
+
+[*.gd]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
This is the Godot editor's default, but Zed doesn't know that.