### PR TITLE
Dialogue: Redesign balloon

### DIFF
--- a/scenes/ui_elements/dialogue/balloon.tscn
+++ b/scenes/ui_elements/dialogue/balloon.tscn
@@ -12,70 +12,25 @@ script = ExtResource("1_36de5")
 [node name="Balloon" type="Control" parent="."]
 unique_name_in_owner = true
 layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
 theme = ExtResource("2_pfnde")
 
-[node name="Panel" type="Panel" parent="Balloon"]
-clip_children = 2
-layout_mode = 1
-anchors_preset = 12
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 21.0
-offset_top = -183.0
-offset_right = -19.0
-offset_bottom = -19.0
-grow_horizontal = 2
-grow_vertical = 0
-mouse_filter = 1
+[node name="PanelContainer" type="PanelContainer" parent="Balloon"]
+layout_mode = 0
+offset_right = 384.0
+offset_bottom = 384.0
 
-[node name="Dialogue" type="MarginContainer" parent="Balloon/Panel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="Balloon/Panel/Dialogue"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Balloon/PanelContainer"]
+custom_minimum_size = Vector2(480, 480)
 layout_mode = 2
 
-[node name="CharacterLabel" type="RichTextLabel" parent="Balloon/Panel/Dialogue/VBoxContainer"]
-unique_name_in_owner = true
-modulate = Color(1, 1, 1, 0.501961)
-layout_mode = 2
-mouse_filter = 1
-bbcode_enabled = true
-text = "Character"
-fit_content = true
-scroll_active = false
-
-[node name="DialogueLabel" parent="Balloon/Panel/Dialogue/VBoxContainer" instance=ExtResource("2_a8ve6")]
+[node name="DialogueLabel" parent="Balloon/PanelContainer/VBoxContainer" instance=ExtResource("2_a8ve6")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 text = "Dialogue..."
 
-[node name="Responses" type="MarginContainer" parent="Balloon"]
-layout_mode = 1
-anchors_preset = 7
-anchor_left = 0.5
-anchor_top = 1.0
-anchor_right = 0.5
-anchor_bottom = 1.0
-offset_left = -147.0
-offset_top = -558.0
-offset_right = 494.0
-offset_bottom = -154.0
-grow_horizontal = 2
-grow_vertical = 0
-
-[node name="ResponsesMenu" type="VBoxContainer" parent="Balloon/Responses" node_paths=PackedStringArray("response_template")]
+[node name="ResponsesMenu" type="VBoxContainer" parent="Balloon/PanelContainer/VBoxContainer" node_paths=PackedStringArray("response_template")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 8
@@ -83,9 +38,28 @@ theme_override_constants/separation = 2
 script = ExtResource("3_72ixx")
 response_template = NodePath("ResponseExample")
 
-[node name="ResponseExample" type="Button" parent="Balloon/Responses/ResponsesMenu"]
+[node name="ResponseExample" type="Button" parent="Balloon/PanelContainer/VBoxContainer/ResponsesMenu"]
 layout_mode = 2
 text = "Response example"
 
+[node name="CharacterPanel" type="PanelContainer" parent="Balloon"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(256, 64)
+layout_mode = 2
+offset_left = 64.0
+offset_right = 576.0
+offset_bottom = 64.0
+theme_type_variation = &"BlueRibbon"
+
+[node name="CharacterLabel" type="RichTextLabel" parent="Balloon/CharacterPanel"]
+unique_name_in_owner = true
+layout_mode = 2
+mouse_filter = 1
+theme_override_colors/default_color = Color(1, 1, 1, 1)
+bbcode_enabled = true
+text = "[center]Character[/center]"
+fit_content = true
+scroll_active = false
+
 [connection signal="gui_input" from="Balloon" to="." method="_on_balloon_gui_input"]
-[connection signal="response_selected" from="Balloon/Responses/ResponsesMenu" to="." method="_on_responses_menu_response_selected"]
+[connection signal="response_selected" from="Balloon/PanelContainer/VBoxContainer/ResponsesMenu" to="." method="_on_responses_menu_response_selected"]

--- a/scenes/ui_elements/dialogue/components/balloon.gd
+++ b/scenes/ui_elements/dialogue/components/balloon.gd
@@ -44,6 +44,9 @@ var _locale: String = TranslationServer.get_locale()
 ## The base balloon anchor
 @onready var balloon: Control = %Balloon
 
+## The panel holding the label showing the name of the currently-speaking character
+@onready var character_panel: PanelContainer = %CharacterPanel
+
 ## The label showing the name of the currently speaking character
 @onready var character_label: RichTextLabel = %CharacterLabel
 
@@ -103,8 +106,8 @@ func apply_dialogue_line() -> void:
 	balloon.focus_mode = Control.FOCUS_ALL
 	balloon.grab_focus()
 
-	character_label.visible = not dialogue_line.character.is_empty()
-	character_label.text = tr(dialogue_line.character, "dialogue")
+	character_panel.visible = not dialogue_line.character.is_empty()
+	character_label.text = "[center]%s[/center]" % tr(dialogue_line.character, "dialogue")
 
 	dialogue_label.hide()
 	dialogue_label.dialogue_line = dialogue_line

--- a/scenes/ui_elements/dialogue/components/theme.tres
+++ b/scenes/ui_elements/dialogue/components/theme.tres
@@ -1,11 +1,21 @@
-[gd_resource type="Theme" load_steps=12 format=3 uid="uid://cvitou84ni7qe"]
+[gd_resource type="Theme" load_steps=16 format=3 uid="uid://cvitou84ni7qe"]
 
 [ext_resource type="Texture2D" uid="uid://dv7kcbngjjwq7" path="res://assets/tiny-swords/UI/Buttons/Button_Blue_3Slides.png" id="1_0xtm5"]
 [ext_resource type="Texture2D" uid="uid://bxk0fu4vv6wt2" path="res://assets/tiny-swords/UI/Buttons/Button_Hover_3Slides.png" id="1_1romn"]
 [ext_resource type="FontFile" uid="uid://d05uo8wmexkd8" path="res://assets/fonts/m6x11plus.ttf" id="1_4jodi"]
-[ext_resource type="Texture2D" uid="uid://b00c4kiewn30t" path="res://assets/tiny-swords/UI/Banners/Banner_Horizontal.png" id="1_np8m2"]
+[ext_resource type="Texture2D" uid="uid://cme4pire1qmn1" path="res://assets/tiny-swords/UI/Ribbons/Ribbon_Blue_3Slides.png" id="1_mtpqe"]
 [ext_resource type="Texture2D" uid="uid://bqe8u2t2tsoma" path="res://assets/tiny-swords/UI/Buttons/Button_Disable_3Slides.png" id="1_rcupm"]
+[ext_resource type="Texture2D" uid="uid://rwt2v0hex5nm" path="res://assets/tiny-swords/UI/Ribbons/Ribbon_Yellow_3Slides.png" id="1_rtjv3"]
 [ext_resource type="Texture2D" uid="uid://dcum6i8n2paam" path="res://assets/tiny-swords/UI/Buttons/Button_Blue_3Slides_Pressed.png" id="4_si72l"]
+[ext_resource type="Texture2D" uid="uid://c3yokak1jgx7" path="res://assets/tiny-swords/UI/Banners/Banner_Vertical.png" id="5_mu1ca"]
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_qmeow"]
+content_margin_top = 4.0
+texture = ExtResource("1_mtpqe")
+texture_margin_left = 64.0
+texture_margin_right = 64.0
+axis_stretch_horizontal = 2
+axis_stretch_vertical = 2
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_iy6d2"]
 texture = ExtResource("1_rcupm")
@@ -43,30 +53,42 @@ texture_margin_bottom = 28.0
 axis_stretch_horizontal = 2
 axis_stretch_vertical = 2
 
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_0xtm5"]
-texture = ExtResource("1_np8m2")
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_mu1ca"]
+content_margin_left = 80.0
+content_margin_top = 80.0
+content_margin_right = 80.0
+content_margin_bottom = 80.0
+texture = ExtResource("5_mu1ca")
 texture_margin_left = 64.0
 texture_margin_top = 64.0
 texture_margin_right = 64.0
 texture_margin_bottom = 64.0
-expand_margin_left = 48.0
-expand_margin_top = 48.0
-expand_margin_right = 48.0
-expand_margin_bottom = 32.0
+axis_stretch_horizontal = 2
+axis_stretch_vertical = 2
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_7k42u"]
+content_margin_top = 4.0
+texture = ExtResource("1_rtjv3")
+texture_margin_left = 64.0
+texture_margin_right = 64.0
 axis_stretch_horizontal = 2
 axis_stretch_vertical = 2
 
 [resource]
 default_font = ExtResource("1_4jodi")
 default_font_size = 36
+BlueRibbon/base_type = &"PanelContainer"
+BlueRibbon/styles/panel = SubResource("StyleBoxTexture_qmeow")
 Button/styles/disabled = SubResource("StyleBoxTexture_iy6d2")
 Button/styles/focus = SubResource("StyleBoxTexture_si72l")
 Button/styles/hover = SubResource("StyleBoxTexture_rcupm")
 Button/styles/normal = SubResource("StyleBoxTexture_rcupm")
 Button/styles/pressed = SubResource("StyleBoxTexture_w6oc6")
-MarginContainer/constants/margin_bottom = 15
-MarginContainer/constants/margin_left = 30
-MarginContainer/constants/margin_right = 30
-MarginContainer/constants/margin_top = 15
-Panel/styles/panel = SubResource("StyleBoxTexture_0xtm5")
+MarginContainer/constants/margin_bottom = 16
+MarginContainer/constants/margin_left = 16
+MarginContainer/constants/margin_right = 16
+MarginContainer/constants/margin_top = 16
+PanelContainer/styles/panel = SubResource("StyleBoxTexture_mu1ca")
 RichTextLabel/colors/default_color = Color(0, 0, 0, 1)
+YellowRibbon/base_type = &"PanelContainer"
+YellowRibbon/styles/panel = SubResource("StyleBoxTexture_7k42u")


### PR DESCRIPTION
This rebuilds the dialogue balloon scene to be tall rather than wide, anchored to the top-left corner of the viewport, and with the speaker's name pulled out to a ribbon at the top of the scroll. The dialogue-choice buttons are moved into the scroll.

Compared to the previous implementation, derived from Godot Dialogue Manager's example, I found it clearer to use PanelContainers rather than using Panel and then carefully positioning the children. The theme is updated accordingly.

Two styles of ribbon are defined for the speaker's name, BlueRibbon and YellowRibbon. Only one is used in this implementation, but the intention is that, in future, BlueRibbon will be used for the protagonist's name and YellowRibbon for the names of NPCs.

Compared to the design, the balloon is always anchored at the top-left, rather than being in the top-left for narration and bottom-left for dialogue. Again this is deferred to a future change.

Helps https://github.com/endlessm/threadbare/issues/205