### PR TITLE
CollectibleItem: Prevent collecting twice

### DIFF
--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -86,12 +86,11 @@ func _on_interacted(_from_right: bool) -> void:
 
 	GameState.add_collected_item(item)
 
-	interact_area.end_interaction()
-
 	if collected_dialogue:
 		DialogueManager.show_dialogue_balloon(collected_dialogue, dialogue_title, [self])
 		await DialogueManager.dialogue_ended
 
+	interact_area.end_interaction()
 	queue_free()
 
 	if scene_to_go_to:


### PR DESCRIPTION
Previously, it was possible to collect a collectible more than once, if the collectible had associated dialogue.

This was because the interaction was signalled as complete before triggering the dialogue, but before the collectible is queue_free()d. As a result, player input is unpaused, which causes the PlayerInteraction component to be re-enabled, and by definition the player is in a position to trigger the interaction.

Keep the interaction alive until the conversation is complete. Even in the (currently hypothetical) case where collecting the collectible doesn't trigger a scene transition, this is late enough because the collectible is freed at this point.

Fixes https://github.com/endlessm/threadbare/issues/184