### PR TITLE
Tree: Randomize x scale proportionally to y

### DIFF
--- a/scenes/game_elements/props/tree/components/tree.gd
+++ b/scenes/game_elements/props/tree/components/tree.gd
@@ -6,4 +6,6 @@ extends Decoration
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_SCENE_INSTANTIATED:
-		scale = Vector2(randf_range(0.8, 1.2), randf_range(0.8, 1.2))
+		var y_scale := randf_range(0.8, 1.2)
+		var x_scale := y_scale * randf_range(0.9, 1.1)
+		scale = Vector2(x_scale, y_scale)


### PR DESCRIPTION
Previously, the x-axis and y-axis scale were randomized independently, each to a random value in the range [0.8, 1.2]. This meant that you could get trees that were very tall but narrow, or very short but wide.

Instead, choose the y-axis scale (height) randomly from that same range, but then choose the x-axis scale to be derived from the y-axis scale, scaled within a narrower band. This means that if the y-axis scale is 0.8, then the x-axis scale is constrained to be within 0.72 and 0.88; similarly if the y-axis scale is 1.2, the x-axis scale is between 0.96 and 1.44.