### PR TITLE
ci: Rebuild GitHub Pages when a branch is deleted

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,5 +1,6 @@
 name: "Publish to GitHub Pages"
 on:
+  delete:
   workflow_dispatch:
   workflow_run:
     workflows:


### PR DESCRIPTION
In https://github.com/endlessm/amalgamate-pages/releases/tag/v1.0.3 the amalgamate-pages action was updated to not show builds for branches which have been deleted. In the case where the branch was deleted due to a PR being merged, the workflow will end up being run anyway due to the new build on `main`, but this might happen before the branch is deleted; and a branch may also be deleted without having been merged.

Run the workflow when a branch is deleted so that any corresponding web build is removed.