### PR TITLE
MusicalRock: End interaction immediately, while sound plays

### DIFF
--- a/scenes/game_elements/characters/player/components/player_interaction.gd
+++ b/scenes/game_elements/characters/player/components/player_interaction.gd
@@ -25,10 +25,10 @@ func _process(_delta: float) -> void:
 		return
 
 	if %PlayerController.is_action_just_released(&"ui_accept"):
-		interact_area.interaction_ended.connect(_on_interaction_ended, CONNECT_ONE_SHOT)
-		interact_area.start_interaction(interact_ray.target_position.x < 0)
 		interact_ray.enabled = false
 		interact_label.visible = false
+		interact_area.interaction_ended.connect(_on_interaction_ended, CONNECT_ONE_SHOT)
+		interact_area.start_interaction(interact_ray.target_position.x < 0)
 	else:
 		interact_label.visible = true
 		interact_label.label_text = interact_area.action

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock.gd
@@ -33,7 +33,7 @@ func _modulate_rock() -> void:
 
 
 func _on_interaction_started(_from_right: bool) -> void:
-	await play()
+	play()
 	interact_area.interaction_ended.emit()
 
 


### PR DESCRIPTION
Previously, the rock interaction lasted as long as the sound effect. This was annoying because the player was frozen on the spot for the whole sound effect, rather than being able to move to the next note.

Don't await the end of the sound effect before ending the interaction.

Helps #112

----

Someone mentioned this in the playtest today; I can't find it in the notes but I think it makes the puzzle feel better. Making this change required fixing a latent bug in PlayerInteraction.