### PR TITLE
Fixed size label: Fix visibility

### DIFF
--- a/scenes/player/player_interaction.gd
+++ b/scenes/player/player_interaction.gd
@@ -15,6 +15,12 @@ func _get_is_interacting() -> bool:
 	return not interact_ray.enabled
 
 
+func _ready() -> void:
+	var player: Player = owner
+	if player.mode == player.Mode.FIGHTING:
+		interact_label.visible = false
+
+
 func _process(_delta: float) -> void:
 	if is_interacting:
 		return

--- a/scenes/props/fixed_size_label/fixed_size_label.gd
+++ b/scenes/props/fixed_size_label/fixed_size_label.gd
@@ -17,6 +17,15 @@ extends Control
 @onready var label_container: PanelContainer = %LabelContainer
 
 
+func _set(property: StringName, value: Variant) -> bool:
+	if not is_node_ready():
+		return false
+	if property == "visible":
+		label_container.visible = value
+		return true
+	return false
+
+
 func _set_label_text(new_text: String) -> void:
 	label_text = new_text
 	if not is_node_ready():


### PR DESCRIPTION
Fix regression when changing the interact label by the fixed size label in 3aa25d56.

Setting visibility to the new label doesn't hide the label container because it may have been reparented to the ScreenOverlay node.

So, add a generic object setter to the FixedSizeLabel and check if the property being set is the visibility. If so, set the label container visibility to the same value.

Fix https://github.com/endlessm/threadbare/issues/113