### PR TITLE
Cinematic: Pause player input

### DIFF
--- a/scenes/ui_elements/cinematic/cinematic.gd
+++ b/scenes/ui_elements/cinematic/cinematic.gd
@@ -23,6 +23,7 @@ extends Node2D
 
 
 func _ready() -> void:
+	Pause.pause_system(Pause.System.PLAYER_INPUT, self)
 	DialogueManager.show_dialogue_balloon(dialogue, "", [self])
 	await DialogueManager.dialogue_ended
 
@@ -36,3 +37,5 @@ func _ready() -> void:
 				Transition.Effect.FADE,
 			)
 		)
+
+	Pause.unpause_system(Pause.System.PLAYER_INPUT, self)


### PR DESCRIPTION
A forthcoming stealth maze template uses a Cinematic to trigger some dialogue at the start of the scene. However, currently player input is not paused during cinematics.

Pause player input in this case.

Fixes https://github.com/endlessm/threadbare/issues/339