### PR TITLE
intro: Replace placeholder text with dialogue

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -91,7 +91,7 @@ running={
 
 [internationalization]
 
-locale/translations_pot_files=PackedStringArray("res://scenes/npcs/talker/default.dialogue", "res://scenes/music_puzzle/musician.dialogue")
+locale/translations_pot_files=PackedStringArray("res://scenes/npcs/talker/default.dialogue", "res://scenes/music_puzzle/musician.dialogue", "res://scenes/intro/intro.dialogue")
 
 [layer_names]
 

--- a/scenes/intro/intro.dialogue
+++ b/scenes/intro/intro.dialogue
@@ -1,0 +1,6 @@
+~ start
+[speed=0.5]You know that feeling you get when you sit with your blanket wrapped around you? Cozy, right? Does everything feel safe?[next=auto]
+[speed=0.5]That blanket is like a hug from a loved one. It shelters you. What color is it? What is it made from?[next=auto]
+do start_fade()
+[speed=0.5]What if I told you that somewhere, not too far nor too near, there’s a world made of fabric that once upon a time used to feel like that, like a hug from a loved one... But now...[next=5]
+=> END

--- a/scenes/intro/intro.dialogue.import
+++ b/scenes/intro/intro.dialogue.import
@@ -1,0 +1,15 @@
+[remap]
+
+importer="dialogue_manager_compiler_14"
+type="Resource"
+uid="uid://bq1eaih8esqsi"
+path="res://.godot/imported/intro.dialogue-25bb5494cefd8148152e7e6e009bbf39.tres"
+
+[deps]
+
+source_file="res://scenes/intro/intro.dialogue"
+dest_files=["res://.godot/imported/intro.dialogue-25bb5494cefd8148152e7e6e009bbf39.tres"]
+
+[params]
+
+defaults=true

--- a/scenes/intro/intro.gd
+++ b/scenes/intro/intro.gd
@@ -1,12 +1,20 @@
 extends Control
 
+## Dialogue introducing the world
+@export var introduction: DialogueResource = preload("res://scenes/intro/intro.dialogue")
+
 @onready var animation_player: AnimationPlayer = $AnimationPlayer
 
 
 func _ready() -> void:
+	DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
+	DialogueManager.show_dialogue_balloon(introduction, "", [self])
+
+
+func start_fade() -> void:
 	animation_player.play(&"introduction")
 
 
-func _process(_delta: float) -> void:
-	if Input.is_action_just_pressed("ui_accept"):
-		get_tree().change_scene_to_packed(preload("res://scenes/main.tscn"))
+func _on_dialogue_ended(_dialogue: DialogueResource) -> void:
+	DialogueManager.dialogue_ended.disconnect(_on_dialogue_ended)
+	get_tree().change_scene_to_packed(preload("res://scenes/main.tscn"))

--- a/scenes/intro/intro.tscn
+++ b/scenes/intro/intro.tscn
@@ -13,22 +13,10 @@ length = 0.001
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Backstory:visible_ratio")
+tracks/0/path = NodePath("TextureRect:material:shader_parameter/saturation")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [0.0]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("TextureRect:material:shader_parameter/saturation")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
@@ -41,22 +29,10 @@ length = 5.0
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("Backstory:visible_ratio")
+tracks/0/path = NodePath("TextureRect:material:shader_parameter/saturation")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 5),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [0.0, 1.0]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("TextureRect:material:shader_parameter/saturation")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
 "times": PackedFloat32Array(0, 5),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
@@ -89,32 +65,6 @@ grow_vertical = 2
 texture = ExtResource("3_teox7")
 expand_mode = 3
 stretch_mode = 6
-
-[node name="Backstory" type="RichTextLabel" parent="."]
-clip_contents = false
-custom_minimum_size = Vector2(1400, 100)
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -700.0
-offset_top = -50.0
-offset_right = 700.0
-offset_bottom = 50.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_horizontal = 4
-size_flags_vertical = 4
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 16
-theme_override_font_sizes/normal_font_size = 72
-text = "A fabric world is unravelled and torn..."
-scroll_active = false
-autowrap_mode = 0
-visible_characters = 0
-visible_ratio = 0.0
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {


### PR DESCRIPTION
Previously, a one-line placeholder introduction to the world was displayed by animating the visible_ratio property of a RichTextLabel.

Instead, define the on-screen introduction text as a dialogue file. Trigger the fade-out animation with a mutation (a.k.a. method call) in the dialogue file. Replace the RichTextLabel with an invocation of that dialogue.

https://github.com/endlessm/threadbare/issues/6