### PR TITLE
Use new sprites in Frays End to give more variation

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=4 uid="uid://cufkthb25mpxy"]
+[gd_scene load_steps=17 format=4 uid="uid://cufkthb25mpxy"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_4evgk"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="3_tp7qs"]
@@ -13,6 +13,7 @@
 [ext_resource type="PackedScene" uid="uid://7hoy2p14t6kc" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/main.tscn" id="11_0a1i7"]
 [ext_resource type="PackedScene" uid="uid://ipvcfv2g0oi1" path="res://scenes/game_elements/characters/npcs/talker/talker.tscn" id="11_mr2ek"]
 [ext_resource type="Resource" uid="uid://ykdgo73x62wa" path="res://scenes/game_elements/characters/npcs/story_quest_starter/components/story_quest_starter.dialogue" id="12_0a1i7"]
+[ext_resource type="Texture2D" uid="uid://wxp04k82t4n8" path="res://scenes/game_elements/props/tree/components/Tree_Wool_Green_01.png" id="12_780ok"]
 [ext_resource type="PackedScene" uid="uid://bp20cjimwi8l0" path="res://scenes/game_elements/props/buildings/house/house_2.tscn" id="15_uhynt"]
 [ext_resource type="PackedScene" uid="uid://712saqgof3kf" path="res://scenes/game_elements/props/eternal_loom/eternal_loom.tscn" id="16_ojp30"]
 
@@ -70,30 +71,29 @@ y_sort_enabled = true
 
 [node name="House_1" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(1600, 815)
-house_texture = ExtResource("5_uojly")
+house_sprite__texture = ExtResource("5_uhynt")
 
 [node name="House_2" parent="Buildings" instance=ExtResource("15_uhynt")]
 position = Vector2(1760, 810)
-house_texture = ExtResource("6_ojp30")
+house_sprite__texture = ExtResource("5_uojly")
 
 [node name="House_3" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(512, 681)
-house_texture = ExtResource("6_uhynt")
 
 [node name="House_4" parent="Buildings" instance=ExtResource("15_uhynt")]
 position = Vector2(329, 679)
-house_texture = ExtResource("5_uhynt")
+house_sprite__texture = ExtResource("6_uhynt")
 
 [node name="House_5" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(320, 1080)
+house_sprite__texture = ExtResource("6_ojp30")
 
 [node name="House_6" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(705, 1374)
-house_texture = ExtResource("6_uhynt")
+house_sprite__texture = ExtResource("5_uhynt")
 
 [node name="House_7" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(1282, 1277)
-house_texture = ExtResource("5_uojly")
 
 [node name="House_8" parent="Buildings" instance=ExtResource("15_uhynt")]
 position = Vector2(484, 1074)
@@ -138,6 +138,7 @@ position = Vector2(-1, 120)
 [node name="Tree" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(219, 1575)
 scale = Vector2(1.02827, 0.954083)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree2" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(348, 1643)
@@ -150,10 +151,12 @@ scale = Vector2(1.0693, 0.93294)
 [node name="Tree4" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(690, 1640)
 scale = Vector2(1.00407, 0.844444)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree5" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(793, 1574)
 scale = Vector2(0.99841, 0.909467)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree6" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(919, 1609)
@@ -186,6 +189,7 @@ scale = Vector2(1.10775, 0.863948)
 [node name="Tree13" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1372, 1599)
 scale = Vector2(0.901034, 1.06491)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree14" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1490, 1608)
@@ -202,10 +206,12 @@ scale = Vector2(1.19504, 1.14309)
 [node name="Tree17" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1609, 1588)
 scale = Vector2(0.863371, 1.0823)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree18" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1728, 1620)
 scale = Vector2(1.0169, 0.958685)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree19" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1822, 1673)
@@ -214,6 +220,7 @@ scale = Vector2(1.01412, 1.11068)
 [node name="Tree20" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1675, 1675)
 scale = Vector2(0.905584, 1.09593)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree21" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(449, 1645)
@@ -254,6 +261,7 @@ scale = Vector2(0.858296, 1.01392)
 [node name="Tree33" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(23, 1482)
 scale = Vector2(0.821827, 1.10457)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree34" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(77, 1553)
@@ -314,6 +322,7 @@ scale = Vector2(0.950726, 0.962261)
 [node name="Tree45" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(848, 1766)
 scale = Vector2(1.01252, 1.11131)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree46" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1035, 1772)
@@ -326,6 +335,7 @@ scale = Vector2(1.01122, 0.957152)
 [node name="Tree48" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1280, 1780)
 scale = Vector2(0.814387, 1.05919)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree49" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1412, 1790)
@@ -334,6 +344,7 @@ scale = Vector2(1.09888, 1.06697)
 [node name="Tree50" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1573, 1774)
 scale = Vector2(1.05205, 0.862139)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree51" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1699, 1738)
@@ -354,6 +365,7 @@ scale = Vector2(0.917038, 1.17016)
 [node name="Tree55" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(1885, 1805)
 scale = Vector2(0.828057, 1.05841)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree56" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(525, 1784)
@@ -362,6 +374,7 @@ scale = Vector2(1.14444, 1.12203)
 [node name="Tree57" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(368, 1779)
 scale = Vector2(0.842905, 1.01921)
+tree__texture = ExtResource("12_780ok")
 
 [node name="Tree58" parent="Trees" instance=ExtResource("7_7v00g")]
 position = Vector2(212, 1787)


### PR DESCRIPTION
Now that we are able to set decoration textures through the editor, we can add some variation to houses & trees in frays end
![image](https://github.com/user-attachments/assets/68aaf4ab-5a95-4c25-a4ca-29c91956f302)
