### PR TITLE
Fix 130 interact label doesnt use pixel art font

### DIFF
--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -32,11 +32,18 @@ func _set_mode(new_mode: Mode) -> void:
 		return
 	match mode:
 		Mode.COZY:
-			player_interaction.process_mode = ProcessMode.PROCESS_MODE_INHERIT
-			player_fighting.process_mode = ProcessMode.PROCESS_MODE_DISABLED
+			_toggle_player_behavior(player_interaction, true)
+			_toggle_player_behavior(player_fighting, false)
 		Mode.FIGHTING:
-			player_interaction.process_mode = ProcessMode.PROCESS_MODE_DISABLED
-			player_fighting.process_mode = ProcessMode.PROCESS_MODE_INHERIT
+			_toggle_player_behavior(player_interaction, false)
+			_toggle_player_behavior(player_fighting, true)
+
+
+func _toggle_player_behavior(behavior_node: Node2D, is_active: bool):
+	behavior_node.visible = is_active
+	behavior_node.process_mode = (
+		ProcessMode.PROCESS_MODE_INHERIT if is_active else ProcessMode.PROCESS_MODE_DISABLED
+	)
 
 
 func _ready() -> void:

--- a/scenes/player/player_interaction.gd
+++ b/scenes/player/player_interaction.gd
@@ -17,8 +17,6 @@ func _get_is_interacting() -> bool:
 
 func _ready() -> void:
 	var player: Player = owner
-	if player.mode == player.Mode.FIGHTING:
-		interact_label.visible = false
 
 
 func _process(_delta: float) -> void:

--- a/scenes/props/fixed_size_label/fixed_size_label.gd
+++ b/scenes/props/fixed_size_label/fixed_size_label.gd
@@ -17,15 +17,6 @@ extends Control
 @onready var label_container: PanelContainer = %LabelContainer
 
 
-func _set(property: StringName, value: Variant) -> bool:
-	if not is_node_ready():
-		return false
-	if property == "visible":
-		label_container.visible = value
-		return true
-	return false
-
-
 func _set_label_text(new_text: String) -> void:
 	label_text = new_text
 	if not is_node_ready():
@@ -49,11 +40,16 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
+	visibility_changed.connect(self.on_visibility_changed)
 	var screen_overlay: CanvasLayer = get_tree().current_scene.get_node_or_null("ScreenOverlay")
 	if not screen_overlay:
 		push_error("ScreenOverlay not found in current scene.")
 		return
 	label_container.reparent.call_deferred(screen_overlay)
+
+
+func on_visibility_changed():
+	label_container.visible = is_visible_in_tree()
 
 
 func _exit_tree() -> void:

--- a/scenes/props/fixed_size_label/fixed_size_label.tscn
+++ b/scenes/props/fixed_size_label/fixed_size_label.tscn
@@ -1,9 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://yfpfno276rol"]
 
+[ext_resource type="Theme" uid="uid://cxvdpya062ujt" path="res://scenes/ui/theme.tres" id="1_ah0mj"]
 [ext_resource type="Script" uid="uid://b681aqqkiwo3k" path="res://scenes/props/fixed_size_label/fixed_size_label.gd" id="1_k3ae5"]
-
-[sub_resource type="LabelSettings" id="LabelSettings_hrdht"]
-font_size = 40
 
 [node name="FixedSizeLabel" type="Control"]
 layout_mode = 3
@@ -25,6 +23,7 @@ grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
+theme = ExtResource("1_ah0mj")
 
 [node name="MarginContainer" type="MarginContainer" parent="LabelContainer"]
 layout_mode = 2
@@ -37,8 +36,7 @@ theme_override_constants/margin_bottom = 5
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 1
-theme_override_font_sizes/font_size = 20
+theme_type_variation = &"FixedSizeLabel"
 text = "Talk"
-label_settings = SubResource("LabelSettings_hrdht")
 horizontal_alignment = 1
 vertical_alignment = 1

--- a/scenes/ui/theme.tres
+++ b/scenes/ui/theme.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Theme" load_steps=2 format=3 uid="uid://cxvdpya062ujt"]
+
+[ext_resource type="FontFile" uid="uid://d05uo8wmexkd8" path="res://assets/fonts/m6x11plus.ttf" id="1_cqcnm"]
+
+[resource]
+FixedSizeLabel/base_type = &"Label"
+FixedSizeLabel/font_sizes/font_size = 36
+FixedSizeLabel/fonts/font = ExtResource("1_cqcnm")


### PR DESCRIPTION
Set FixedSizeLabel font to m6x11plus pixel font.

Also, removed different places where the size of the label's font was being modified, and left only one: the theme.

Finally, added a custom type to the newly created theme that is specific for FixedSizeLabel

Branched from https://github.com/endlessm/threadbare/pull/132 , so please review that one first.

![image](https://github.com/user-attachments/assets/4ab1c4fc-14fa-4cfd-b483-fb3fa40116c0)
![image](https://github.com/user-attachments/assets/51f0098d-896e-4ab8-a1ba-355131e51996)
