### PR TITLE
Elders should look at the front

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -154,6 +154,7 @@ quest_scene = ExtResource("11_0a1i7")
 quest_description = "This quest will need speed, reflexes, and ingenuity."
 npc_name = "Lore Quest Elder"
 dialogue = ExtResource("12_yntpr")
+look_at_side = 0
 sprite_frames = ExtResource("4_7v00g")
 
 [node name="StoryQuestElder" parent="NPCs" instance=ExtResource("11_mr2ek")]
@@ -164,6 +165,7 @@ quest_scene = ExtResource("14_xa7wa")
 quest_description = ""
 npc_name = "Story Quest Elder"
 dialogue = ExtResource("12_0a1i7")
+look_at_side = 0
 sprite_frames = ExtResource("4_7v00g")
 
 [node name="fray_axeman" parent="NPCs" instance=ExtResource("17_0a1i7")]


### PR DESCRIPTION
Otherwise they turn when being involved in conversations. Regression introduced when rebuilding the Fray's End scene.

Fix https://github.com/endlessm/threadbare/issues/281