### PR TITLE
StoryQuestStarter: Remove “Maybe later” dialogue branch

### DIFF
--- a/scenes/game_elements/characters/npcs/story_quest_starter/components/story_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/story_quest_starter/components/story_quest_starter.dialogue
@@ -7,9 +7,6 @@
 - No!
 	StoryWeaver: I'm afraid of new experiences and want to live a boring, monochrome life.
 	{{npc_name}}: [[Suit yourself.|Maybe I'll see you later.|Think about it and talk to me if you change your mind.]]
-- Maybe later...
-	StoryWeaver: I'm not quite ready yet.
-	{{npc_name}}: No problem. Come back when you're ready.
 - Yes.
 	StoryWeaver: OK... I think I'm as ready as I'll ever be.
 	{{npc_name}}: We believe in you, StoryWeaver.


### PR DESCRIPTION
This is functionally the same as the “No!” option and consensus during
an in-person playtest was that we should remove it.
