### PR TITLE
ci: Notify Discord of PRs merged to main via webhook

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 name: Discord Notification
 
-on: 
+on:
   pull_request:
     types:
       - closed
@@ -12,8 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Discord notification
+      if: github.event.pull_request.merged == true
       env:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        # DISCORD_USERNAME: # Omitted in favor of Discord configuration
-        # DISCORD_AVATAR: # Omitted in favor of Discord configuration
+        # DISCORD_USERNAME: # Omitted in favor of Discord default ("GitHub")
+        # DISCORD_AVATAR: # Omitted in favor of Discord default (GitHub logo)
       uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9 # 0.3.2

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+name: Discord Notification
+
+on: 
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Discord notification
+      env:
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        # DISCORD_USERNAME: # Omitted in favor of Discord configuration
+        # DISCORD_AVATAR: # Omitted in favor of Discord configuration
+      uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9 # 0.3.2

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Discord notification
       if: github.event.pull_request.merged == true
       env:
-        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_MERGE }}
         # DISCORD_USERNAME: # Omitted in favor of Discord default ("GitHub")
         # DISCORD_AVATAR: # Omitted in favor of Discord default (GitHub logo)
       uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9 # 0.3.2

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types:
       - closed
+    branches:
+      - main
 
 jobs:
   notify:


### PR DESCRIPTION
We want to highlight work that gets merged into the game in the Discord so we can celebrate learner achievements. This also provides a lower-noise feed for anyone interested in following along with Threadbare development beyond just releases.

GitHub's built-in webhooks are not granular enough for our needs; they deliver _all_ PR-related events which causes too much noise. Instead, this workflow uses a GitHub Action to deliver a notification to Discord via webhook only when a pull request is merged into main.

- Requires a `DISCORD_WEBHOOK_MERGE` repository secret
- Uses https://github.com/marketplace/actions/actions-for-discord
- Docs: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows