### PR TITLE
Make interact label position work even if camera's zoomed

### DIFF
--- a/scenes/ink_combat/ink_combat.tscn
+++ b/scenes/ink_combat/ink_combat.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=4 uid="uid://c764br4tplkb2"]
+[gd_scene load_steps=9 format=4 uid="uid://c764br4tplkb2"]
 
 [ext_resource type="Script" uid="uid://c38tkgfys3d63" path="res://scenes/ink_combat/ink_combat.gd" id="1_v7ikp"]
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_wrx86"]
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://b82nsrh332syj" path="res://scenes/ink_combat/ink_drinker/ink_drinker.tscn" id="5_h0i4r"]
 [ext_resource type="PackedScene" uid="uid://drkv055xkrpuu" path="res://scenes/ink_combat/reward.tscn" id="6_28gg6"]
 [ext_resource type="PackedScene" uid="uid://y8ha8abfyap2" path="res://scenes/ink_combat/inkwell/inkwell.tscn" id="6_v7ikp"]
+[ext_resource type="PackedScene" uid="uid://cq5nivq3remyi" path="res://scenes/ui/screen_overlay.tscn" id="8_28gg6"]
 
 [node name="InkCombat" type="Node2D"]
 script = ExtResource("1_v7ikp")
@@ -92,7 +93,6 @@ ink_color_name = 1
 unique_name_in_owner = true
 position = Vector2(1464, 1220)
 
-[node name="ScreenOverlay" type="CanvasLayer" parent="."]
-follow_viewport_enabled = true
+[node name="ScreenOverlay" parent="." instance=ExtResource("8_28gg6")]
 
 [connection signal="finished" from="." to="OnTheGround/Reward" method="_on_ink_combat_finished"]

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=4 uid="uid://7hoy2p14t6kc"]
+[gd_scene load_steps=19 format=4 uid="uid://7hoy2p14t6kc"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_0wfyh"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/player/player.tscn" id="3_sugp2"]
@@ -14,6 +14,7 @@
 [ext_resource type="Texture2D" uid="uid://dgqq26xsu3hrf" path="res://scenes/music_puzzle/clues/3.png" id="12_jkv2x"]
 [ext_resource type="Texture2D" uid="uid://dybrvl42chyoi" path="res://scenes/music_puzzle/clues/4.png" id="13_jbj1t"]
 [ext_resource type="PackedScene" path="res://scenes/props/collectible_item.tscn" id="15_jbj1t"]
+[ext_resource type="PackedScene" uid="uid://cq5nivq3remyi" path="res://scenes/ui/screen_overlay.tscn" id="16_dp3eg"]
 [ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/inventory/inventory_item.gd" id="16_muem4"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui/hud.tscn" id="17_muem4"]
 
@@ -131,7 +132,7 @@ revealed = false
 scene_to_go_to = "uid://db6vhi7s2f37c"
 item = SubResource("Resource_dp3eg")
 
-[node name="ScreenOverlay" type="CanvasLayer" parent="."]
+[node name="ScreenOverlay" parent="." instance=ExtResource("16_dp3eg")]
 
 [node name="HUD" parent="." instance=ExtResource("17_muem4")]
 

--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -9,7 +9,7 @@
 [ext_resource type="Script" uid="uid://e78f8iq448e1" path="res://scenes/player/animation_player.gd" id="7_0owmy"]
 [ext_resource type="Script" uid="uid://kni2yl26matc" path="res://scenes/player/player_fighting.gd" id="7_5gtgg"]
 [ext_resource type="PackedScene" uid="uid://deqi3gd0anesg" path="res://scenes/health_bar/health_bar.tscn" id="8_h17s1"]
-[ext_resource type="Script" uid="uid://jpf848nkaa7h" path="res://scenes/player/player_controller.gd" id="8_qek5x"]
+[ext_resource type="Script" path="res://scenes/player/player_controller.gd" id="8_qek5x"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_g2els"]
 atlas = ExtResource("1_3vyb7")

--- a/scenes/player/player_interaction.gd
+++ b/scenes/player/player_interaction.gd
@@ -30,9 +30,7 @@ func _process(_delta: float) -> void:
 	var interact_area: InteractArea = interact_ray.get_interact_area()
 
 	var label_offset: Vector2 = Vector2(interact_label.size.x / 2, interact_label.size.y)
-	interact_label.position = (
-		interact_marker.get_global_transform_with_canvas().origin - label_offset
-	)
+	interact_label.position = interact_marker.global_position - label_offset
 
 	if not interact_area:
 		interact_label.visible = false

--- a/scenes/stealth_level/stealth_level.tscn
+++ b/scenes/stealth_level/stealth_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=31 format=4 uid="uid://db6vhi7s2f37c"]
+[gd_scene load_steps=32 format=4 uid="uid://db6vhi7s2f37c"]
 
 [ext_resource type="Script" uid="uid://dnp0tjloec2d7" path="res://scenes/stealth_level/game_logic.gd" id="1_f6lvl"]
 [ext_resource type="PackedScene" path="res://scenes/props/collectible_item.tscn" id="2_1b8xw"]
@@ -9,6 +9,7 @@
 [ext_resource type="Resource" uid="uid://c1yk3v73nq17b" path="res://scenes/stealth_level/stealth_level_elder_intro.dialogue" id="6_oyx4c"]
 [ext_resource type="Script" uid="uid://dcxadiejx57og" path="res://scenes/stealth_level/stealth_quest.gd" id="7_ghwae"]
 [ext_resource type="PackedScene" uid="uid://d37mebu7atru7" path="res://scenes/enemies/guard/guard.tscn" id="8_lbv6i"]
+[ext_resource type="PackedScene" uid="uid://cq5nivq3remyi" path="res://scenes/ui/screen_overlay.tscn" id="9_xtu6t"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui/hud.tscn" id="10_idy4y"]
 [ext_resource type="PackedScene" uid="uid://dua6mynlw2ptw" path="res://scenes/props/checkpoint/checkpoint.tscn" id="11_idy4y"]
 
@@ -374,7 +375,7 @@ grow_vertical = 2
 color = Color(0, 0, 0, 0)
 metadata/_edit_lock_ = true
 
-[node name="ScreenOverlay" type="CanvasLayer" parent="."]
+[node name="ScreenOverlay" parent="." instance=ExtResource("9_xtu6t")]
 
 [node name="HUD" parent="." instance=ExtResource("10_idy4y")]
 

--- a/scenes/ui/screen_overlay.tscn
+++ b/scenes/ui/screen_overlay.tscn
@@ -1,0 +1,4 @@
+[gd_scene format=3 uid="uid://cq5nivq3remyi"]
+
+[node name="ScreenOverlay" type="CanvasLayer"]
+follow_viewport_enabled = true

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=4 uid="uid://cufkthb25mpxy"]
+[gd_scene load_steps=16 format=4 uid="uid://cufkthb25mpxy"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_4evgk"]
 [ext_resource type="PackedScene" uid="uid://do8ya53bglr13" path="res://scenes/buildings/castle.tscn" id="2_vb7pi"]
@@ -13,6 +13,7 @@
 [ext_resource type="PackedScene" uid="uid://ipvcfv2g0oi1" path="res://scenes/npcs/talker/talker.tscn" id="11_mr2ek"]
 [ext_resource type="Script" uid="uid://hqdquinbimce" path="res://scenes/world_map/teleporter.gd" id="12_r4ivj"]
 [ext_resource type="Script" uid="uid://0enyu5v4ra34" path="res://scenes/world_map/spawn_point.gd" id="13_r4ivj"]
+[ext_resource type="PackedScene" uid="uid://cq5nivq3remyi" path="res://scenes/ui/screen_overlay.tscn" id="13_uojly"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_r4ivj"]
 size = Vector2(52, 127)
@@ -204,7 +205,7 @@ metadata/_custom_type_script = "uid://hqdquinbimce"
 position = Vector2(16, -2.5)
 shape = SubResource("RectangleShape2D_r4ivj")
 
-[node name="ScreenOverlay" type="CanvasLayer" parent="."]
+[node name="ScreenOverlay" parent="." instance=ExtResource("13_uojly")]
 
 [node name="RightEntranceSpawnPoint" type="Marker2D" parent="." groups=["spawn_point"]]
 position = Vector2(2011, 1026)

--- a/scenes/world_map/song_sanctuaries.tscn
+++ b/scenes/world_map/song_sanctuaries.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=4 uid="uid://cnse1w070wmr7"]
+[gd_scene load_steps=12 format=4 uid="uid://cnse1w070wmr7"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_1vl85"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/props/sign.tscn" id="2_lertq"]
@@ -9,6 +9,7 @@
 [ext_resource type="Script" uid="uid://0enyu5v4ra34" path="res://scenes/world_map/spawn_point.gd" id="5_nfxoe"]
 [ext_resource type="PackedScene" uid="uid://7hoy2p14t6kc" path="res://scenes/main.tscn" id="6_58j83"]
 [ext_resource type="Resource" uid="uid://ykdgo73x62wa" path="res://scenes/world_map/story_quest_starter.dialogue" id="7_fb8io"]
+[ext_resource type="PackedScene" uid="uid://cq5nivq3remyi" path="res://scenes/ui/screen_overlay.tscn" id="9_fb8io"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_nfxoe"]
 size = Vector2(58, 115)
@@ -68,7 +69,7 @@ metadata/_custom_type_script = "uid://hqdquinbimce"
 position = Vector2(-1, -2.5)
 shape = SubResource("RectangleShape2D_nfxoe")
 
-[node name="ScreenOverlay" type="CanvasLayer" parent="."]
+[node name="ScreenOverlay" parent="." instance=ExtResource("9_fb8io")]
 
 [node name="LeftEntranceSpawnPoint" type="Marker2D" parent="." groups=["spawn_point"]]
 position = Vector2(32, 1025)


### PR DESCRIPTION
ScreenOverlay had follow_viewport enabled set to true, so it is already passing a transform to its children. Changed the player interaction code so it doesn't try to compensate for the canvas layer, since ScreenOverlay is already handling that with the follow_viewport setting.

Also, replaced every instance of the ScreenOverlay canvas layer by a scene, so if we need to change any setting is done just once.

## Before (85c3721cc4b3525d95ce30dd3f625666ba63a115)

https://github.com/user-attachments/assets/d81f0441-c0c4-4d04-a33f-da75b11daa9f

## Now (1d9eab9e5bf1bd5c768d794dc5f5345223588896)

https://github.com/user-attachments/assets/97a8dbef-446b-4d14-9968-ea1f9386a719

