### PR TITLE
Fix #79: stealth level is broken on release builds

### DIFF
--- a/scenes/enemies/guard/guard.gd
+++ b/scenes/enemies/guard/guard.gd
@@ -383,8 +383,17 @@ func _notification(what: int) -> void:
 ## Function used for a tool button that either selects the current patrol_path
 ## in the editor, or creates a new one
 func edit_patrol_path() -> void:
+	if not Engine.is_editor_hint():
+		return
+
+	# Cannot directly reference [class EditorInterface] in code that isn't
+	# part of a script that runs only in the editor (like plugins).
+	# This function should only be called in the editor, but having a direct
+	# reference to the [class EditorInterface] causes errors on runtime builds.
+	var editor_interface = Engine.get_singleton("EditorInterface")
+
 	if patrol_path:
-		EditorInterface.edit_node.call_deferred(patrol_path)
+		editor_interface.edit_node.call_deferred(patrol_path)
 	else:
 		var new_patrol_path: Path2D = Path2D.new()
 		patrol_path = new_patrol_path
@@ -393,4 +402,4 @@ func edit_patrol_path() -> void:
 		patrol_path.global_position = global_position
 		patrol_path.curve = Curve2D.new()
 		patrol_path.name = "%s-PatrolPath" % name
-		EditorInterface.edit_node.call_deferred(patrol_path)
+		editor_interface.edit_node.call_deferred(patrol_path)


### PR DESCRIPTION
It can be played here: https://endlessm.github.io/threadbare/#stealth_level/stealth_level

Having a reference to an editor's only type causes errors on release build. Changed the code so it dynamically finds the node.

Directly referencing a node like EditorInterface can only be done in plugins and scripts that only runs in the editor.