### PR TITLE
Added transition properties to teleporters and setup transitions in Frays End and Song Sanctuaries

### DIFF
--- a/scenes/globals/property_utils.gd
+++ b/scenes/globals/property_utils.gd
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name PropertyUtils
+extends Object
+
+
+static func get_enum_hint_string(an_enum: Dictionary) -> String:
+	var result := []
+	for name in an_enum.keys():
+		var readable_name: String = name.capitalize().replace("_", " ")
+		result.append("%s:%d" % [readable_name, an_enum[name]])
+	return ",".join(result)
+
+
+static func enum_property(name: String, clazz: StringName, an_enum: Dictionary) -> Dictionary:
+	return {
+		"name": name,
+		"type": TYPE_INT,
+		"class_name": clazz,
+		"hint": PROPERTY_HINT_ENUM,
+		"hint_string": get_enum_hint_string(an_enum),
+		"usage": PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_CLASS_IS_ENUM
+	}

--- a/scenes/globals/property_utils.gd.uid
+++ b/scenes/globals/property_utils.gd.uid
@@ -1,0 +1,1 @@
+uid://b05ru2ni8sv50

--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -60,12 +60,15 @@ func _set_hash(resource_path: String) -> void:
 		_window.location.replace(url.href)
 
 
-func change_to_file_with_transition(scene_path: String, spawn_point: NodePath = ^"") -> void:
-	Pause.pause_system(Pause.System.PLAYER_INPUT, self)
-	await Transitions.leave_scene(Transition.Effect.RIGHT_TO_LEFT_WIPE)
-	change_to_file(scene_path, spawn_point)
-	await Transitions.introduce_scene(Transition.Effect.LEFT_TO_RIGHT_WIPE)
-	Pause.unpause_system(Pause.System.PLAYER_INPUT, self)
+func change_to_file_with_transition(
+	scene_path: String,
+	spawn_point: NodePath = ^"",
+	enter_transition: Transition.Effect = Transition.Effect.RIGHT_TO_LEFT_WIPE,
+	exit_transition: Transition.Effect = Transition.Effect.LEFT_TO_RIGHT_WIPE
+) -> void:
+	Transitions.pause_and_do_transition(
+		change_to_file.bind(scene_path, spawn_point), enter_transition, exit_transition
+	)
 
 
 func change_to_file(scene_path: String, spawn_point: NodePath = ^"") -> void:

--- a/scenes/globals/scene_switcher/transitions/transitions.gd
+++ b/scenes/globals/scene_switcher/transitions/transitions.gd
@@ -71,3 +71,16 @@ func introduce_scene(
 	visible = true
 	await _do_tween(1.0, _transition_effect, duration, easing, transition_type)
 	visible = false
+
+
+func pause_and_do_transition(
+	in_between: Callable,
+	out_transition: Transition.Effect = Transition.Effect.FADE,
+	in_transition: Transition.Effect = Transition.Effect.FADE,
+	system: Pause.System = Pause.System.PLAYER_INPUT
+) -> void:
+	Pause.pause_system(system, self)
+	await leave_scene(out_transition)
+	await in_between.call()
+	await introduce_scene(in_transition)
+	Pause.unpause_system(system, self)

--- a/scenes/globals/scene_switcher/transitions/transitions.tscn
+++ b/scenes/globals/scene_switcher/transitions/transitions.tscn
@@ -7,7 +7,7 @@
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_8r8i7"]
 shader = ExtResource("2_rdj0f")
 shader_parameter/cutoff = 1.0
-shader_parameter/smooth_size = 0.8
+shader_parameter/smooth_size = 0.5
 shader_parameter/mask = ExtResource("3_ij4f6")
 
 [node name="Transitions" type="CanvasLayer"]

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -203,9 +203,9 @@ position = Vector2(2117, 1023)
 collision_layer = 4
 script = ExtResource("12_r4ivj")
 scene_to_go_to = "uid://cnse1w070wmr7"
-spawn_point_path = NodePath("")
-exit_transition = 2
-enter_transition = 1
+spawn_point_path = NodePath("LeftEntranceSpawnPoint")
+exit_transition = 1
+enter_transition = 2
 metadata/_custom_type_script = "uid://hqdquinbimce"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Teleporter"]

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -204,6 +204,8 @@ collision_layer = 4
 script = ExtResource("12_r4ivj")
 scene_to_go_to = "uid://cnse1w070wmr7"
 spawn_point_path = NodePath("")
+exit_transition = 2
+enter_transition = 1
 metadata/_custom_type_script = "uid://hqdquinbimce"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Teleporter"]
@@ -220,5 +222,5 @@ metadata/_custom_type_script = "uid://0enyu5v4ra34"
 
 [node name="VisibleTeleporter" parent="." instance=ExtResource("14_uojly")]
 position = Vector2(537, 287)
-collision_layer = 4
+use_transition = false
 spawn_point_path = NodePath("../RightEntranceSpawnPoint")

--- a/scenes/world_map/song_sanctuaries.tscn
+++ b/scenes/world_map/song_sanctuaries.tscn
@@ -305,6 +305,8 @@ collision_layer = 4
 script = ExtResource("4_jbn3a")
 scene_to_go_to = "uid://cufkthb25mpxy"
 spawn_point_path = NodePath("RightEntranceSpawnPoint")
+exit_transition = 2
+enter_transition = 1
 metadata/_custom_type_script = "uid://hqdquinbimce"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Teleporter"]


### PR DESCRIPTION
Two issues have been grouped into this PR because they are closely related.

Three properties have been added to the teleporters. A boolean specifying if the teleporter should use transitions, and a couple of properties to specify an enter_transition and an exit_transition. These properties only appear when the "use_transition" boolean is true.

This PR also sets up transitions of Frays End and Song Sanctuaries teleporters so they match the players movement direction.

Fixes #69 
Fixes #67 