### PR TITLE
Fade from splash to intro narrative

### DIFF
--- a/scenes/menus/intro/components/intro.gd
+++ b/scenes/menus/intro/components/intro.gd
@@ -12,6 +12,10 @@ var introduction: DialogueResource = preload("res://scenes/menus/intro/component
 
 
 func _ready() -> void:
+	# Wait a moment before starting the dialogue. In particular, this allows
+	# time for any fade-in transition from the previous scene to finish.
+	await get_tree().create_timer(1.0).timeout
+
 	DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
 	DialogueManager.show_dialogue_balloon(introduction, "", [self])
 

--- a/scenes/menus/splash/components/splash.gd
+++ b/scenes/menus/splash/components/splash.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
-	if Input.is_action_just_pressed(&"ui_accept"):
+	if Input.is_action_just_pressed(&"ui_accept") or Input.is_action_just_pressed(&"ui_cancel"):
 		switch_to_intro()
 
 

--- a/scenes/menus/splash/components/splash.gd
+++ b/scenes/menus/splash/components/splash.gd
@@ -13,8 +13,9 @@ func _ready() -> void:
 	scene_switch_timer.timeout.connect(switch_to_intro)
 
 
-func _process(_delta: float) -> void:
-	if Input.is_action_just_pressed(&"ui_accept") or Input.is_action_just_pressed(&"ui_cancel"):
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed(&"ui_accept") or event.is_action_pressed(&"ui_cancel"):
+		get_viewport().set_input_as_handled()
 		switch_to_intro()
 
 

--- a/scenes/menus/splash/components/splash.gd
+++ b/scenes/menus/splash/components/splash.gd
@@ -4,9 +4,13 @@ extends Node2D
 
 const NEXT_SCENE: PackedScene = preload("res://scenes/menus/intro/intro.tscn")
 
+@onready var logo_stitcher: LogoStitcher = %LogoStitcher
+@onready var scene_switch_timer: Timer = %SceneSwitchTimer
+
 
 func _ready() -> void:
-	$LogoStitcher.finished.connect(_on_logo_stitcher_finished)
+	logo_stitcher.finished.connect(scene_switch_timer.start)
+	scene_switch_timer.timeout.connect(switch_to_intro)
 
 
 func _process(_delta: float) -> void:
@@ -15,9 +19,7 @@ func _process(_delta: float) -> void:
 
 
 func switch_to_intro() -> void:
-	SceneSwitcher.change_to_packed(NEXT_SCENE)
-
-
-func _on_logo_stitcher_finished() -> void:
-	await get_tree().create_timer(5.0).timeout
-	switch_to_intro()
+	scene_switch_timer.timeout.disconnect(switch_to_intro)
+	SceneSwitcher.change_to_packed_with_transition(
+		NEXT_SCENE, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+	)

--- a/scenes/menus/splash/components/splash.gd
+++ b/scenes/menus/splash/components/splash.gd
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 extends Node2D
 
+const NEXT_SCENE: PackedScene = preload("res://scenes/menus/intro/intro.tscn")
+
 
 func _ready() -> void:
 	$LogoStitcher.finished.connect(_on_logo_stitcher_finished)
@@ -13,7 +15,7 @@ func _process(_delta: float) -> void:
 
 
 func switch_to_intro() -> void:
-	SceneSwitcher.change_to_packed(preload("res://scenes/menus/intro/intro.tscn"))
+	SceneSwitcher.change_to_packed(NEXT_SCENE)
 
 
 func _on_logo_stitcher_finished() -> void:

--- a/scenes/menus/splash/splash.tscn
+++ b/scenes/menus/splash/splash.tscn
@@ -31,6 +31,7 @@ position = Vector2(960, 540)
 texture = ExtResource("2_a6n0j")
 
 [node name="LogoStitcher" type="Node2D" parent="." node_paths=PackedStringArray("path", "line", "audio")]
+unique_name_in_owner = true
 script = ExtResource("3_m61hw")
 path = NodePath("Path2D")
 line = NodePath("Line2D")
@@ -62,3 +63,8 @@ offset_bottom = 904.0
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_font_sizes/font_size = 64
 text = "Threadbare"
+
+[node name="SceneSwitchTimer" type="Timer" parent="."]
+unique_name_in_owner = true
+wait_time = 5.0
+one_shot = true


### PR DESCRIPTION
Previously, when the splash screen was complete (either due to 5 seconds passing from the end of the animation, or the player pressing a key), the scene would be switched abruptly to the intro, without any transition.

Add a fade.

Compared to #152 there are a few more details here to deal around avoiding double-transitioning and delaying the start of the intro dialogue until the fade is complete.