### PR TITLE
Add explicit type annotations

### DIFF
--- a/scenes/music_puzzle/music_puzzle.gd
+++ b/scenes/music_puzzle/music_puzzle.gd
@@ -14,8 +14,8 @@ signal solved
 ## If enabled, show messages in the console describing the player's progress (or not) in the puzzle
 @export var debug: bool = false
 
-var _current_melody := 0
-var _position := 0
+var _current_melody: int = 0
+var _position: int = 0
 
 
 func _ready() -> void:
@@ -32,7 +32,7 @@ func _on_note_played(note: String) -> void:
 	if _current_melody >= melodies.size():
 		return
 
-	var melody := melodies[_current_melody]
+	var melody: String = melodies[_current_melody]
 	_debug(
 		"Current melody %s position %d expecting %s, received %s",
 		[melody, _position, melody[_position], note],
@@ -68,7 +68,10 @@ func _on_note_played(note: String) -> void:
 
 func _get_configuration_warnings() -> PackedStringArray:
 	if melodies.size() != fires.size():
-		var fmt = "There should be one fire for each melody, but there are %d melodies and %d fires"
-		return [fmt % [melodies.size(), fires.size()]]
+		var fmt: String = """
+			There should be one fire for each melody, \
+			but currently there are %d melodies and %d fires.
+		"""
+		return [fmt.strip_edges() % [melodies.size(), fires.size()]]
 
 	return []

--- a/scenes/music_puzzle/musical_rock.gd
+++ b/scenes/music_puzzle/musical_rock.gd
@@ -3,7 +3,7 @@ extends StaticBody2D
 
 signal note_played
 
-const NOTES = "ABCDEFG"
+const NOTES: String = "ABCDEFG"
 
 ## Note
 @export_enum("A", "B", "C", "D", "E", "F", "G") var note: String = "C":
@@ -24,7 +24,7 @@ func _ready() -> void:
 	audio_stream_player_2d.stream = audio_stream
 
 
-func _modulate_rock():
+func _modulate_rock() -> void:
 	if sprite_2d:
 		var i: int = NOTES.find(note)
 		sprite_2d.modulate = Color.from_hsv(i * 100.0 / NOTES.length(), 0.67, 0.89)

--- a/scenes/music_puzzle/musical_rock_xylophone.gd
+++ b/scenes/music_puzzle/musical_rock_xylophone.gd
@@ -7,13 +7,13 @@ var _notes: Dictionary[String, MusicalRock]
 
 
 func _ready() -> void:
-	for node in get_children():
-		var rock := node as MusicalRock
+	for node: Node in get_children():
+		var rock: MusicalRock = node as MusicalRock
 		if not rock:
 			continue
 
 		_notes[rock.note] = rock
-		rock.note_played.connect(func(): note_played.emit(rock.note))
+		rock.note_played.connect(func() -> void: note_played.emit(rock.note))
 
 
 func play_note(note: String) -> void:


### PR DESCRIPTION
This squashes warnings that are shown in the debugger tab when running the game from the editor.

I have tried to find a way to check for these warnings in CI but it seems hard to do. If I adjust project.godot to make these warnings fatal rather than warnings, it blocks running the project (really annoying in development) or exporting it.

The alternative seems to be to write a CLI tool that feeds the source files into Godot's LSP server and extracts the diagnostics. Overkill.