### PR TITLE
Fix license of player assets

### DIFF
--- a/scenes/player/player_attack_01.png.license
+++ b/scenes/player/player_attack_01.png.license
@@ -1,2 +1,2 @@
 SPDX-FileCopyrightText: Endless OS Foundation LLC
-SPDX-License-Identifier: CC0-1.0
+SPDX-License-Identifier: CC-BY-SA-4.0

--- a/scenes/player/player_attack_02.png.license
+++ b/scenes/player/player_attack_02.png.license
@@ -1,2 +1,2 @@
 SPDX-FileCopyrightText: Endless OS Foundation LLC
-SPDX-License-Identifier: CC0-1.0
+SPDX-License-Identifier: CC-BY-SA-4.0

--- a/scenes/player/player_idle.png.license
+++ b/scenes/player/player_idle.png.license
@@ -1,2 +1,2 @@
 SPDX-FileCopyrightText: Endless OS Foundation LLC
-SPDX-License-Identifier: CC0-1.0
+SPDX-License-Identifier: CC-BY-SA-4.0

--- a/scenes/player/player_walk.png.license
+++ b/scenes/player/player_walk.png.license
@@ -1,2 +1,2 @@
 SPDX-FileCopyrightText: Endless OS Foundation LLC
-SPDX-License-Identifier: CC0-1.0
+SPDX-License-Identifier: CC-BY-SA-4.0


### PR DESCRIPTION
According to the README, hreadbare's original assets are covered by Creative Commons Attribution-ShareAlike 4.0 International.