### PR TITLE
ci: Report errors from `reuse lint`

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,5 +31,7 @@ jobs:
       with:
         cache-dependency-glob: ".github/workflows/checks.yaml"
     - name: Check REUSE compliance
+      shell: bash
       run: |
+        set -o pipefail
         uv run --with reuse reuse lint | tee $GITHUB_STEP_SUMMARY

--- a/scenes/ink_combat/ink_combat.gd
+++ b/scenes/ink_combat/ink_combat.gd
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
 extends Node2D
 
 signal finished


### PR DESCRIPTION
When I added a job that runs `reuse lint`, I piped its output to `tee $GITHUB_STEP_SUMMARY` so that the output shows up in a nicely-formatted way in the workflow run summary.

Unfortunately, by default the exit status of a shell pipeline is the exit status of the rightmost command. This means that even if `reuse lint` fails, the pipeline will succeed, erroneously claiming that the licensing information is correctly specified.

Use bash's pipefail option to cause the pipeline to fail in this case.