### PR TITLE
Add link to playable game in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Threadbare
 
+[Play it here!](https://endlessm.github.io/threadbare/)
+
 ## License
 
 Threadbare's original source code in Threadbare itself is covered by [Mozilla


### PR DESCRIPTION
In order to make it easier to find and share the link, add it to the readme of the project.