### PR TITLE
Dialogue: Add visible “next” Button

### DIFF
--- a/scenes/ui_elements/dialogue/balloon.tscn
+++ b/scenes/ui_elements/dialogue/balloon.tscn
@@ -44,6 +44,24 @@ layout_mode = 2
 size_flags_vertical = 3
 text = "Ah! Another wanderer. It's been awhile since anyone came looking for answers instead of treasure."
 
+[node name="HBoxContainer" type="HBoxContainer" parent="Balloon/PanelContainer/VBoxContainer"]
+layout_mode = 2
+alignment = 2
+
+[node name="NextButtonContainer" type="MarginContainer" parent="Balloon/PanelContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/margin_left = 0
+theme_override_constants/margin_top = 0
+theme_override_constants/margin_right = 0
+theme_override_constants/margin_bottom = 30
+
+[node name="NextButton" type="Button" parent="Balloon/PanelContainer/VBoxContainer/HBoxContainer/NextButtonContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_type_variation = &"FlatButton"
+text = "next >"
+
 [node name="ResponsesMenu" type="VBoxContainer" parent="Balloon/PanelContainer/VBoxContainer" node_paths=PackedStringArray("response_template")]
 unique_name_in_owner = true
 layout_mode = 2

--- a/scenes/ui_elements/dialogue/components/balloon.gd
+++ b/scenes/ui_elements/dialogue/components/balloon.gd
@@ -62,6 +62,13 @@ var _player_name: String = ""
 ## The label showing the currently spoken dialogue
 @onready var dialogue_label: DialogueLabel = %DialogueLabel
 
+## The “Next” button container, visible when the current line is complete and there are
+## no response choices.
+@onready var next_button_container: MarginContainer = %NextButtonContainer
+
+## The “Next” button, to connect signals.
+@onready var next_button: Button = %NextButton
+
 ## The menu of responses
 @onready var responses_menu: DialogueResponsesMenu = %ResponsesMenu
 
@@ -75,6 +82,7 @@ func _ready() -> void:
 		responses_menu.next_action = next_action
 
 	mutation_cooldown.timeout.connect(_on_mutation_cooldown_timeout)
+	next_button.pressed.connect(func(): next(dialogue_line.next_id))
 	add_child(mutation_cooldown)
 
 
@@ -129,6 +137,8 @@ func apply_dialogue_line() -> void:
 	responses_menu.hide()
 	responses_menu.responses = dialogue_line.responses
 
+	next_button_container.hide()
+
 	# Show our balloon
 	balloon.show()
 	will_hide_balloon = false
@@ -154,6 +164,7 @@ func apply_dialogue_line() -> void:
 		is_waiting_for_input = true
 		balloon.focus_mode = Control.FOCUS_ALL
 		balloon.grab_focus()
+		next_button_container.show()
 
 
 ## Go to the next line

--- a/scenes/ui_elements/dialogue/components/theme.tres
+++ b/scenes/ui_elements/dialogue/components/theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=16 format=3 uid="uid://cvitou84ni7qe"]
+[gd_resource type="Theme" load_steps=22 format=3 uid="uid://cvitou84ni7qe"]
 
 [ext_resource type="Texture2D" uid="uid://dv7kcbngjjwq7" path="res://assets/tiny-swords/UI/Buttons/Button_Blue_3Slides.png" id="1_0xtm5"]
 [ext_resource type="Texture2D" uid="uid://bxk0fu4vv6wt2" path="res://assets/tiny-swords/UI/Buttons/Button_Hover_3Slides.png" id="1_1romn"]
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://bqe8u2t2tsoma" path="res://assets/tiny-swords/UI/Buttons/Button_Disable_3Slides.png" id="1_rcupm"]
 [ext_resource type="Texture2D" uid="uid://rwt2v0hex5nm" path="res://assets/tiny-swords/UI/Ribbons/Ribbon_Yellow_3Slides.png" id="1_rtjv3"]
 [ext_resource type="Texture2D" uid="uid://dcum6i8n2paam" path="res://assets/tiny-swords/UI/Buttons/Button_Blue_3Slides_Pressed.png" id="4_si72l"]
+[ext_resource type="Texture2D" uid="uid://ccavio2v8sk7c" path="res://assets/tiny-swords/UI/Banners/Carved_3Slides.png" id="5_7k42u"]
 [ext_resource type="Texture2D" uid="uid://c3yokak1jgx7" path="res://assets/tiny-swords/UI/Banners/Banner_Vertical.png" id="5_mu1ca"]
 [ext_resource type="Texture2D" uid="uid://1po5xmfs16ot" path="res://assets/tiny-swords/UI/Ribbons/Ribbon_BlueLight_3Slides.png" id="7_mtpqe"]
 
@@ -44,6 +45,40 @@ texture_margin_right = 32.0
 texture_margin_bottom = 28.0
 axis_stretch_horizontal = 2
 axis_stretch_vertical = 2
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_7k42u"]
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_q6hjb"]
+texture = ExtResource("5_7k42u")
+texture_margin_left = 64.0
+texture_margin_top = 12.0
+texture_margin_right = 64.0
+texture_margin_bottom = 12.0
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+modulate_color = Color(0.77084, 0.770839, 0.770839, 1)
+
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_q6hjb"]
+load_path = "res://.godot/imported/Carved_3Slides.png-78300fffea87a448262c0f7eedc93b2c.ctex"
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_3vcfk"]
+texture = SubResource("CompressedTexture2D_q6hjb")
+texture_margin_left = 64.0
+texture_margin_top = 12.0
+texture_margin_right = 64.0
+texture_margin_bottom = 12.0
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+modulate_color = Color(0.666569, 0.666569, 0.666569, 1)
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_lerkg"]
+texture = ExtResource("5_7k42u")
+texture_margin_left = 64.0
+texture_margin_top = 12.0
+texture_margin_right = 64.0
+texture_margin_bottom = 12.0
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_7k42u"]
 content_margin_bottom = 18.0
@@ -88,6 +123,11 @@ Button/styles/focus = SubResource("StyleBoxTexture_si72l")
 Button/styles/hover = SubResource("StyleBoxTexture_rcupm")
 Button/styles/normal = SubResource("StyleBoxTexture_rcupm")
 Button/styles/pressed = SubResource("StyleBoxTexture_w6oc6")
+FlatButton/styles/focus = SubResource("StyleBoxEmpty_7k42u")
+FlatButton/styles/hover = SubResource("StyleBoxTexture_q6hjb")
+FlatButton/styles/hover_pressed = SubResource("StyleBoxTexture_3vcfk")
+FlatButton/styles/normal = SubResource("StyleBoxTexture_lerkg")
+FlatButton/styles/pressed = SubResource("StyleBoxTexture_3vcfk")
 Label/colors/font_color = Color(0, 0, 0, 1)
 MarginContainer/constants/margin_bottom = 16
 MarginContainer/constants/margin_left = 16


### PR DESCRIPTION
Dialogue: Add visible “next” Button

In playtesting we have found that not all players realise that they need
to press a key to progress the dialogue.

Add a button that, when pressed, acts like the input action for "next"
(Enter, Space, Xbox joypad A) has been entered.

Style variations for the button added in a new style called FlatButton.

Fixes https://github.com/endlessm/threadbare/issues/263