### PR TITLE
Enable 2D pixel snapping for crisper pixel art look

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -104,3 +104,5 @@ locale/translations_pot_files=PackedStringArray("res://scenes/npcs/talker/defaul
 
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
+2d/snap/snap_2d_transforms_to_pixel=true
+2d/snap/snap_2d_vertices_to_pixel=true

--- a/project.godot
+++ b/project.godot
@@ -105,4 +105,3 @@ locale/translations_pot_files=PackedStringArray("res://scenes/npcs/talker/defaul
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
 2d/snap/snap_2d_transforms_to_pixel=true
-2d/snap/snap_2d_vertices_to_pixel=true


### PR DESCRIPTION
See here:

https://docs.godotengine.org/en/stable/classes/class_projectsettings.html#class-projectsettings-property-rendering-2d-snap-snap-2d-transforms-to-pixel

It's a subtle change, but it should reduce some artifacts that you may see when working with pixel art, like for instance, tiles in tilemaps not quite fitting together, blurry lines, and stuff like that.