### PR TITLE
Adding a Player Controller

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -107,7 +107,7 @@ running={
 
 [internationalization]
 
-locale/translations_pot_files=PackedStringArray("res://scenes/npcs/talker/default.dialogue", "res://scenes/music_puzzle/musician.dialogue", "res://scenes/intro/intro.dialogue", "res://scenes/stealth_level/stealth_level_elder_intro.dialogue", "res://scenes/world_map/story_quest_starter.dialogue", "res://scenes/stealth_level/stealth_level_challenge_complete.dialogue")
+locale/translations_pot_files=PackedStringArray("res://scenes/npcs/talker/default.dialogue", "res://scenes/music_puzzle/musician.dialogue", "res://scenes/intro/intro.dialogue", "res://scenes/stealth_level/stealth_level_elder_intro.dialogue", "res://scenes/world_map/story_quest_starter.dialogue")
 
 [layer_names]
 

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -48,17 +48,13 @@ func _process(delta: float) -> void:
 		velocity = Vector2.ZERO
 		return
 
-	var axis: Vector2 = (
-		Input.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down")
-		if not Pause.is_paused(Pause.System.PLAYER_INPUT)
-		else Vector2.ZERO
-	)
+	var axis: Vector2 = %PlayerController.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down")
 
 	if not axis.is_zero_approx():
 		last_nonzero_axis = axis
 
 	var speed: float
-	if Input.is_action_pressed(&"running") and not Pause.is_paused(Pause.System.PLAYER_INPUT):
+	if %PlayerController.is_action_pressed(&"running"):
 		speed = run_speed
 	else:
 		speed = walk_speed

--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=93 format=3 uid="uid://iu2q66clupc6"]
+[gd_scene load_steps=94 format=3 uid="uid://iu2q66clupc6"]
 
 [ext_resource type="Texture2D" uid="uid://dm0dwcbjsb743" path="res://assets/tiny-swords/Factions/Knights/Troops/Warrior/Blue/Warrior_Blue.png" id="1_3vyb7"]
 [ext_resource type="Script" uid="uid://bwllxup305eib" path="res://scenes/player/player.gd" id="1_g2els"]
@@ -9,6 +9,7 @@
 [ext_resource type="Script" uid="uid://e78f8iq448e1" path="res://scenes/player/animation_player.gd" id="7_0owmy"]
 [ext_resource type="Script" uid="uid://kni2yl26matc" path="res://scenes/player/player_fighting.gd" id="7_5gtgg"]
 [ext_resource type="PackedScene" uid="uid://deqi3gd0anesg" path="res://scenes/health_bar/health_bar.tscn" id="8_h17s1"]
+[ext_resource type="Script" uid="uid://jpf848nkaa7h" path="res://scenes/player/player_controller.gd" id="8_qek5x"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_g2els"]
 atlas = ExtResource("1_3vyb7")
@@ -1202,3 +1203,7 @@ libraries = {
 &"": SubResource("AnimationLibrary_qek5x")
 }
 script = ExtResource("7_0owmy")
+
+[node name="PlayerController" type="Node" parent="."]
+unique_name_in_owner = true
+script = ExtResource("8_qek5x")

--- a/scenes/player/player_controller.gd
+++ b/scenes/player/player_controller.gd
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Node
+
+
+func is_action_pressed(action: StringName, exact_match: bool = false) -> bool:
+	return not inputs_paused() and Input.is_action_pressed(action, exact_match)
+
+
+func is_action_just_pressed(action: StringName, exact_match: bool = false) -> bool:
+	return not inputs_paused() and Input.is_action_just_pressed(action, exact_match)
+
+
+func is_action_just_released(action: StringName, exact_match: bool = false) -> bool:
+	#Since inputs being paused is assumed to be like if the player suddenly
+	#left the controller inactive, we don't check the pause for release
+	return Input.is_action_just_released(action, exact_match)
+
+
+func get_vector(
+	negative_x: StringName,
+	positive_x: StringName,
+	negative_y: StringName,
+	positive_y: StringName,
+	deadzone: float = -1.0
+) -> Vector2:
+	return (
+		Vector2.ZERO
+		if inputs_paused()
+		else Input.get_vector(negative_x, positive_x, negative_y, positive_y, deadzone)
+	)
+
+
+func inputs_paused() -> bool:
+	return Pause.is_paused(Pause.System.PLAYER_INPUT)

--- a/scenes/player/player_controller.gd.uid
+++ b/scenes/player/player_controller.gd.uid
@@ -1,0 +1,1 @@
+uid://jpf848nkaa7h

--- a/scenes/player/player_fighting.gd
+++ b/scenes/player/player_fighting.gd
@@ -18,11 +18,9 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
-	if Pause.is_paused(Pause.System.PLAYER_INPUT):
-		is_fighting = false
-	elif Input.is_action_just_pressed(&"ui_accept"):
+	if %PlayerController.is_action_just_pressed(&"ui_accept"):
 		is_fighting = true
-	elif Input.is_action_just_released(&"ui_accept"):
+	elif %PlayerController.is_action_just_released(&"ui_accept"):
 		is_fighting = false
 
 

--- a/scenes/player/player_interaction.gd
+++ b/scenes/player/player_interaction.gd
@@ -37,10 +37,8 @@ func _process(_delta: float) -> void:
 	if not interact_area:
 		interact_label.visible = false
 		return
-	if (
-		Input.is_action_just_released(&"ui_accept")
-		and not Pause.is_paused(Pause.System.PLAYER_INPUT)
-	):
+
+	if %PlayerController.is_action_just_released(&"ui_accept"):
 		interact_area.interaction_ended.connect(_on_interaction_ended, CONNECT_ONE_SHOT)
 		interact_area.start_interaction(interact_ray.target_position.x < 0)
 		interact_ray.enabled = false


### PR DESCRIPTION
Since we need to be able to pause the inputs of a player, a Player Controller has been added as an intermediary between the Input singleton and the player scripts. This controller checks if the input has been paused, and if so, ignores them.

Player Controllers are also a good practice in general, since they allow to easily have player characters that are controlled by entities that are not input, like code for cinematics, or another player through multiplayer.