### PR TITLE
Add cloud overlay to allow scenes to have cloud shadows

### DIFF
--- a/scenes/game_elements/props/clouds_overlay/clouds_overlay.tscn
+++ b/scenes/game_elements/props/clouds_overlay/clouds_overlay.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=7 format=3 uid="uid://ci42ypvn5v8jr"]
+
+[ext_resource type="Shader" uid="uid://chgaevc31p1mn" path="res://scenes/game_elements/props/clouds_overlay/components/clouds_shadows.gdshader" id="1_l5uri"]
+[ext_resource type="Script" uid="uid://bw0lg5yx4pxs2" path="res://scenes/game_elements/props/clouds_overlay/components/clouds_overlay.gd" id="2_gw00f"]
+
+[sub_resource type="Gradient" id="Gradient_l5uri"]
+interpolation_mode = 1
+offsets = PackedFloat32Array(0, 0.74, 0.8, 1)
+colors = PackedColorArray(0, 0, 0, 0, 0, 0, 0, 0.075, 0, 0, 0, 0.15, 0, 0, 0, 0.15)
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_shbkg"]
+fractal_lacunarity = 0.2
+fractal_gain = 0.0
+domain_warp_enabled = true
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_xa65i"]
+resource_local_to_scene = true
+width = 1920
+height = 1080
+seamless = true
+color_ramp = SubResource("Gradient_l5uri")
+noise = SubResource("FastNoiseLite_shbkg")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_shbkg"]
+resource_local_to_scene = true
+shader = ExtResource("1_l5uri")
+shader_parameter/cloud_texture = SubResource("NoiseTexture2D_xa65i")
+shader_parameter/offset = Vector2(773.009, 386.505)
+shader_parameter/scale = 0.2
+
+[node name="CloudsOverlay" type="ColorRect"]
+z_index = 10
+z_as_relative = false
+texture_filter = 1
+material = SubResource("ShaderMaterial_shbkg")
+offset_right = 1920.0
+offset_bottom = 1080.0
+script = ExtResource("2_gw00f")

--- a/scenes/game_elements/props/clouds_overlay/components/clouds_overlay.gd
+++ b/scenes/game_elements/props/clouds_overlay/components/clouds_overlay.gd
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+extends ColorRect
+
+@export var wind_direction: Vector2 = Vector2(1.0, 0.5)
+@export_range(0, 50, 0.1) var wind_speed: float = 10
+
+@export_range(0, 1, 0.01) var cloud_density: float = 0.2:
+	set(val):
+		cloud_density = val
+		update_noise_color_ramp()
+@export_range(0, 1, 0.01) var cloud_fluffyness: float = 0.3:
+	set(val):
+		cloud_fluffyness = val
+		update_noise_color_ramp()
+@export_range(0, 1, 0.01) var cloud_opacity: float = 0.15:
+	set(val):
+		cloud_opacity = val
+		update_noise_color_ramp()
+
+var current_offset: Vector2 = Vector2.ZERO
+
+
+func _process(delta: float) -> void:
+	if not Engine.is_editor_hint():
+		global_position = get_viewport().get_camera_2d().get_screen_center_position() - size / 2
+	current_offset += wind_direction.normalized() * wind_speed * delta
+	material.set_shader_parameter("offset", current_offset)
+
+
+func update_noise_color_ramp() -> void:
+	var new_color_ramp: Gradient = Gradient.new()
+	new_color_ramp.interpolation_mode = Gradient.GRADIENT_INTERPOLATE_CONSTANT
+
+	new_color_ramp.set_color(0, Color(0, 0, 0, 0))
+	new_color_ramp.set_color(1, Color(0, 0, 0, cloud_opacity))
+
+	var cloud_start_point = 1 - cloud_density
+	var cloud_end_point = cloud_start_point - cloud_fluffyness * (1 - cloud_start_point)
+
+	new_color_ramp.add_point(cloud_start_point, Color(0, 0, 0, cloud_opacity))
+	new_color_ramp.add_point(cloud_end_point, Color(0, 0, 0, cloud_opacity / 2))
+
+	var noise_texture: NoiseTexture2D = material.get_shader_parameter("cloud_texture")
+	noise_texture.color_ramp = new_color_ramp

--- a/scenes/game_elements/props/clouds_overlay/components/clouds_overlay.gd.uid
+++ b/scenes/game_elements/props/clouds_overlay/components/clouds_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://bw0lg5yx4pxs2

--- a/scenes/game_elements/props/clouds_overlay/components/clouds_shadows.gdshader
+++ b/scenes/game_elements/props/clouds_overlay/components/clouds_shadows.gdshader
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: The Threadbare Authors
+// SPDX-License-Identifier: MPL-2.0
+shader_type canvas_item;
+
+uniform sampler2D cloud_texture;
+uniform sampler2D density_texture;
+
+uniform vec2 offset;
+
+uniform float scale: hint_range(0.1, 10.0, 0.1) = 1.0;
+
+varying vec2 world_pos;
+
+void vertex() {
+   // Transform it into world coordinates
+   world_pos = (MODEL_MATRIX * vec4(1.0, 1.0, 0.0, 1.0)).xy;
+}
+
+vec2 to_uv_coordinates(vec2 position, sampler2D tex) {
+	ivec2 tex_size = textureSize(tex, 0);
+	return vec2(position.x / float(tex_size.x), position.y / float(tex_size.y));
+}
+
+void fragment() {
+	COLOR = texture(cloud_texture, fract((UV + to_uv_coordinates(world_pos, cloud_texture) + to_uv_coordinates(offset, cloud_texture)) * scale));
+}

--- a/scenes/game_elements/props/clouds_overlay/components/clouds_shadows.gdshader.uid
+++ b/scenes/game_elements/props/clouds_overlay/components/clouds_shadows.gdshader.uid
@@ -1,0 +1,1 @@
+uid://chgaevc31p1mn

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=26 format=4 uid="uid://cufkthb25mpxy"]
+[gd_scene load_steps=27 format=4 uid="uid://cufkthb25mpxy"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_4evgk"]
 [ext_resource type="SpriteFrames" uid="uid://cntyc07xhpu0k" path="res://scenes/game_elements/characters/npcs/npc_prop/sprite_frames/fray_idle_blue.tres" id="3_rti58"]
@@ -25,6 +25,7 @@
 [ext_resource type="PackedScene" uid="uid://n8dhed3nvf50" path="res://scenes/game_elements/characters/npcs/npc_prop/fray_hammerman.tscn" id="19_yntpr"]
 [ext_resource type="PackedScene" uid="uid://6tkhqe1nvwop" path="res://scenes/game_elements/characters/npcs/npc_prop/fray_idle.tscn" id="20_xa7wa"]
 [ext_resource type="SpriteFrames" uid="uid://cpm5o35ede3qs" path="res://scenes/game_elements/characters/npcs/npc_prop/sprite_frames/fray_idle_purple.tres" id="22_e453w"]
+[ext_resource type="PackedScene" uid="uid://ci42ypvn5v8jr" path="res://scenes/game_elements/props/clouds_overlay/clouds_overlay.tscn" id="26_dvgp7"]
 
 [node name="FraysEnd" type="Node2D"]
 y_sort_enabled = true
@@ -752,3 +753,5 @@ scale = Vector2(1.05, 1.05)
 [node name="fray_idle" parent="." instance=ExtResource("20_xa7wa")]
 position = Vector2(1617, 625)
 sprite_frames = ExtResource("22_e453w")
+
+[node name="CloudsOverlay" parent="." instance=ExtResource("26_dvgp7")]


### PR DESCRIPTION
The clouds_overlay, when added to a scene, will follow the camera around and paint cloud shadows all over it.

It can be adjusted to allow for different cloud densities, wind speeds, wind directions, opacity, and fluffyness.

https://github.com/user-attachments/assets/c0e255e6-447d-4d1c-a7f1-a9411624f840

Fixes #124 