### PR TITLE
PlayerInteraction: Disable when inputs are paused

### DIFF
--- a/scenes/game_elements/characters/player/components/player_interaction.gd
+++ b/scenes/game_elements/characters/player/components/player_interaction.gd
@@ -20,11 +20,11 @@ func _process(_delta: float) -> void:
 		return
 	var interact_area: InteractArea = interact_ray.get_interact_area()
 
-	if not interact_area:
+	if %PlayerController.inputs_paused() or not interact_area:
 		interact_label.visible = false
 		return
 
-	if %PlayerController.is_action_just_released(&"ui_accept"):
+	if %PlayerController.is_action_just_pressed(&"ui_accept"):
 		interact_ray.enabled = false
 		interact_label.visible = false
 		interact_area.interaction_ended.connect(_on_interaction_ended, CONNECT_ONE_SHOT)


### PR DESCRIPTION
Previously, it was possible to trigger an interaction while changing scene. For example, when you interact with an NPC and choose to start a quest, the interaction ending triggers a scene transition. However, during this 1-second transition, the player character is (by definition) in the correct position to trigger an interaction with the NPC, so the “Talk” prompt was re-displayed and pressing ui_accept quickly enough would cause the dialogue to begin again.

The first part needs special handling to not display the interact label when inputs are paused: use PlayerController.inputs_paused() to detect this case and hide the label if it would otherwise be displayed.

The second part is because the input handling used PlayerController.is_action_just_released() rather than .is_action_just_pressed(). Unlike the other is_action_* methods in PlayerController, PlayerController.is_action_just_released() ignores whether input is paused. Switching to
PlayerController.is_action_just_pressed() matches other input actions and also addresses this problem. Strictly speaking this is redundant with checking inputs_paused() above, but you might imagine refactoring the input to a different function in future.

Fixes https://github.com/endlessm/threadbare/issues/159