### PR TITLE
ci: Disable cancel-on-progress

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,6 @@ on:
 # Cancel any ongoing previous run if a PR is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   pre-commit:

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -10,7 +10,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 env:
   GODOT_VERSION: 4.4.1

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -13,7 +13,6 @@ on:
 # Cancel any ongoing previous run if the job is re-triggered
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
Previously, all our workflows had this set on the basis that it is
wasted work to finish building the project or publishing the website if
another job is queued that will replace it.

However it causes the user that triggered the cancelled job to be
emailed about the job cancellation. There is no way I can find to
disable this email.

Disable this feature for now.
