### PR TITLE
Remove date from first-party FileCopyrightText notices

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -20,7 +20,7 @@ path = [
     # .import files are largely machine-generated but developers can tweak their contents
     "**/*.import",
 ]
-SPDX-FileCopyrightText = "2025 The Threadbare Authors"
+SPDX-FileCopyrightText = "The Threadbare Authors"
 SPDX-License-Identifier = "MPL-2.0"
 
 [[annotations]]

--- a/assets/midjourney/embroidered-world-map.webp.license
+++ b/assets/midjourney/embroidered-world-map.webp.license
@@ -1,4 +1,4 @@
-SPDX-FileCopyrightText: 2025 The Threadbare Authors
+SPDX-FileCopyrightText: The Threadbare Authors
 SPDX-License-Identifier: CC-BY-SA-4.0
 
 This image was created by Midjourney. Per the Midjourney Terms of Service:

--- a/scenes/ink_combat/big_splash/big_splash.gd
+++ b/scenes/ink_combat/big_splash/big_splash.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 class_name BigSplash
 extends Node2D

--- a/scenes/ink_combat/ink_blob/ink_blob.gd
+++ b/scenes/ink_combat/ink_blob/ink_blob.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 class_name InkBlob
 extends RigidBody2D

--- a/scenes/ink_combat/ink_drinker/ink_drinker.gd
+++ b/scenes/ink_combat/ink_drinker/ink_drinker.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 class_name InkDrinker
 extends CharacterBody2D

--- a/scenes/ink_combat/inkwell/inkwell.gd
+++ b/scenes/ink_combat/inkwell/inkwell.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 class_name Inkwell
 extends StaticBody2D

--- a/scenes/ink_combat/player/animation_player.gd
+++ b/scenes/ink_combat/player/animation_player.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 extends AnimationPlayer
 

--- a/scenes/ink_combat/player/player.gd
+++ b/scenes/ink_combat/player/player.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 class_name FightingPlayer
 extends CharacterBody2D

--- a/scenes/ink_combat/player/player_fighting.gd
+++ b/scenes/ink_combat/player/player_fighting.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 extends Node2D
 

--- a/scenes/ink_combat/player/player_sprite.gd
+++ b/scenes/ink_combat/player/player_sprite.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 extends AnimatedSprite2D
 

--- a/scenes/ink_combat/splash/splash.gd
+++ b/scenes/ink_combat/splash/splash.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 class_name Splash
 extends AnimatedSprite2D

--- a/scenes/player/animation_player.gd
+++ b/scenes/player/animation_player.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 extends AnimationPlayer
 

--- a/scenes/scene_switcher/scene_switcher.gd
+++ b/scenes/scene_switcher/scene_switcher.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 extends Node
 

--- a/scenes/transitions/transition_layer.gdshader
+++ b/scenes/transitions/transition_layer.gdshader
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 The Threadbare Authors
+// SPDX-FileCopyrightText: The Threadbare Authors
 // SPDX-License-Identifier: MPL-2.0
 shader_type canvas_item;
 render_mode unshaded;

--- a/scenes/transitions/transitions.gd
+++ b/scenes/transitions/transitions.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 class_name Transition
 extends CanvasLayer

--- a/scenes/world_map/story_quest_starter.gd
+++ b/scenes/world_map/story_quest_starter.gd
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Threadbare Authors
+# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 @tool
 class_name StoryQuestStarter


### PR DESCRIPTION
Previously, the codebase was inconsistent. Some files used:

    SPDX-FileCopyrightText: 2025 The Threadbare Authors

while others used:

    SPDX-FileCopyrightText: The Threadbare Authors

As argued in https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/ there is no strict need to include the year in copyright notices – the information is present in the Git commit history. And excluding the year means that there is no need to think about bumping the upper bound of the range each time a file is modified in a new year.

Remove the year from first-party copyright notices.