### PR TITLE
Don't add dialogue to translatable files

### DIFF
--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -329,6 +329,9 @@ func update_import_paths(from_path: String, to_path: String) -> void:
 
 
 func _update_localization() -> void:
+	if not DMSettings.get_setting(DMSettings.UPDATE_POT_FILES_AUTOMATICALLY, true):
+		return
+
 	var dialogue_files = dialogue_cache.get_files()
 
 	# Add any new files to POT generation

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -23,6 +23,8 @@ const EXTRA_CSV_LOCALES = "editor/translations/extra_csv_locales"
 const INCLUDE_CHARACTER_IN_TRANSLATION_EXPORTS = "editor/translations/include_character_in_translation_exports"
 ## Includes a "_notes" column in CSV exports
 const INCLUDE_NOTES_IN_TRANSLATION_EXPORTS = "editor/translations/include_notes_in_translation_exports"
+## Automatically update the project's list of translatable files when dialogue files are added or removed
+const UPDATE_POT_FILES_AUTOMATICALLY = "editor/translations/update_pot_files_automatically"
 
 ## A custom test scene to use when testing dialogue.
 const CUSTOM_TEST_SCENE_PATH = "editor/advanced/custom_test_scene_path"
@@ -81,6 +83,11 @@ static var SETTINGS_CONFIGURATION = {
 	},
 	INCLUDE_NOTES_IN_TRANSLATION_EXPORTS: {
 		value = false,
+		type = TYPE_BOOL,
+		is_advanced = true
+	},
+	UPDATE_POT_FILES_AUTOMATICALLY: {
+		value = true,
 		type = TYPE_BOOL,
 		is_advanced = true
 	},

--- a/project.godot
+++ b/project.godot
@@ -37,6 +37,7 @@ Elder: [[Hi|Hello|Howdy]], StoryWeaver.
 => END
 "
 runtime/balloon_path="uid://dhydhpp43urah"
+editor/translations/update_pot_files_automatically=false
 
 [display]
 
@@ -115,10 +116,6 @@ pause={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
-
-[internationalization]
-
-locale/translations_pot_files=PackedStringArray("res://scenes/ui_elements/cinematic/cinematic_placeholder.dialogue", "res://scenes/menus/intro/components/intro.dialogue", "res://scenes/game_elements/characters/npcs/talker/components/default.dialogue", "res://scenes/game_elements/characters/npcs/story_quest_starter/components/lore_quest_starter.dialogue", "res://scenes/game_elements/characters/npcs/story_quest_starter/components/story_quest_starter.dialogue", "res://scenes/game_elements/props/eternal_loom/eternal_loom_interaction.dialogue", "res://scenes/quests/story_quests/stella_and_the_missing_star/4_outro/stella_outro.dialogue", "res://scenes/quests/story_quests/stella_and_the_missing_star/0_intro/stella_intro.dialogue", "res://scenes/quests/lore_quests/quest_001/4_closing_transition/components/story_quest_closing_transition.dialogue", "res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue", "res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/dialogues/ink_well.dialogue", "res://scenes/world_map/components/tutorial_npc.dialogue", "res://scenes/world_map/components/levers.dialogue", "res://scenes/quests/story_quests/template/0_intro/intro.dialogue", "res://scenes/quests/story_quests/template/4_outro/stella_outro.dialogue", "res://scenes/quests/story_quests/template/4_outro/outro.dialogue")
 
 [layer_names]
 


### PR DESCRIPTION
Up till now, adding or removing dialogue files has caused project.godot to be
updated. This has repeatedly caused conflicts even with our small team working
on the game, and would lead to chaos when learners start adding their own
dialogue and we try to merge their changes.

The game is not currently localized, and you could imagine that we might not
want to localize all learners' dialogue files, only the core game and LoreQuest
dialogue.

Using a new feature I patched into the addon (and sent upstream), disable this
behaviour, and delete the existing list from project.godot.
