### PR TITLE
Fix wind shader calculations for large positions

### DIFF
--- a/scenes/game_elements/props/tree/tree.gdshader
+++ b/scenes/game_elements/props/tree/tree.gdshader
@@ -16,8 +16,7 @@ void vertex() {
 }
 
 void fragment() {
-	vec2 noise_position = world_pos;
-	float noise_value = texture(phase_noise, noise_position / phase_period).x;
+	float noise_value = texture(phase_noise, fract(world_pos)).x;
 	float wind_phase = noise_value * 100.0;
 	float wind_speed = noise_value * max_wind_speed;
 	float max_offset = sin(TIME * wind_speed + wind_phase) * max_wind_intensity;


### PR DESCRIPTION
There was a bug in the wind shader where large positions would all resolve to the same noise value, making the trees move at unison in those cases.

Instead of using the raw world position as a UV coordinate for the noise texture, we should use its fractional part so it remains between 0 and 1.