### PR TITLE
player: Use unit-length input vector

### DIFF
--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -13,10 +13,7 @@ func _process(delta: float) -> void:
 		velocity = Vector2.ZERO
 		return
 
-	var axis: Vector2 = Vector2(
-		Input.get_axis(&"ui_left", &"ui_right"),
-		Input.get_axis(&"ui_up", &"ui_down"),
-	)
+	var axis: Vector2 = Input.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down")
 
 	var speed: float
 	if Input.is_action_pressed(&"running"):


### PR DESCRIPTION
Previously, the horizontal and vertical axes were fetched separately as a float between -1 and 1, and then combined into a Vector2. In the case where the player is pressing right and down, the resulting vector will be (1, 1), which has length sqrt(2) ≈ 1.4. This means that the player can move faster on the diagonal than horizontally or vertically.

Instead, use Input.get_vector(), which returns a unit vector based on the four actions provided. This means the player moves the same speed regardless of which direction they're walking/running in.