### PR TITLE
Intro: Use straight apostrophe

### DIFF
--- a/scenes/menus/intro/components/intro.dialogue
+++ b/scenes/menus/intro/components/intro.dialogue
@@ -8,5 +8,5 @@ do animation_player.animation_finished
 [speed=0.5]You know that feeling you get when you sit with your blanket wrapped around you? Cozy, right? Does everything feel safe?
 [speed=0.5]That blanket is like a hug from a loved one. It shelters you. What color is it? What is it made from?
 do animation_player.play(&"introduction")
-[speed=0.5]What if I told you that somewhere, not too far nor too near, there’s a world made of fabric that once upon a time used to feel like that, like a hug from a loved one... But now...
+[speed=0.5]What if I told you that somewhere, not too far nor too near, there's a world made of fabric that once upon a time used to feel like that, like a hug from a loved one... But now...
 => END


### PR DESCRIPTION
The current font does not have a glyph for `’`.