### PR TITLE
Disable INFERRED_DECLARATION warning

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -25,7 +25,6 @@ Transitions="*res://scenes/transitions/transitions.tscn"
 [debug]
 
 gdscript/warnings/untyped_declaration=1
-gdscript/warnings/inferred_declaration=1
 
 [dialogue_manager]
 


### PR DESCRIPTION
Previously, we had configured the project such that the following code would raise a warning that the type was being inferred rather than explicitly specified:

    var sprite := Sprite2D.new()

https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/static_typing.html#warning-system says:

> Additionally, you can enable the INFERRED_DECLARATION warning if you
> prefer a more readable and reliable, but more verbose syntax.

While it's nice to spell out the types of variables in some cases – particularly top-level fields of a class – my feeling is that writing out the type of every variable in a function is often less readable. Sadly there is no way to enable this warning only for top-level fields.

Disable this warning, allowing variables to have an inferred type when initialised with :=. The following will still be rejected because the variable is wholly untyped:

    var sprite = Sprite2D.new()