### PR TITLE
Add a player direction to spawn point

### DIFF
--- a/scenes/game_elements/characters/npcs/shared_components/npc.gd
+++ b/scenes/game_elements/characters/npcs/shared_components/npc.gd
@@ -4,17 +4,11 @@
 class_name NPC
 extends CharacterBody2D
 
-enum LookAtSide {
-	FRONT = 0,
-	LEFT = -1,
-	RIGHT = 1,
-}
-
 const DEFAULT_SPRITE_FRAME: SpriteFrames = preload(
 	"res://scenes/game_elements/characters/shared_components/sprite_frames/sprite_frame_01.tres"
 )
 
-@export var look_at_side: LookAtSide = LookAtSide.LEFT:
+@export var look_at_side: Enums.LookAtSide = Enums.LookAtSide.LEFT:
 	set = _set_look_at_side
 
 @export var sprite_frames: SpriteFrames = DEFAULT_SPRITE_FRAME:
@@ -23,11 +17,11 @@ const DEFAULT_SPRITE_FRAME: SpriteFrames = preload(
 @onready var animated_sprite_2d: AnimatedSprite2D = %AnimatedSprite2D
 
 
-func _set_look_at_side(new_look_at_side: LookAtSide) -> void:
+func _set_look_at_side(new_look_at_side: Enums.LookAtSide) -> void:
 	look_at_side = new_look_at_side
 	if not is_node_ready():
 		return
-	animated_sprite_2d.flip_h = look_at_side == LookAtSide.LEFT
+	animated_sprite_2d.flip_h = look_at_side == Enums.LookAtSide.LEFT
 
 
 func _set_sprite_frames(new_sprite_frames: SpriteFrames) -> void:

--- a/scenes/game_elements/characters/npcs/talker/components/talker.gd
+++ b/scenes/game_elements/characters/npcs/talker/components/talker.gd
@@ -11,7 +11,7 @@ const DEFAULT_DIALOGUE: DialogueResource = preload(
 @export var npc_name: String
 @export var dialogue: DialogueResource = DEFAULT_DIALOGUE
 
-var _previous_look_at_side: NPC.LookAtSide = NPC.LookAtSide.LEFT
+var _previous_look_at_side: Enums.LookAtSide = Enums.LookAtSide.LEFT
 
 @onready var interact_area: InteractArea = %InteractArea
 
@@ -26,8 +26,8 @@ func _ready() -> void:
 
 func _on_interaction_started(from_right: bool) -> void:
 	_previous_look_at_side = look_at_side
-	if look_at_side != NPC.LookAtSide.FRONT:
-		look_at_side = NPC.LookAtSide.RIGHT if from_right else NPC.LookAtSide.LEFT
+	if look_at_side != Enums.LookAtSide.UNSPECIFIED:
+		look_at_side = Enums.LookAtSide.RIGHT if from_right else Enums.LookAtSide.LEFT
 	DialogueManager.show_dialogue_balloon(dialogue, "", [self])
 
 

--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -104,13 +104,18 @@ func _process(delta: float) -> void:
 	move_and_slide()
 
 
-func teleport_to(tele_position: Vector2, smooth_camera: bool = false) -> void:
+func teleport_to(
+	tele_position: Vector2,
+	smooth_camera: bool = false,
+	look_side: Enums.LookAtSide = Enums.LookAtSide.UNSPECIFIED
+) -> void:
 	var camera: Camera2D = get_viewport().get_camera_2d()
 
 	if is_instance_valid(camera):
 		var smoothing_was_enabled: bool = camera.position_smoothing_enabled
 		camera.position_smoothing_enabled = smooth_camera
 		global_position = tele_position
+		%PlayerSprite.look_at_side(look_side)
 		await get_tree().process_frame
 		camera.position_smoothing_enabled = smoothing_was_enabled
 	else:

--- a/scenes/game_elements/characters/player/components/player_sprite.gd
+++ b/scenes/game_elements/characters/player/components/player_sprite.gd
@@ -12,3 +12,9 @@ func _process(_delta: float) -> void:
 		return
 	if not is_zero_approx(player.velocity.x):
 		flip_h = player.velocity.x < 0
+
+
+func look_at_side(side: Enums.LookAtSide) -> void:
+	if side == 0:
+		return
+	flip_h = side < 0

--- a/scenes/game_elements/props/sign/components/sign.gd
+++ b/scenes/game_elements/props/sign/components/sign.gd
@@ -3,9 +3,7 @@
 @tool
 extends Node2D
 
-enum Direction { LEFT = 1, RIGHT = 2 }
-
-@export var direction: Direction = Direction.LEFT:
+@export var direction: Enums.LookAtSide = Enums.LookAtSide.LEFT:
 	set(a_direction):
 		direction = a_direction
 		if !is_inside_tree():
@@ -29,7 +27,7 @@ func _ready() -> void:
 
 
 func update_appearance() -> void:
-	$Appearance.flip_h = direction != Direction.LEFT
+	$Appearance.flip_h = direction == Enums.LookAtSide.RIGHT
 
 
 func _on_area_2d_body_entered(_body: Node2D) -> void:

--- a/scenes/game_elements/props/spawn_point/components/spawn_point.gd
+++ b/scenes/game_elements/props/spawn_point/components/spawn_point.gd
@@ -4,6 +4,8 @@
 class_name SpawnPoint
 extends Marker2D
 
+@export var look_at_side_on_spawn: Enums.LookAtSide = Enums.LookAtSide.UNSPECIFIED
+
 
 func _init() -> void:
 	add_to_group("spawn_point", true)
@@ -21,4 +23,4 @@ func move_player_to_self_position(smooth_camera: bool = false) -> void:
 	var player: Node2D = get_tree().get_first_node_in_group("player")
 
 	if is_instance_valid(player):
-		player.teleport_to(self.global_position, smooth_camera)
+		player.teleport_to(self.global_position, smooth_camera, look_at_side_on_spawn)

--- a/scenes/globals/enums.gd
+++ b/scenes/globals/enums.gd
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name Enums
+
+enum LookAtSide {
+	UNSPECIFIED = 0,
+	LEFT = -1,
+	RIGHT = 1,
+}

--- a/scenes/globals/enums.gd.uid
+++ b/scenes/globals/enums.gd.uid
@@ -1,0 +1,1 @@
+uid://bwkyn3uwenonq

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -179,34 +179,28 @@ y_sort_enabled = true
 
 [node name="Talker" parent="NPCs" instance=ExtResource("11_mr2ek")]
 position = Vector2(961, 292)
-look_at_side = null
 sprite_frames = null
 
 [node name="Talker6" parent="NPCs" instance=ExtResource("11_mr2ek")]
 position = Vector2(1564, 1506)
 npc_name = "Leonardo"
 dialogue = ExtResource("14_yntpr")
-look_at_side = null
 sprite_frames = null
 
 [node name="Talker2" parent="NPCs" instance=ExtResource("11_mr2ek")]
 position = Vector2(1566, 581)
-look_at_side = null
 sprite_frames = null
 
 [node name="Talker3" parent="NPCs" instance=ExtResource("11_mr2ek")]
 position = Vector2(380, 601)
-look_at_side = null
 sprite_frames = null
 
 [node name="Talker4" parent="NPCs" instance=ExtResource("11_mr2ek")]
 position = Vector2(1079, 821)
-look_at_side = null
 sprite_frames = null
 
 [node name="Talker5" parent="NPCs" instance=ExtResource("11_mr2ek")]
 position = Vector2(1769, 922)
-look_at_side = null
 sprite_frames = null
 
 [node name="Teleporter" type="Area2D" parent="."]
@@ -229,6 +223,7 @@ shape = SubResource("RectangleShape2D_r4ivj")
 position = Vector2(2011, 1026)
 gizmo_extents = 30.0
 script = ExtResource("13_r4ivj")
+look_at_side_on_spawn = -1
 metadata/_custom_type_script = "uid://0enyu5v4ra34"
 
 [node name="VisibleTeleporter" parent="." instance=ExtResource("14_uojly")]

--- a/scenes/world_map/song_sanctuaries.tscn
+++ b/scenes/world_map/song_sanctuaries.tscn
@@ -315,4 +315,5 @@ shape = SubResource("RectangleShape2D_nfxoe")
 position = Vector2(32, 1025)
 gizmo_extents = 30.0
 script = ExtResource("5_nfxoe")
+look_at_side_on_spawn = 1
 metadata/_custom_type_script = "uid://0enyu5v4ra34"


### PR DESCRIPTION
This commit adds a player direction to the spawn point. When set to other than "UNSPECIFIED", it will change the player look at direction to either left or right.

When players teleport from one scene to the other, sometimes it looks weird if the player looks in the opposite direction. This solves that issue by allowing to specify the look direction in the spawn point.