### PR TITLE
Change player's behavior node visibility when it changes mode

### DIFF
--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -32,11 +32,18 @@ func _set_mode(new_mode: Mode) -> void:
 		return
 	match mode:
 		Mode.COZY:
-			player_interaction.process_mode = ProcessMode.PROCESS_MODE_INHERIT
-			player_fighting.process_mode = ProcessMode.PROCESS_MODE_DISABLED
+			_toggle_player_behavior(player_interaction, true)
+			_toggle_player_behavior(player_fighting, false)
 		Mode.FIGHTING:
-			player_interaction.process_mode = ProcessMode.PROCESS_MODE_DISABLED
-			player_fighting.process_mode = ProcessMode.PROCESS_MODE_INHERIT
+			_toggle_player_behavior(player_interaction, false)
+			_toggle_player_behavior(player_fighting, true)
+
+
+func _toggle_player_behavior(behavior_node: Node2D, is_active: bool):
+	behavior_node.visible = is_active
+	behavior_node.process_mode = (
+		ProcessMode.PROCESS_MODE_INHERIT if is_active else ProcessMode.PROCESS_MODE_DISABLED
+	)
 
 
 func _ready() -> void:

--- a/scenes/player/player_interaction.gd
+++ b/scenes/player/player_interaction.gd
@@ -17,8 +17,6 @@ func _get_is_interacting() -> bool:
 
 func _ready() -> void:
 	var player: Player = owner
-	if player.mode == player.Mode.FIGHTING:
-		interact_label.visible = false
 
 
 func _process(_delta: float) -> void:

--- a/scenes/props/fixed_size_label/fixed_size_label.gd
+++ b/scenes/props/fixed_size_label/fixed_size_label.gd
@@ -17,15 +17,6 @@ extends Control
 @onready var label_container: PanelContainer = %LabelContainer
 
 
-func _set(property: StringName, value: Variant) -> bool:
-	if not is_node_ready():
-		return false
-	if property == "visible":
-		label_container.visible = value
-		return true
-	return false
-
-
 func _set_label_text(new_text: String) -> void:
 	label_text = new_text
 	if not is_node_ready():
@@ -49,11 +40,16 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
+	visibility_changed.connect(self.on_visibility_changed)
 	var screen_overlay: CanvasLayer = get_tree().current_scene.get_node_or_null("ScreenOverlay")
 	if not screen_overlay:
 		push_error("ScreenOverlay not found in current scene.")
 		return
 	label_container.reparent.call_deferred(screen_overlay)
+
+
+func on_visibility_changed():
+	label_container.visible = is_visible_in_tree()
 
 
 func _exit_tree() -> void:


### PR DESCRIPTION
Also, make Fixed Size Label hide or show the label that it places on the ScreenOverlay based on whether it is visible in the tree or not.


https://github.com/user-attachments/assets/d3aec36e-88fe-43dc-b553-1372b40071b0

