### PR TITLE
Talker: Look at player when interacting

### DIFF
--- a/scenes/interact/interact_area.gd
+++ b/scenes/interact/interact_area.gd
@@ -3,14 +3,14 @@
 class_name InteractArea
 extends Area2D
 
-signal interaction_started
+signal interaction_started(from_right: bool)
 signal interaction_ended
 
 @export var action: String = "Talk"
 
 
-func start_interaction() -> void:
-	interaction_started.emit()
+func start_interaction(from_right: bool) -> void:
+	interaction_started.emit(from_right)
 
 
 func end_interaction() -> void:

--- a/scenes/music_puzzle/musical_rock.gd
+++ b/scenes/music_puzzle/musical_rock.gd
@@ -32,7 +32,7 @@ func _modulate_rock() -> void:
 		sprite_2d.modulate = Color.from_hsv(i * 100.0 / NOTES.length(), 0.67, 0.89)
 
 
-func _on_interaction_started() -> void:
+func _on_interaction_started(_from_right: bool) -> void:
 	await play()
 	interact_area.interaction_ended.emit()
 

--- a/scenes/npcs/talker/talker.gd
+++ b/scenes/npcs/talker/talker.gd
@@ -9,6 +9,8 @@ const DEFAULT_DIALOGUE: DialogueResource = preload("res://scenes/npcs/talker/def
 @export var npc_name: String
 @export var dialogue: DialogueResource = DEFAULT_DIALOGUE
 
+var _previous_look_at_side: NPC.LookAtSide
+
 @onready var interact_area: InteractArea = %InteractArea
 
 
@@ -20,11 +22,14 @@ func _ready() -> void:
 	DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
 
 
-func _on_interaction_started() -> void:
+func _on_interaction_started(from_right: bool) -> void:
+	_previous_look_at_side = look_at_side
+	look_at_side = NPC.LookAtSide.RIGHT if from_right else NPC.LookAtSide.LEFT
 	DialogueManager.show_dialogue_balloon(dialogue, "", [self])
 
 
 func _on_dialogue_ended(_dialogue_resource: DialogueResource) -> void:
+	look_at_side = _previous_look_at_side
 	# This little wait is needed to avoid triggering another dialogue:
 	await get_tree().create_timer(0.3).timeout
 	interact_area.interaction_ended.emit()

--- a/scenes/player/player_interaction.gd
+++ b/scenes/player/player_interaction.gd
@@ -39,7 +39,7 @@ func _process(_delta: float) -> void:
 		return
 	if Input.is_action_just_released(&"ui_accept"):
 		interact_area.interaction_ended.connect(_on_interaction_ended)
-		interact_area.start_interaction()
+		interact_area.start_interaction(interact_ray.target_position.x < 0)
 		interact_ray.enabled = false
 		interact_label.visible = false
 	else:


### PR DESCRIPTION
When the player start interaction signal is emitted, it also tells if it's interacting from the right side. Then the Talker NPC saves the previous facing direction, and faces the player while the interaction happens.

Adjust the music rocks which also use the interaction to ignore the parameter.