### PR TITLE
Consistently capitalize ‘StoryWeaver’ in dialogue

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -31,7 +31,7 @@ gdscript/warnings/untyped_declaration=1
 [dialogue_manager]
 
 editor/new_file_template="~ start
-Elder: [[Hi|Hello|Howdy]], Storyweaver.
+Elder: [[Hi|Hello|Howdy]], StoryWeaver.
 => END
 "
 runtime/balloon_path="uid://dhydhpp43urah"

--- a/scenes/game_elements/characters/npcs/story_quest_starter/components/story_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/story_quest_starter/components/story_quest_starter.dialogue
@@ -1,17 +1,17 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-{{npc_name}}: [[Hi|Hello|Howdy]], Storyweaver.
+{{npc_name}}: [[Hi|Hello|Howdy]], StoryWeaver.
 {{npc_name}}: I have a quest for you. {{quest_description}}
 {{npc_name}}: Will you embark on this quest?
 - No!
-	Storyweaver: I'm afraid of new experiences and want to live a boring, monochrome life.
+	StoryWeaver: I'm afraid of new experiences and want to live a boring, monochrome life.
 	{{npc_name}}: [[Suit yourself.|Maybe I'll see you later.|Think about it and talk to me if you change your mind.]]
 - Maybe later...
-	Storyweaver: I'm not quite ready yet.
+	StoryWeaver: I'm not quite ready yet.
 	{{npc_name}}: No problem. Come back when you're ready.
 - Yes.
-	Storyweaver: OK... I think I'm as ready as I'll ever be.
-	{{npc_name}}: We believe in you, Storyweaver.
+	StoryWeaver: OK... I think I'm as ready as I'll ever be.
+	{{npc_name}}: We believe in you, StoryWeaver.
 	do enter_quest()
 => END

--- a/scenes/game_elements/characters/npcs/talker/components/default.dialogue
+++ b/scenes/game_elements/characters/npcs/talker/components/default.dialogue
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-Elder: [[Hi|Hello|Howdy]], Storyweaver.
+Elder: [[Hi|Hello|Howdy]], StoryWeaver.
 => END

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue
@@ -26,7 +26,7 @@ StoryWeaver: Can you show me what you remember?
 => demonstrate_melody
 
 ~ hello_again
-Musician: Hello again, Storyweaver. Would you like me to remind you what I said?
+Musician: Hello again, StoryWeaver. Would you like me to remind you what I said?
 - Yes => demonstrate_melody
 - No
 	Musician: OK then, good luck.

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/components/dialogues/stealth_level_elder_intro.dialogue
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/components/dialogues/stealth_level_elder_intro.dialogue
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-Tom, the Elder: Hello, Storyweaver. We need you to contact the elder on the other side of the island.
+Tom, the Elder: Hello, StoryWeaver. We need you to contact the elder on the other side of the island.
 Tom, the Elder: The path is full of dangerous weaverns, too many to combat them, so you'll have to avoid them.
 Tom, the Elder: Good luck!
 => END


### PR DESCRIPTION
Previously a mixture of ‘StoryWeaver’ and ‘Storyweaver’ was used.

While the SpongeBob style is not to my taste, that is the capitalization used in the game's design documents. Consistently spell the protagonist's name as ‘StoryWeaver’.