### PR TITLE
Player: Handle input in _unhandled_input() not _process() 

### DIFF
--- a/scenes/game_elements/characters/npcs/talker/components/talker.gd
+++ b/scenes/game_elements/characters/npcs/talker/components/talker.gd
@@ -35,7 +35,4 @@ func _on_interaction_started(player: Player, from_right: bool) -> void:
 
 func _on_dialogue_ended(_dialogue_resource: DialogueResource) -> void:
 	look_at_side = _previous_look_at_side
-	# This little wait is needed to avoid triggering another dialogue:
-	# TODO: improve this in https://github.com/endlessm/threadbare/issues/103
-	await get_tree().create_timer(0.3).timeout
 	interact_area.interaction_ended.emit()

--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -37,8 +37,6 @@ const DEFAULT_SPRITE_FRAME: SpriteFrames = preload(
 @export var sprite_frames: SpriteFrames = DEFAULT_SPRITE_FRAME:
 	set = _set_sprite_frames
 
-var last_nonzero_axis: Vector2
-
 @onready var player_interaction: PlayerInteraction = %PlayerInteraction
 @onready var player_fighting: Node2D = %PlayerFighting
 @onready var player_sprite: AnimatedSprite2D = %PlayerSprite
@@ -87,9 +85,6 @@ func _process(delta: float) -> void:
 		return
 
 	var axis: Vector2 = %PlayerController.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down")
-
-	if not axis.is_zero_approx():
-		last_nonzero_axis = axis
 
 	var speed: float
 	if %PlayerController.is_action_pressed(&"running"):

--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -37,6 +37,8 @@ const DEFAULT_SPRITE_FRAME: SpriteFrames = preload(
 @export var sprite_frames: SpriteFrames = DEFAULT_SPRITE_FRAME:
 	set = _set_sprite_frames
 
+var input_vector: Vector2
+
 @onready var player_interaction: PlayerInteraction = %PlayerInteraction
 @onready var player_fighting: Node2D = %PlayerFighting
 @onready var player_sprite: AnimatedSprite2D = %PlayerSprite
@@ -76,14 +78,7 @@ func _ready() -> void:
 	_set_sprite_frames(sprite_frames)
 
 
-func _process(delta: float) -> void:
-	if Engine.is_editor_hint():
-		return
-
-	if player_interaction.is_interacting:
-		velocity = Vector2.ZERO
-		return
-
+func _unhandled_input(_event: InputEvent) -> void:
 	var axis: Vector2 = %PlayerController.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down")
 
 	var speed: float
@@ -92,13 +87,24 @@ func _process(delta: float) -> void:
 	else:
 		speed = walk_speed
 
+	input_vector = axis * speed
+
+
+func _process(delta: float) -> void:
+	if Engine.is_editor_hint():
+		return
+
+	if player_interaction.is_interacting:
+		velocity = Vector2.ZERO
+		return
+
 	var step: float
-	if axis.is_zero_approx():
+	if input_vector.is_zero_approx():
 		step = stopping_step
 	else:
 		step = moving_step
 
-	velocity = velocity.move_toward(axis * speed, step * delta)
+	velocity = velocity.move_toward(input_vector, step * delta)
 
 	move_and_slide()
 

--- a/scenes/game_elements/characters/player/components/player_fighting.gd
+++ b/scenes/game_elements/characters/player/components/player_fighting.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 	air_stream.body_entered.connect(_on_air_stream_body_entered)
 
 
-func _process(_delta: float) -> void:
+func _unhandled_input(_event: InputEvent) -> void:
 	if %PlayerController.is_action_just_pressed(&"ui_accept"):
 		is_fighting = true
 	elif %PlayerController.is_action_just_released(&"ui_accept"):

--- a/scenes/game_elements/characters/player/components/player_interaction.gd
+++ b/scenes/game_elements/characters/player/components/player_interaction.gd
@@ -20,21 +20,27 @@ func _get_is_interacting() -> bool:
 func _process(_delta: float) -> void:
 	if is_interacting:
 		return
-	var interact_area: InteractArea = interact_zone.get_interact_area()
 
+	var interact_area: InteractArea = interact_zone.get_interact_area()
 	if %PlayerController.inputs_paused() or not interact_area:
 		interact_label.visible = false
-		return
-
-	if %PlayerController.is_action_just_pressed(&"ui_accept"):
-		interact_zone.monitoring = false
-		interact_label.visible = false
-		interact_area.interaction_ended.connect(_on_interaction_ended, CONNECT_ONE_SHOT)
-		interact_area.start_interaction(player, interact_zone.is_looking_from_right)
 	else:
 		interact_label.visible = true
 		interact_label.label_text = interact_area.action
 		interact_marker.global_position = interact_area.get_global_interact_label_position()
+
+
+func _unhandled_input(_event: InputEvent) -> void:
+	if is_interacting:
+		return
+
+	var interact_area: InteractArea = interact_zone.get_interact_area()
+	if interact_area and %PlayerController.is_action_just_pressed(&"ui_accept"):
+		get_viewport().set_input_as_handled()
+		interact_zone.monitoring = false
+		interact_label.visible = false
+		interact_area.interaction_ended.connect(_on_interaction_ended, CONNECT_ONE_SHOT)
+		interact_area.start_interaction(player, interact_zone.is_looking_from_right)
 
 
 func _on_interaction_ended() -> void:

--- a/scenes/game_elements/props/eternal_loom/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/eternal_loom.gd
@@ -20,9 +20,6 @@ func _on_interacted(player: Player, _from_right: bool) -> void:
 	DialogueManager.show_dialogue_balloon(ETERNAL_LOOM_INTERACTION, "", [self, player])
 	await DialogueManager.dialogue_ended
 
-	# This little wait is needed to avoid triggering another dialogue:
-	# TODO: improve this in https://github.com/endlessm/threadbare/issues/103
-	await get_tree().create_timer(0.3).timeout
 	interact_area.end_interaction()
 
 

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/components/ink_combat.gd
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/components/ink_combat.gd
@@ -11,14 +11,8 @@ signal goal_reached
 
 func _ready() -> void:
 	if intro_dialogue:
-		Pause.pause_system(Pause.System.PLAYER_INPUT, self)
 		DialogueManager.show_dialogue_balloon(intro_dialogue, "", [self])
 		await DialogueManager.dialogue_ended
-		Pause.unpause_system(Pause.System.PLAYER_INPUT, self)
-
-	# Add a short delay so the player doesn"t attack when closing the dialogue
-	# or just entered the scene:
-	await get_tree().create_timer(0.5).timeout
 
 	fill_game_logic.goal_reached.connect(_on_goal_reached)
 	fill_game_logic.start()


### PR DESCRIPTION
Previously, player input (directions, interacting, and repelling ink
blobs) was all done in the _process() method of Player, PlayerFighting
and PlayerInteraction. This meant that we had to take special steps to
avoid processing input during and at the end of dialogue.

Godot Dialogue Manager takes care to mark all input events as handled
during dialogue, and documents in its FAQ that player input should be
handled in _unhandled_input() rather than _process().

https://github.com/nathanhoad/godot_dialogue_manager/blob/main/docs/FAQ.md#how-do-i-stop-my-player-from-moving-while-dialogue-is-showing

Handle player input in _unhandled_input(). Two cases are simple:

- Player: add an input_vector field, update it from _unhandled_input(),
and use it in _process()
- PlayerFighting; rename _process() to _unhandled_input().

PlayerInteraction is slightly more complicated because we still
need to update the visibility of the interaction label in _process(): if
you keep an arrow key held down, the player's position (and potential
interaction) will change without any new unhandled input. So the
visibility of the label continues to be managed in _process(), while the
interact action itself is triggered in _unhandled_input().

This change fixes an issue when a Cinematic node is used to trigger introductory
dialogue in a scene which also has an interactive Player, as we are doing in the
StoryQuest template's stealth template. Previously the player could be moved
during the introductory dialogue. Now it cannot.

It also allows us to remove some artificial short pauses after interactions and dialogue finish.

Fixes https://github.com/endlessm/threadbare/issues/339
Fixes https://github.com/endlessm/threadbare/issues/103