### PR TITLE
Add Pause Overlay as a Global Scene

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -107,6 +107,12 @@ running={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":9,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
+pause={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194305,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
+]
+}
 
 [internationalization]
 

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ GameState="*res://scenes/globals/game_state/game_state.tscn"
 SceneSwitcher="*res://scenes/globals/scene_switcher/scene_switcher.gd"
 Transitions="*res://scenes/globals/scene_switcher/transitions/transitions.tscn"
 Pause="*res://scenes/globals/pause/pause.gd"
+PauseOverlay="*res://scenes/globals/pause/pause_overlay.tscn"
 
 [debug]
 

--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -3,7 +3,7 @@
 extends CanvasLayer
 
 
-func _unhandled_key_input(event: InputEvent) -> void:
+func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed(&"pause"):
 		toggle_pause()
 		get_viewport().set_input_as_handled()

--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends CanvasLayer
+
+
+func _unhandled_key_input(event: InputEvent) -> void:
+	if event.is_action_pressed("ui_cancel"):
+		toggle_pause()
+		get_viewport().set_input_as_handled()
+
+
+func toggle_pause() -> void:
+	if Pause.is_paused(Pause.System.GAME):
+		visible = false
+		Pause.unpause_system(Pause.System.GAME, self)
+	else:
+		visible = true
+		Pause.pause_system(Pause.System.GAME, self)

--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -4,7 +4,7 @@ extends CanvasLayer
 
 
 func _unhandled_key_input(event: InputEvent) -> void:
-	if event.is_action_pressed("ui_cancel"):
+	if event.is_action_pressed(&"pause"):
 		toggle_pause()
 		get_viewport().set_input_as_handled()
 

--- a/scenes/globals/pause/pause_overlay.gd.uid
+++ b/scenes/globals/pause/pause_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://y88qplkioj1q

--- a/scenes/globals/pause/pause_overlay.tscn
+++ b/scenes/globals/pause/pause_overlay.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=4 format=3 uid="uid://bo2gd4sehdugm"]
+
+[ext_resource type="Script" uid="uid://y88qplkioj1q" path="res://scenes/globals/pause/pause_overlay.gd" id="1_lf64b"]
+[ext_resource type="Theme" uid="uid://coxcra1002kil" path="res://scenes/ui_elements/shared_components/theme.tres" id="1_s73yc"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_s73yc"]
+bg_color = Color(0, 0, 0, 0.326)
+
+[node name="PauseOverlay" type="CanvasLayer"]
+process_mode = 3
+layer = 2
+visible = false
+script = ExtResource("1_lf64b")
+
+[node name="Panel" type="Panel" parent="."]
+unique_name_in_owner = true
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_s73yc")
+
+[node name="LabelContainer" type="CenterContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="PauseLabel" type="Label" parent="Panel/LabelContainer"]
+layout_mode = 2
+theme = ExtResource("1_s73yc")
+theme_override_font_sizes/font_size = 108
+text = "PAUSED"

--- a/scenes/ui_elements/shared_components/theme.tres
+++ b/scenes/ui_elements/shared_components/theme.tres
@@ -3,6 +3,8 @@
 [ext_resource type="FontFile" uid="uid://d05uo8wmexkd8" path="res://assets/fonts/m6x11plus.ttf" id="1_cqcnm"]
 
 [resource]
+default_font = ExtResource("1_cqcnm")
+default_font_size = 36
 FixedSizeLabel/base_type = &"Label"
 FixedSizeLabel/font_sizes/font_size = 36
 FixedSizeLabel/fonts/font = ExtResource("1_cqcnm")


### PR DESCRIPTION
A simple scene that pauses the game when the user presses escape. It's globally available, so it works in all scenes.

Also: Changed the default font of the theme, so it can be used for labels.

Fixes #170