### PR TITLE
Create 2 basic audio buses: Music & SFX

### DIFF
--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -1,0 +1,15 @@
+[gd_resource type="AudioBusLayout" format=3 uid="uid://c7thbop54thnf"]
+
+[resource]
+bus/1/name = &"Music"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/bypass_fx = false
+bus/1/volume_db = 0.0
+bus/1/send = &"Master"
+bus/2/name = &"SFX"
+bus/2/solo = false
+bus/2/mute = false
+bus/2/bypass_fx = false
+bus/2/volume_db = 0.0
+bus/2/send = &"Master"

--- a/scenes/music_puzzle/musical_rock.tscn
+++ b/scenes/music_puzzle/musical_rock.tscn
@@ -74,6 +74,7 @@ debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
 unique_name_in_owner = true
+bus = &"SFX"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 unique_name_in_owner = true


### PR DESCRIPTION
Having separate audio buses allows us to change the volume of all the audio that plays in that bus independently. It also allows adding effects to the buses, but we probably won't even use that. However, I think having at least 2 basic buses for Music and Audio, and have all AudioStreamPlayers use one of them (or a new bus inherited from one of them), would be a good start since that lets us have 2 sliders in the config menu: one for music and one for sound effects.