### PR TITLE
ci: Export with Godot 4.4.1

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GODOT_VERSION: 4.4
+  GODOT_VERSION: 4.4.1
 
 jobs:
   build:


### PR DESCRIPTION
This maintenance release was made a couple of days ago. In particular this should fix a shader bug in the web export that manuq ran into when experimenting with deforming the floor as if made of fabric.

https://godotengine.org/article/maintenance-release-godot-4-4-1/ https://github.com/godotengine/godot/pull/103878#issuecomment-2715164989 https://github.com/endlessm/threadbare/issues/10#issuecomment-2715238382