### PR TITLE
Fray's End: Spawn at loom after completing a quest

### DIFF
--- a/scenes/menus/intro/intro.tscn
+++ b/scenes/menus/intro/intro.tscn
@@ -395,4 +395,5 @@ script = ExtResource("1_qeukb")
 dialogue = ExtResource("4_rpon1")
 animation_player = NodePath("../AnimationPlayer")
 next_scene = "uid://cufkthb25mpxy"
+spawn_point_path = "SpawnPointAfterIntro"
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"

--- a/scenes/ui_elements/cinematic/cinematic.gd
+++ b/scenes/ui_elements/cinematic/cinematic.gd
@@ -16,12 +16,23 @@ extends Node2D
 ## Scene to switch to once [member dialogue] is complete
 @export_file("*.tscn") var next_scene: String
 
+## Optional path inside [member next_scene] where the player should appear.
+## If blank, player appears at default position in the scene. If in doubt,
+## leave this blank.
+@export var spawn_point_path: String
+
 
 func _ready() -> void:
 	DialogueManager.show_dialogue_balloon(dialogue, "", [self])
 	await DialogueManager.dialogue_ended
 
 	if next_scene:
-		SceneSwitcher.change_to_file_with_transition(
-			next_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+		(
+			SceneSwitcher
+			. change_to_file_with_transition(
+				next_scene,
+				spawn_point_path,
+				Transition.Effect.FADE,
+				Transition.Effect.FADE,
+			)
 		)

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=43 format=4 uid="uid://cufkthb25mpxy"]
+[gd_scene load_steps=44 format=4 uid="uid://cufkthb25mpxy"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_4evgk"]
 [ext_resource type="SpriteFrames" uid="uid://cntyc07xhpu0k" path="res://scenes/game_elements/characters/npcs/npc_prop/sprite_frames/fray_idle_blue.tres" id="3_rti58"]
@@ -36,6 +36,7 @@
 [ext_resource type="Texture2D" uid="uid://bytssd0mbo28u" path="res://assets/inputs/keyboard-and-mouse/Dark/Arrow_Up_Key_Dark.png" id="29_djq26"]
 [ext_resource type="Resource" uid="uid://byhqan5a7vkgg" path="res://scenes/world_map/components/tutorial_npc.dialogue" id="32_djq26"]
 [ext_resource type="Shader" uid="uid://chgaevc31p1mn" path="res://scenes/game_elements/props/clouds_overlay/components/clouds_shadows.gdshader" id="34_opcsp"]
+[ext_resource type="PackedScene" uid="uid://d0c4l7ev6ca3c" path="res://scenes/game_elements/props/spawn_point/spawn_point.tscn" id="37_thm8h"]
 
 [sub_resource type="Gradient" id="Gradient_l5uri"]
 interpolation_mode = 1
@@ -131,7 +132,7 @@ position = Vector2(272, 890)
 sprite_frames = ExtResource("3_rti58")
 
 [node name="Player" parent="." instance=ExtResource("3_tp7qs")]
-position = Vector2(62, 1747)
+position = Vector2(985, 871)
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 zoom = Vector2(2, 2)
@@ -881,3 +882,6 @@ hint_node = NodePath("../../../ScreenOverlay/InteractionInputHint")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Tutorial/Talker/InteractInputHint"]
 position = Vector2(0.5, -8.5)
 shape = SubResource("RectangleShape2D_djq26")
+
+[node name="SpawnPointAfterIntro" parent="." instance=ExtResource("37_thm8h")]
+position = Vector2(62, 1747)


### PR DESCRIPTION
After we redesigned this scene to have the player start outside Fray's End proper, finishing a quest has regressed: the player should be placed back near the loom in order to deposit the threads they have collected.

Add an optional spawn_point_path property to Cinematic, like the similar feature on Teleporter.

Move the player's default location to near the loom. Add a spawn point at the player's previous default location. Set the spawn_point_path property on the intro cinematic.

I did it this way rather than the other way around (keep the player's default position & place a spawn point in front of a loom) because this way we only need to set the spawn point property in one scene that we maintain, rather than requiring the property to be set correctly at the close of every quest, which to me seems more error-prone.

Fixes https://github.com/endlessm/threadbare/issues/293

