### PR TITLE
Add fade transitions between intro, world map, and quest

### DIFF
--- a/scenes/game_elements/characters/npcs/story_quest_starter/components/story_quest_starter.gd
+++ b/scenes/game_elements/characters/npcs/story_quest_starter/components/story_quest_starter.gd
@@ -42,5 +42,7 @@ func _on_dialogue_ended(dialogue_resource: DialogueResource) -> void:
 
 	if _enter_quest_on_dialogue_ended:
 		GameState.start_quest()
-		SceneSwitcher.change_to_packed(quest_scene)
+		SceneSwitcher.change_to_packed_with_transition(
+			quest_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+		)
 		_enter_quest_on_dialogue_ended = false

--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -66,8 +66,20 @@ func change_to_file_with_transition(
 	enter_transition: Transition.Effect = Transition.Effect.RIGHT_TO_LEFT_WIPE,
 	exit_transition: Transition.Effect = Transition.Effect.LEFT_TO_RIGHT_WIPE
 ) -> void:
+	var scene: PackedScene = load(scene_path)
 	Transitions.pause_and_do_transition(
-		change_to_file.bind(scene_path, spawn_point), enter_transition, exit_transition
+		change_to_packed.bind(scene, spawn_point), enter_transition, exit_transition
+	)
+
+
+func change_to_packed_with_transition(
+	scene: PackedScene,
+	spawn_point: NodePath = ^"",
+	enter_transition: Transition.Effect = Transition.Effect.RIGHT_TO_LEFT_WIPE,
+	exit_transition: Transition.Effect = Transition.Effect.LEFT_TO_RIGHT_WIPE
+) -> void:
+	Transitions.pause_and_do_transition(
+		change_to_packed.bind(scene, spawn_point), enter_transition, exit_transition
 	)
 
 

--- a/scenes/menus/intro/components/intro.gd
+++ b/scenes/menus/intro/components/intro.gd
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 extends Control
 
+const NEXT_SCENE: PackedScene = preload("res://scenes/world_map/frays_end.tscn")
+
 ## Dialogue introducing the world
 @export
 var introduction: DialogueResource = preload("res://scenes/menus/intro/components/intro.dialogue")
@@ -20,4 +22,4 @@ func start_fade() -> void:
 
 func _on_dialogue_ended(_dialogue: DialogueResource) -> void:
 	DialogueManager.dialogue_ended.disconnect(_on_dialogue_ended)
-	SceneSwitcher.change_to_packed(preload("res://scenes/world_map/frays_end.tscn"))
+	SceneSwitcher.change_to_packed(NEXT_SCENE)

--- a/scenes/menus/intro/components/intro.gd
+++ b/scenes/menus/intro/components/intro.gd
@@ -22,4 +22,6 @@ func start_fade() -> void:
 
 func _on_dialogue_ended(_dialogue: DialogueResource) -> void:
 	DialogueManager.dialogue_ended.disconnect(_on_dialogue_ended)
-	SceneSwitcher.change_to_packed(NEXT_SCENE)
+	SceneSwitcher.change_to_packed_with_transition(
+		NEXT_SCENE, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+	)


### PR DESCRIPTION
When testing the game, the abrupt scene-switches at the end of the world map and when entering a quest feel bad, particularly compared to other scene transitions.

Add fade transitions.

The splash-to-intro transition is a bit trickier for reasons that I will explain in a subsequent PR, so is not covered here.