### PR TITLE
Add licensing to default templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
   hooks:
   - id: gdformat
   - id: gdlint
+    exclude: script_templates/
 exclude: |
   (?x)^(
     addons/(.*)

--- a/project.godot
+++ b/project.godot
@@ -30,7 +30,9 @@ gdscript/warnings/untyped_declaration=1
 
 [dialogue_manager]
 
-editor/new_file_template="~ start
+editor/new_file_template="# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+~ start
 Elder: [[Hi|Hello|Howdy]], StoryWeaver.
 => END
 "

--- a/script_templates/Node/Default.gd
+++ b/script_templates/Node/Default.gd
@@ -1,0 +1,16 @@
+# meta-default: true
+# meta-description: Base template for Node with default Godot cycle methods. Includes Threadbare licensing header.
+# meta-name: Default (Threadbare)
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends _BASE_
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass  # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass


### PR DESCRIPTION
Tired of getting your PR rejected because you forgot to add the licensing info in your scripts and dialogues?

Not anymore. Now, whenever you create a new dialogue, it will look like this by default:
```
# SPDX-FileCopyrightText: The Threadbare Authors
# SPDX-License-Identifier: MPL-2.0
~ start
Elder: [[Hi|Hello|Howdy]], StoryWeaver.
=> END
```

And if you create a new script, there will be a new template in the list you can use:

https://github.com/user-attachments/assets/15620817-e730-4bd6-bb86-f081d5fcbbac

