### PR TITLE
Added Pause System

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ DialogueManager="*res://addons/dialogue_manager/dialogue_manager.gd"
 GameState="*res://scenes/game_state/game_state.tscn"
 SceneSwitcher="*res://scenes/scene_switcher/scene_switcher.gd"
 Transitions="*res://scenes/transitions/transitions.tscn"
+Pause="*res://scenes/globals/pause.gd"
 
 [debug]
 

--- a/scenes/globals/pause.gd
+++ b/scenes/globals/pause.gd
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Node
+
+signal pause_changed(system: System, paused: bool)
+
+enum System {
+	PLAYER_INPUT,
+	GAME,
+}
+
+var _pause_requests: Dictionary[System, Array] = {
+	System.PLAYER_INPUT: [],
+	System.GAME: [],
+}
+
+
+func _ready() -> void:
+	pause_changed.connect(_on_pause_changed)
+
+
+func _on_pause_changed(system: System, paused: bool) -> void:
+	if not is_inside_tree():
+		# This can happen when the game is quitting.
+		return
+
+	match system:
+		System.GAME:
+			get_tree().paused = paused
+
+
+func pause_system(system: System, node: Node) -> void:
+	var nodes_pausing: Array = _pause_requests[system]
+
+	if nodes_pausing.has(node):
+		print(
+			(
+				"Node %s requested pause for system %s but already exists"
+				% [node.name, System.find_key(system)]
+			)
+		)
+
+		return
+
+	var was_paused: bool = is_paused(system)
+
+	nodes_pausing.push_back(node)
+	node.tree_exited.connect(self._remove_pauses_of_node.bind(node), CONNECT_ONE_SHOT)
+
+	if not was_paused:
+		pause_changed.emit(system, true)
+
+
+func unpause_system(system: System, node: Node) -> void:
+	var nodes_pausing: Array = _pause_requests[system]
+
+	if nodes_pausing.has(node):
+		node.tree_exited.disconnect(self._remove_pauses_of_node.bind(system, node))
+
+		nodes_pausing.erase(node)
+
+		if nodes_pausing.is_empty():
+			pause_changed.emit(system, false)
+
+
+func is_paused(system: System) -> bool:
+	return not _pause_requests[system].is_empty()
+
+
+func _remove_pauses_of_node(removed_node: Node) -> void:
+	for system: System in _pause_requests.keys():
+		var nodes_pausing: Array = _pause_requests[system]
+
+		if nodes_pausing.has(removed_node):
+			nodes_pausing.erase(removed_node)
+
+			if nodes_pausing.is_empty():
+				pause_changed.emit(system, false)

--- a/scenes/globals/pause.gd.uid
+++ b/scenes/globals/pause.gd.uid
@@ -1,0 +1,1 @@
+uid://b4wpfgte45uhr

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -48,12 +48,17 @@ func _process(delta: float) -> void:
 		velocity = Vector2.ZERO
 		return
 
-	var axis: Vector2 = Input.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down")
+	var axis: Vector2 = (
+		Input.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down")
+		if not Pause.is_paused(Pause.System.PLAYER_INPUT)
+		else Vector2.ZERO
+	)
+
 	if not axis.is_zero_approx():
 		last_nonzero_axis = axis
 
 	var speed: float
-	if Input.is_action_pressed(&"running"):
+	if Input.is_action_pressed(&"running") and not Pause.is_paused(Pause.System.PLAYER_INPUT):
 		speed = run_speed
 	else:
 		speed = walk_speed

--- a/scenes/player/player_fighting.gd
+++ b/scenes/player/player_fighting.gd
@@ -18,7 +18,9 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
-	if Input.is_action_just_pressed(&"ui_accept"):
+	if Pause.is_paused(Pause.System.PLAYER_INPUT):
+		is_fighting = false
+	elif Input.is_action_just_pressed(&"ui_accept"):
 		is_fighting = true
 	elif Input.is_action_just_released(&"ui_accept"):
 		is_fighting = false

--- a/scenes/player/player_interaction.gd
+++ b/scenes/player/player_interaction.gd
@@ -37,7 +37,10 @@ func _process(_delta: float) -> void:
 	if not interact_area:
 		interact_label.visible = false
 		return
-	if Input.is_action_just_released(&"ui_accept"):
+	if (
+		Input.is_action_just_released(&"ui_accept")
+		and not Pause.is_paused(Pause.System.PLAYER_INPUT)
+	):
 		interact_area.interaction_ended.connect(_on_interaction_ended)
 		interact_area.start_interaction(interact_ray.target_position.x < 0)
 		interact_ray.enabled = false

--- a/scenes/scene_switcher/scene_switcher.gd
+++ b/scenes/scene_switcher/scene_switcher.gd
@@ -60,14 +60,12 @@ func _set_hash(resource_path: String) -> void:
 		_window.location.replace(url.href)
 
 
-func change_to_file_with_transition(scene_path: String, spawn_point: NodePath = ^""):
-	# We should probably pause the game during transitions. But pause is
-	# not trivial, so I suggest first tackling it in another issue, then we can
-	# add it here.
-
+func change_to_file_with_transition(scene_path: String, spawn_point: NodePath = ^"") -> void:
+	Pause.pause_system(Pause.System.PLAYER_INPUT, self)
 	await Transitions.leave_scene(Transition.Effect.RIGHT_TO_LEFT_WIPE)
 	change_to_file(scene_path, spawn_point)
 	await Transitions.introduce_scene(Transition.Effect.LEFT_TO_RIGHT_WIPE)
+	Pause.unpause_system(Pause.System.PLAYER_INPUT, self)
 
 
 func change_to_file(scene_path: String, spawn_point: NodePath = ^"") -> void:


### PR DESCRIPTION
Previously, if the player continues to hold a direction during the transition, the character would be moved in the new scene. This could lead to the character ending up in an unexpected location on the other side of the transition – perhaps even off the edge of the scene.

To solve this issue, and to move forward in adding all the systems that the game needs to function, a Pause System has been added, and it is used during scene transitions.

The Pause System allows pausing the whole game, or just the player input, and is flexible enough to allow adding other kinds of pauses. It also supports being requested pauses from a multitude of different origins, and handling it gracefully. This pattern of requests prevents some bugs that could appear if the pause logic becomes more complex. For instance let's say we have an inventory and a pause menu. And both pause the game. The pattern ensures that as long as one is opened, the game is paused. Another safety measure: Each pause request is attached to a node. If that node leaves the tree, then it is assumed that the request should be cleared.

This PR also adds a global singleton called Pause, which handles the pause requests and pausing / unpausing. This has to be global because pauses can affect scenes right after they load (for instance, during a transition), and also, because the mechanism for pausing the whole tree in Godot is global and transcends the current scene.

Fixes #70 