### PR TITLE
pre-commit: Run formatter before linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
 - repo: https://github.com/Scony/godot-gdscript-toolkit
   rev: 4.3.3
   hooks:
-  - id: gdlint
   - id: gdformat
+  - id: gdlint
 exclude: |
   (?x)^(
     addons/(.*)


### PR DESCRIPTION
In my experience, gdlint often complains about problems (such as line length) that gdformat subsequently fixes.

Run the two commands in the opposite order to reduce noise in the output.