### PR TITLE
Collect item: Move label to the top

### DIFF
--- a/scenes/game_elements/props/collectible_item/collectible_item.tscn
+++ b/scenes/game_elements/props/collectible_item/collectible_item.tscn
@@ -235,6 +235,7 @@ z_index = 1
 script = ExtResource("1_7ff3m")
 
 [node name="InteractArea" parent="." instance=ExtResource("6_j0enh")]
+interact_label_position = Vector2(0, -71)
 action = "Collect"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock.tscn
@@ -65,6 +65,7 @@ unique_name_in_owner = true
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_55nmp")
+interact_label_position = Vector2(0, 30)
 action = "Kick"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]


### PR DESCRIPTION
So the label doesn't interfere with the sprite image.

Move it above the sprite, just like the rocks in the music puzzle game.

Fix https://github.com/endlessm/threadbare/issues/338

![Captura desde 2025-04-27 09-30-27](https://github.com/user-attachments/assets/a8bde60b-46d4-4990-94e1-53b9f10fd1b9)
