### PR TITLE
Fix collectible that starts revealed

### DIFF
--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -59,6 +59,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 func _ready() -> void:
 	_update_based_on_revealed()
+	sprite_2d.modulate = Color.WHITE if revealed else Color.TRANSPARENT
 	if Engine.is_editor_hint():
 		return
 


### PR DESCRIPTION
In 77834b0b the collectible animations were improved, and the sprite starts with a transparent modulate color to avoid a flicker effect. But the result of this is that if the collectible starts already revealed (which is the case in the stealth game), the collectible is transparent forever because the revealed animation doesn't play.

So in addition to set visibility when already revealed at the start, set modulate color to white.