### PR TITLE
Splash: Don't handle input while PLAYER_INPUT is is_paused

### DIFF
--- a/scenes/menus/splash/components/splash.gd
+++ b/scenes/menus/splash/components/splash.gd
@@ -14,7 +14,10 @@ func _ready() -> void:
 
 
 func _input(event: InputEvent) -> void:
-	if event.is_action_pressed(&"ui_accept") or event.is_action_pressed(&"ui_cancel"):
+	if (
+		not Pause.is_paused(Pause.System.PLAYER_INPUT)
+		and (event.is_action_pressed(&"ui_accept") or event.is_action_pressed(&"ui_cancel"))
+	):
 		get_viewport().set_input_as_handled()
 		switch_to_intro()
 


### PR DESCRIPTION
Previously, if you pressed Escape or Space twice in quick succession on
the splash screen, switch_to_intro() would be called twice. The second
call triggers a warning when trying to disconnect a signal from the
timer a second time.

Ignore input when PLAYER_INPUT is paused (i.e. mid-transition).
