### PR TITLE
Dialogue: Adjust ribbon colour based on who is speaking

### DIFF
--- a/scenes/game_elements/characters/npcs/talker/components/talker.gd
+++ b/scenes/game_elements/characters/npcs/talker/components/talker.gd
@@ -24,7 +24,7 @@ func _ready() -> void:
 	DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
 
 
-func _on_interaction_started(from_right: bool) -> void:
+func _on_interaction_started(player: Player, from_right: bool) -> void:
 	_previous_look_at_side = look_at_side
 	if look_at_side != Enums.LookAtSide.UNSPECIFIED:
 		look_at_side = Enums.LookAtSide.RIGHT if from_right else Enums.LookAtSide.LEFT

--- a/scenes/game_elements/characters/npcs/talker/components/talker.gd
+++ b/scenes/game_elements/characters/npcs/talker/components/talker.gd
@@ -28,7 +28,7 @@ func _on_interaction_started(player: Player, from_right: bool) -> void:
 	_previous_look_at_side = look_at_side
 	if look_at_side != Enums.LookAtSide.UNSPECIFIED:
 		look_at_side = Enums.LookAtSide.RIGHT if from_right else Enums.LookAtSide.LEFT
-	DialogueManager.show_dialogue_balloon(dialogue, "", [self])
+	DialogueManager.show_dialogue_balloon(dialogue, "", [self, player])
 
 
 func _on_dialogue_ended(_dialogue_resource: DialogueResource) -> void:

--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -17,6 +17,10 @@ const DEFAULT_SPRITE_FRAME: SpriteFrames = preload(
 	"res://scenes/game_elements/characters/shared_components/sprite_frames/story_weaver.tres"
 )
 
+## The character's name. This is used to highlight when the player's character
+## is speaking during dialogue.
+@export var player_name: String = "StoryWeaver"
+
 ## Controls how the player can interact with the world around them.
 @export var mode: Mode = Mode.COZY:
 	set = _set_mode

--- a/scenes/game_elements/characters/player/components/player_interaction.gd
+++ b/scenes/game_elements/characters/player/components/player_interaction.gd
@@ -10,6 +10,8 @@ var is_interacting: bool:
 @onready var interact_marker: Marker2D = %InteractMarker
 @onready var interact_label: FixedSizeLabel = %InteractLabel
 
+@onready var player: Player = self.owner as Player
+
 
 func _get_is_interacting() -> bool:
 	return not interact_zone.monitoring
@@ -28,7 +30,7 @@ func _process(_delta: float) -> void:
 		interact_zone.monitoring = false
 		interact_label.visible = false
 		interact_area.interaction_ended.connect(_on_interaction_ended, CONNECT_ONE_SHOT)
-		interact_area.start_interaction(interact_zone.is_looking_from_right)
+		interact_area.start_interaction(player, interact_zone.is_looking_from_right)
 	else:
 		interact_label.visible = true
 		interact_label.label_text = interact_area.action

--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -79,7 +79,7 @@ func reveal() -> void:
 ## When interacted with, the collectible will display a brief animation
 ## and when that finishes, a new [InventoryItem] will be added to the
 ## [Inventory] and the interaction will have ended.
-func _on_interacted(_from_right: bool) -> void:
+func _on_interacted(player: Player, _from_right: bool) -> void:
 	z_index += 1
 	animation_player.play("collected")
 	await animation_player.animation_finished

--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -87,7 +87,7 @@ func _on_interacted(player: Player, _from_right: bool) -> void:
 	GameState.add_collected_item(item)
 
 	if collected_dialogue:
-		DialogueManager.show_dialogue_balloon(collected_dialogue, dialogue_title, [self])
+		DialogueManager.show_dialogue_balloon(collected_dialogue, dialogue_title, [self, player])
 		await DialogueManager.dialogue_ended
 
 	interact_area.end_interaction()

--- a/scenes/game_elements/props/eternal_loom/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/eternal_loom.gd
@@ -16,7 +16,7 @@ func _ready():
 
 
 func _on_interacted(player: Player, _from_right: bool) -> void:
-	var balloon := DialogueManager.show_dialogue_balloon(ETERNAL_LOOM_INTERACTION, "", [self])
+	DialogueManager.show_dialogue_balloon(ETERNAL_LOOM_INTERACTION, "", [self, player])
 	await DialogueManager.dialogue_ended
 
 	# This little wait is needed to avoid triggering another dialogue:

--- a/scenes/game_elements/props/eternal_loom/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/eternal_loom.gd
@@ -15,7 +15,7 @@ func _ready():
 	interact_area.interaction_started.connect(self._on_interacted)
 
 
-func _on_interacted(_from_right: bool) -> void:
+func _on_interacted(player: Player, _from_right: bool) -> void:
 	var balloon := DialogueManager.show_dialogue_balloon(ETERNAL_LOOM_INTERACTION, "", [self])
 	await DialogueManager.dialogue_ended
 

--- a/scenes/game_elements/props/interact_area/components/interact_area.gd
+++ b/scenes/game_elements/props/interact_area/components/interact_area.gd
@@ -3,7 +3,7 @@
 class_name InteractArea
 extends Area2D
 
-signal interaction_started(from_right: bool)
+signal interaction_started(player: Player, from_right: bool)
 signal interaction_ended
 
 const INTERACTABLE_LAYER = 6
@@ -15,8 +15,8 @@ const INTERACTABLE_LAYER = 6
 @export var action: String = "Talk"
 
 
-func start_interaction(from_right: bool) -> void:
-	interaction_started.emit(from_right)
+func start_interaction(player: Player, from_right: bool) -> void:
+	interaction_started.emit(player, from_right)
 
 
 func end_interaction() -> void:

--- a/scenes/game_elements/props/lever/components/lever.gd
+++ b/scenes/game_elements/props/lever/components/lever.gd
@@ -40,7 +40,7 @@ func update_appearance() -> void:
 	%LeverSprite.frame = 1 if is_on else 0
 
 
-func _on_interact_area_interaction_started(_from_right: bool) -> void:
+func _on_interact_area_interaction_started(_player: Player, _from_right: bool) -> void:
 	toggle()
 	await get_tree().process_frame
 	%InteractArea.end_interaction()

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock.gd
@@ -32,7 +32,7 @@ func _modulate_rock() -> void:
 		sprite_2d.modulate = Color.from_hsv(i * 100.0 / NOTES.length(), 0.67, 0.89)
 
 
-func _on_interaction_started(_from_right: bool) -> void:
+func _on_interaction_started(_player: Player, _from_right: bool) -> void:
 	play()
 	interact_area.interaction_ended.emit()
 

--- a/scenes/ui_elements/dialogue/components/balloon.gd
+++ b/scenes/ui_elements/dialogue/components/balloon.gd
@@ -13,7 +13,12 @@ extends CanvasLayer
 var resource: DialogueResource
 
 ## Temporary game states
-var temporary_game_states: Array = []
+var temporary_game_states: Array = []:
+	set(new_value):
+		temporary_game_states = new_value
+		for state in new_value:
+			if state is Player:
+				_player_name = (state as Player).player_name
 
 ## See if we are waiting for the player
 var is_waiting_for_input: bool = false
@@ -40,6 +45,7 @@ var dialogue_line: DialogueLine:
 var mutation_cooldown: Timer = Timer.new()
 
 var _locale: String = TranslationServer.get_locale()
+var _player_name: String = ""
 
 ## The base balloon anchor
 @onready var balloon: Control = %Balloon
@@ -107,6 +113,9 @@ func apply_dialogue_line() -> void:
 	balloon.grab_focus()
 
 	character_panel.visible = not dialogue_line.character.is_empty()
+	character_panel.theme_type_variation = (
+		"BlueRibbon" if _player_name == dialogue_line.character else "YellowRibbon"
+	)
 	character_label.text = "[center]%s[/center]" % tr(dialogue_line.character, "dialogue")
 
 	dialogue_label.hide()


### PR DESCRIPTION
Previously, the speaker name ribbon was always blue.

With this change, the ribbon is blue if the player's character is speaking, or yellow otherwise, as designed in #162.

This is a little trickier than expected because the player controls different characters in StoryQuests (e.g. Stella in *Stella and the Missing Star*) compared to in the base game & its LoreQuests (StoryWeaver). To make this work, add a `player_name` property to the `Player` class, and pass the `Player` instance through to dialogue, similar to how the `npc_name` and NPC being interacted with is passed to the dialogue. Then, in our custom dialogue balloon, look for the Player in the list of game states, and fish out its name if found.

Fixes #230
