### PR TITLE
Simple global state to store Items (for now)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/icon="uid://bc70phmq55dkf"
 [autoload]
 
 DialogueManager="*res://addons/dialogue_manager/dialogue_manager.gd"
+GameState="*res://scenes/game_state/game_state.tscn"
 
 [debug]
 

--- a/scenes/game_state/game_state.gd
+++ b/scenes/game_state/game_state.gd
@@ -1,0 +1,3 @@
+extends Node
+
+@export var inventory: Inventory = Inventory.new()

--- a/scenes/game_state/game_state.gd.uid
+++ b/scenes/game_state/game_state.gd.uid
@@ -1,0 +1,1 @@
+uid://chmg3o6wyqvwu

--- a/scenes/game_state/game_state.tscn
+++ b/scenes/game_state/game_state.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=5 format=3 uid="uid://cbope0t84e52k"]
+
+[ext_resource type="Script" uid="uid://chmg3o6wyqvwu" path="res://scenes/game_state/game_state.gd" id="1_45hrl"]
+[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/inventory/inventory_item.gd" id="2_vojg7"]
+[ext_resource type="Script" uid="uid://b1t0u12edqkoe" path="res://scenes/inventory/inventory.gd" id="3_u8kfi"]
+
+[sub_resource type="Resource" id="Resource_igp6c"]
+script = ExtResource("3_u8kfi")
+items = Array[ExtResource("2_vojg7")]([])
+metadata/_custom_type_script = "uid://b1t0u12edqkoe"
+
+[node name="GameState" type="Node"]
+script = ExtResource("1_45hrl")
+inventory = SubResource("Resource_igp6c")

--- a/scenes/inventory/inventory.gd
+++ b/scenes/inventory/inventory.gd
@@ -1,0 +1,4 @@
+class_name Inventory
+extends Resource
+
+@export var items: Array[InventoryItem]

--- a/scenes/inventory/inventory.gd.uid
+++ b/scenes/inventory/inventory.gd.uid
@@ -1,0 +1,1 @@
+uid://b1t0u12edqkoe

--- a/scenes/inventory/inventory_item.gd
+++ b/scenes/inventory/inventory_item.gd
@@ -1,0 +1,11 @@
+class_name InventoryItem
+extends Resource
+
+enum ItemType {
+	MEMORY,
+	IMAGINATION,
+	SPIRIT,
+}
+
+@export var name: String
+@export var type: ItemType

--- a/scenes/inventory/inventory_item.gd.uid
+++ b/scenes/inventory/inventory_item.gd.uid
@@ -1,0 +1,1 @@
+uid://bgmwplmj3bfls

--- a/scenes/world_map/song_sanctuaries.tscn
+++ b/scenes/world_map/song_sanctuaries.tscn
@@ -29,7 +29,7 @@ position = Vector2(172, 904)
 text = "Frays End
 Where Everything Begins"
 
-[node name="Player" parent="." instance=ExtResource("3_jbn3a")]
+[node name="Player" parent="." groups=["player"] instance=ExtResource("3_jbn3a")]
 position = Vector2(390, 1049)
 
 [node name="Camera2D" type="Camera2D" parent="Player"]


### PR DESCRIPTION
After some back and forth with @JuanFdS, we came up with an approach that we believe is user friendly for the Learners, if they need to use global state.

We have a global scene called GameState which, at the moment, only has an "inventory", which in turn has "items". We thought that this results in code-as-documentation, where you can know what kind of global state there's by looking into the code of game_state.gd.

Items can be created as resources and they can be, for the time being, of any of the three types: Memory, Imagination, or Spirit.

The global scene can be edited using godot inspector, which can be useful to test different states.
![image](https://github.com/user-attachments/assets/4a0db1db-a7ea-4511-b991-c760bd381afe)

As for persistance, there's none at the moment (other than editing the scene manually, which is fixed at compiled time). But in the future, a serializer / deserializer could be implemented that sets the global state based on some conventions, to ensure that learners can add global state without much hazzle and have that be persisted.

Fixes #9 