### PR TITLE
Fix several game elements collisions

### DIFF
--- a/scenes/game_elements/props/buildings/castle/castle.tscn
+++ b/scenes/game_elements/props/buildings/castle/castle.tscn
@@ -14,6 +14,8 @@ texture = ExtResource("1_84rdl")
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
 position = Vector2(0, -63)
+collision_layer = 16
+collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
 position = Vector2(0, 63)

--- a/scenes/game_elements/props/buildings/house/house_1.tscn
+++ b/scenes/game_elements/props/buildings/house/house_1.tscn
@@ -9,6 +9,8 @@ size = Vector2(64.0002, 80)
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
 position = Vector2(1, -98)
+collision_layer = 16
+collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
 position = Vector2(-1.00012, 66.0001)

--- a/scenes/game_elements/props/buildings/house/house_2.tscn
+++ b/scenes/game_elements/props/buildings/house/house_2.tscn
@@ -9,6 +9,8 @@ size = Vector2(62.7499, 97.0001)
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
 position = Vector2(1, -98)
+collision_layer = 16
+collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
 position = Vector2(-0.999973, 65.3749)

--- a/scenes/game_elements/props/buildings/tower/tower.tscn
+++ b/scenes/game_elements/props/buildings/tower/tower.tscn
@@ -9,6 +9,8 @@ size = Vector2(56, 85.0002)
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
 position = Vector2(0, -63)
+collision_layer = 16
+collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
 position = Vector2(0, 39)

--- a/scenes/game_elements/props/sign/sign.tscn
+++ b/scenes/game_elements/props/sign/sign.tscn
@@ -20,6 +20,7 @@ offset = Vector2(0, -30)
 
 [node name="Collider" type="StaticBody2D" parent="."]
 collision_layer = 16
+collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Collider"]
 rotation = -1.57079

--- a/scenes/game_elements/props/tree/tree.tscn
+++ b/scenes/game_elements/props/tree/tree.tscn
@@ -16,6 +16,8 @@ scale = Vector2(1, 1)
 texture = ExtResource("2_2lvgq")
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
+collision_layer = 16
+collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
 shape = SubResource("CircleShape2D_d888c")


### PR DESCRIPTION
All these elements are game elements that the player should collide with. Set them all to the collision layer 5 (walls) and, if they had collision mask 1, removed it since it's redundant.

Fixes https://github.com/endlessm/threadbare/issues/156