### PR TITLE
world_map: Add ScreenOverlay CanvasLayer nodes

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -200,3 +200,5 @@ metadata/_custom_type_script = "uid://hqdquinbimce"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Teleporter"]
 position = Vector2(16, -2.5)
 shape = SubResource("RectangleShape2D_r4ivj")
+
+[node name="ScreenOverlay" type="CanvasLayer" parent="."]

--- a/scenes/world_map/song_sanctuaries.tscn
+++ b/scenes/world_map/song_sanctuaries.tscn
@@ -50,3 +50,5 @@ metadata/_custom_type_script = "uid://hqdquinbimce"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Teleporter"]
 position = Vector2(-1, -2.5)
 shape = SubResource("RectangleShape2D_nfxoe")
+
+[node name="ScreenOverlay" type="CanvasLayer" parent="."]


### PR DESCRIPTION
The Player scene has a label that is shown when an interaction is available. This label is reparented to the current scene's "ScreenOverlay" node. However, the Frays End and Song Sanctuaries scenes did not have a ScreenOverlay node, causing the label to be displayed at an incorrect position (or not visibly at all).

Add a ScreenOverlay node to each scene.