### PR TITLE
Add a wind shader to the trees

### DIFF
--- a/scenes/game_elements/props/tree/components/wind_affected_material.tres
+++ b/scenes/game_elements/props/tree/components/wind_affected_material.tres
@@ -1,0 +1,25 @@
+[gd_resource type="ShaderMaterial" load_steps=6 format=3 uid="uid://bmwe2wu7hxepf"]
+
+[ext_resource type="Shader" uid="uid://djspf45cxnom2" path="res://scenes/game_elements/props/tree/tree.gdshader" id="1_un8pg"]
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_f0x1c"]
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_f0x1c"]
+width = 1024
+height = 1024
+noise = SubResource("FastNoiseLite_f0x1c")
+
+[sub_resource type="Curve" id="Curve_f0x1c"]
+_data = [Vector2(0, 0), 0.0, 0.0, 0, 0, Vector2(0.391579, 1), 0.0, 0.0, 0, 0, Vector2(1, 1), 0.0, 0.0, 0, 0]
+point_count = 3
+
+[sub_resource type="CurveTexture" id="CurveTexture_ym1v0"]
+curve = SubResource("Curve_f0x1c")
+
+[resource]
+shader = ExtResource("1_un8pg")
+shader_parameter/wind_affect_curve = SubResource("CurveTexture_ym1v0")
+shader_parameter/phase_period = 1001.0
+shader_parameter/phase_noise = SubResource("NoiseTexture2D_f0x1c")
+shader_parameter/max_wind_speed = 5.0
+shader_parameter/max_wind_intensity = 2.0

--- a/scenes/game_elements/props/tree/tree.gdshader
+++ b/scenes/game_elements/props/tree/tree.gdshader
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: The Threadbare Authors
+// SPDX-License-Identifier: MPL-2.0
+shader_type canvas_item;
+
+uniform sampler2D wind_affect_curve;
+uniform float phase_period : hint_range(1.0, 10000.0, 10.0) = 1000.0;
+uniform sampler2D phase_noise;
+uniform float max_wind_speed : hint_range(0.0, 50.0, 0.1) = 5.0;
+uniform float max_wind_intensity : hint_range(0.0, 10.0, 0.1) = 2.0;
+
+varying vec2 world_pos;
+
+void vertex() {
+   // Transform it into world coordinates
+   world_pos = (MODEL_MATRIX * vec4(1.0, 1.0, 0.0, 1.0)).xy;
+}
+
+void fragment() {
+	vec2 noise_position = world_pos;
+	float noise_value = texture(phase_noise, noise_position / phase_period).x;
+	float wind_phase = noise_value * 100.0;
+	float wind_speed = noise_value * max_wind_speed;
+	float max_offset = sin(TIME * wind_speed + wind_phase) * max_wind_intensity;
+	float curve_value = texture(wind_affect_curve, vec2((1.0 - UV.y), 0.0)).x;
+	COLOR = texture(TEXTURE, UV + vec2(max_offset * (1.0 - UV.y) * curve_value * 0.02, 0.0));
+}

--- a/scenes/game_elements/props/tree/tree.gdshader.uid
+++ b/scenes/game_elements/props/tree/tree.gdshader.uid
@@ -1,0 +1,1 @@
+uid://djspf45cxnom2

--- a/scenes/game_elements/props/tree/tree.tscn
+++ b/scenes/game_elements/props/tree/tree.tscn
@@ -1,18 +1,19 @@
-[gd_scene load_steps=4 format=3 uid="uid://7873qa54birk"]
+[gd_scene load_steps=5 format=3 uid="uid://7873qa54birk"]
 
 [ext_resource type="Script" uid="uid://b0b2y72gvp50f" path="res://scenes/game_elements/props/tree/components/tree.gd" id="1_7ot8u"]
 [ext_resource type="Texture2D" uid="uid://bui8hwo4l3p6y" path="res://scenes/game_elements/props/tree/components/Tree.png" id="2_2lvgq"]
+[ext_resource type="Material" uid="uid://bmwe2wu7hxepf" path="res://scenes/game_elements/props/tree/components/wind_affected_material.tres" id="2_f0x1c"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_d888c"]
 radius = 16.0312
 
 [node name="Tree" type="Node2D"]
-scale = Vector2(0.983872, 1.05449)
 script = ExtResource("1_7ot8u")
 
 [node name="Tree" type="Sprite2D" parent="."]
-position = Vector2(0, -75.8661)
-scale = Vector2(1, 1)
+texture_filter = 1
+material = ExtResource("2_f0x1c")
+position = Vector2(0, -79.7941)
 texture = ExtResource("2_2lvgq")
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]


### PR DESCRIPTION
The trees now have a material that has a shader that simulates wind.

It's done through a fragment shader that offsets the texture sampling based on time and some parameters.

The material also has a noise to define a "wind map" so that trees close to each other have similar wind conditions but there is some variability in the movement. Some parameters are also considered, like max_wind_speed and max_wind_intensity. Those parameters could be increased to simulate a quiet breeze, or a strong gust.