### PR TITLE
Fill game: Fix enemy throwing without target label

### DIFF
--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/components/fill_game_logic.gd
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/components/fill_game_logic.gd
@@ -20,6 +20,11 @@ func start() -> void:
 	_update_allowed_colors()
 
 
+func _ready() -> void:
+	var filling_barrels: Array = get_tree().get_nodes_in_group("filling_barrels")
+	barrels_to_win = clampi(barrels_to_win, 0, filling_barrels.size())
+
+
 func _update_allowed_colors() -> void:
 	var allowed_labels: Array[String] = []
 	var color_per_label: Dictionary[String, Color]

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/components/throwing_enemy/components/throwing_enemy.gd
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/components/throwing_enemy/components/throwing_enemy.gd
@@ -184,6 +184,9 @@ func _on_timeout() -> void:
 	animated_sprite_2d.play(&"attack anticipation")
 	await animated_sprite_2d.animation_finished
 	animated_sprite_2d.play(&"attack")
+	if not allowed_labels:
+		_is_attacking = false
+		return
 	var projectile: Projectile = PROJECTILE_SCENE.instantiate()
 	projectile.direction = projectile_marker.global_position.direction_to(player.global_position)
 	projectile.label = allowed_labels.pick_random()


### PR DESCRIPTION
If the is no target label to add to a projectile, simply don't throw.

Fix https://github.com/endlessm/threadbare/issues/276