### PR TITLE
intro: Remove [next=auto] directives

### DIFF
--- a/scenes/intro/intro.dialogue
+++ b/scenes/intro/intro.dialogue
@@ -1,6 +1,6 @@
 ~ start
-[speed=0.5]You know that feeling you get when you sit with your blanket wrapped around you? Cozy, right? Does everything feel safe?[next=auto]
-[speed=0.5]That blanket is like a hug from a loved one. It shelters you. What color is it? What is it made from?[next=auto]
+[speed=0.5]You know that feeling you get when you sit with your blanket wrapped around you? Cozy, right? Does everything feel safe?
+[speed=0.5]That blanket is like a hug from a loved one. It shelters you. What color is it? What is it made from?
 do start_fade()
-[speed=0.5]What if I told you that somewhere, not too far nor too near, there’s a world made of fabric that once upon a time used to feel like that, like a hug from a loved one... But now...[next=5]
+[speed=0.5]What if I told you that somewhere, not too far nor too near, there’s a world made of fabric that once upon a time used to feel like that, like a hug from a loved one... But now...
 => END


### PR DESCRIPTION
I had included [next=auto] directives at the end of each line of the introduction so that the intro text would advance automatically after a few moments (proportional to the length of the text).

What I had not appreciated is that if you configure the text to advance automatically, the player can't press ui_accept (space/A) to move forward more quickly. This is annoying if you want to skip the introduction.

Remove these directives.