### PR TITLE
project: Remove reference to deleted dialogue file

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -107,7 +107,7 @@ running={
 
 [internationalization]
 
-locale/translations_pot_files=PackedStringArray("res://scenes/npcs/talker/default.dialogue", "res://scenes/music_puzzle/musician.dialogue", "res://scenes/intro/intro.dialogue", "res://scenes/stealth_level/stealth_level_elder_intro.dialogue", "res://scenes/world_map/story_quest_starter.dialogue", "res://scenes/stealth_level/stealth_level_challenge_complete.dialogue")
+locale/translations_pot_files=PackedStringArray("res://scenes/npcs/talker/default.dialogue", "res://scenes/music_puzzle/musician.dialogue", "res://scenes/intro/intro.dialogue", "res://scenes/stealth_level/stealth_level_elder_intro.dialogue", "res://scenes/world_map/story_quest_starter.dialogue")
 
 [layer_names]
 


### PR DESCRIPTION
scenes/stealth_level/stealth_level_challenge_complete.dialogue was removed in commit bb68c70b8c84293de0560cb882c7cc9fc6ec7a8f ("Added collectibles to music puzzle and stealth level") because the NPC in question was replaced by a collectible item.

Remove it from the translations_pot_files list.