### PR TITLE
pre-commit: Exclude SVG files from whitespace checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,9 @@ repos:
   rev: v5.0.0
   hooks:
   - id: trailing-whitespace
+    exclude: \.svg$
   - id: end-of-file-fixer
+    exclude: \.svg$
   - id: check-yaml
   - id: check-added-large-files
 - repo: https://github.com/Scony/godot-gdscript-toolkit


### PR DESCRIPTION
SVG files are, technically speaking, text files; but spiritually they are image files that are generally edited with specialised tools rather than with a text editor.

In particular, it is common for SVG files not to have a trailing newline, and it seems cruel to force artists & developers to add one by hand.

Exclude .svg files from trailing-whitespace and newline checks.