### PR TITLE
Ink combat: Pause player input during intro dialogue

### DIFF
--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/components/ink_combat.gd
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/components/ink_combat.gd
@@ -11,8 +11,10 @@ signal goal_reached
 
 func _ready() -> void:
 	if intro_dialogue:
+		Pause.pause_system(Pause.System.PLAYER_INPUT, self)
 		DialogueManager.show_dialogue_balloon(intro_dialogue, "", [self])
 		await DialogueManager.dialogue_ended
+		Pause.unpause_system(Pause.System.PLAYER_INPUT, self)
 
 	# Add a short delay so the player doesn"t attack when closing the dialogue
 	# or just entered the scene:


### PR DESCRIPTION
Previously you could move the player while the opening dialogue was playing.

Pause PLAYER_INPUT while the dialogue is playing.