### PR TITLE
Tweak dialogue introducing stealth quest

### DIFF
--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/components/dialogues/ink_well.dialogue
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/components/dialogues/ink_well.dialogue
@@ -6,5 +6,5 @@ Musician: But be careful, they spit!
 => END
 ~ well_done
 Musician: Well done StoryWeaver, you have collected enough ink for new songs and stories. Everyone will rejoice.
-Musician: I need to return to the Song Sanctuary to protect the magical stones, but you should return to Fray's End. Beware the InkDrinkers, I think you have upset them. Stay strong in spirit, and move quickly!
+Musician: I need to return to the Song Sanctuary to protect the magical stones, but you should return to Fray's End. Beware: the path back is riddled with StoryVores. Stay strong in spirit, and move quickly!
 => END


### PR DESCRIPTION
Currently this dialogue refers to InkDrinkers. But the guards in the stealth quest are using a different asset, and we do not currently have the necessary animations to replace them with InkDrinkers.

Refer to them as StoryVores in the dialogue that closes the preceding scene instead.

Fixes https://github.com/endlessm/threadbare/issues/309