### PR TITLE
Dialogue: Use flat buttons for response menu

### DIFF
--- a/scenes/ui_elements/dialogue/balloon.tscn
+++ b/scenes/ui_elements/dialogue/balloon.tscn
@@ -62,7 +62,7 @@ theme_override_constants/margin_bottom = 30
 [node name="NextButton" type="Button" parent="Balloon/PanelContainer/VBoxContainer/HBoxContainer/NextButtonContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-theme_type_variation = &"FlatButton"
+theme_type_variation = &"FlatNextButton"
 text = "next >"
 
 [node name="ResponsesMenu" type="VBoxContainer" parent="Balloon/PanelContainer/VBoxContainer" node_paths=PackedStringArray("response_template")]
@@ -75,6 +75,7 @@ response_template = NodePath("ResponseExample")
 
 [node name="ResponseExample" type="Button" parent="Balloon/PanelContainer/VBoxContainer/ResponsesMenu"]
 layout_mode = 2
+theme_type_variation = &"FlatButton"
 text = "Response example"
 
 [connection signal="gui_input" from="Balloon" to="." method="_on_balloon_gui_input"]

--- a/scenes/ui_elements/dialogue/components/theme.tres
+++ b/scenes/ui_elements/dialogue/components/theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=22 format=3 uid="uid://cvitou84ni7qe"]
+[gd_resource type="Theme" load_steps=23 format=3 uid="uid://cvitou84ni7qe"]
 
 [ext_resource type="Texture2D" uid="uid://dv7kcbngjjwq7" path="res://assets/tiny-swords/UI/Buttons/Button_Blue_3Slides.png" id="1_0xtm5"]
 [ext_resource type="Texture2D" uid="uid://bxk0fu4vv6wt2" path="res://assets/tiny-swords/UI/Buttons/Button_Hover_3Slides.png" id="1_1romn"]
@@ -46,8 +46,6 @@ texture_margin_bottom = 28.0
 axis_stretch_horizontal = 2
 axis_stretch_vertical = 2
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_7k42u"]
-
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_q6hjb"]
 texture = ExtResource("5_7k42u")
 texture_margin_left = 64.0
@@ -72,6 +70,25 @@ axis_stretch_vertical = 1
 modulate_color = Color(0.666569, 0.666569, 0.666569, 1)
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_lerkg"]
+texture = ExtResource("5_7k42u")
+texture_margin_left = 64.0
+texture_margin_top = 12.0
+texture_margin_right = 64.0
+texture_margin_bottom = 12.0
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_bbim3"]
+texture = ExtResource("5_7k42u")
+texture_margin_left = 64.0
+texture_margin_top = 12.0
+texture_margin_right = 64.0
+texture_margin_bottom = 12.0
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+modulate_color = Color(1, 1, 1, 0)
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_qndbo"]
 texture = ExtResource("5_7k42u")
 texture_margin_left = 64.0
 texture_margin_top = 12.0
@@ -123,11 +140,13 @@ Button/styles/focus = SubResource("StyleBoxTexture_si72l")
 Button/styles/hover = SubResource("StyleBoxTexture_rcupm")
 Button/styles/normal = SubResource("StyleBoxTexture_rcupm")
 Button/styles/pressed = SubResource("StyleBoxTexture_w6oc6")
-FlatButton/styles/focus = SubResource("StyleBoxEmpty_7k42u")
+FlatButton/styles/focus = SubResource("StyleBoxTexture_lerkg")
 FlatButton/styles/hover = SubResource("StyleBoxTexture_q6hjb")
 FlatButton/styles/hover_pressed = SubResource("StyleBoxTexture_3vcfk")
-FlatButton/styles/normal = SubResource("StyleBoxTexture_lerkg")
+FlatButton/styles/normal = SubResource("StyleBoxTexture_bbim3")
 FlatButton/styles/pressed = SubResource("StyleBoxTexture_3vcfk")
+FlatNextButton/base_type = &"FlatButton"
+FlatNextButton/styles/normal = SubResource("StyleBoxTexture_qndbo")
 Label/colors/font_color = Color(0, 0, 0, 1)
 MarginContainer/constants/margin_bottom = 16
 MarginContainer/constants/margin_left = 16


### PR DESCRIPTION
It has turned out that the previous button style makes it hard to tell which choice is focus when there are only 2 choices: is it the blue button with a grey border, or the dimmer yellow-brown button with a gold border?

Adjust the FlatButton style variation to show no background (actually a fully-transparent modulation of the same texture) when unfocused, and the flat sign texture when focused. Set the response buttons to use this.

Add a new FlatNextButton style, derived from FlatButton, that implements the previous FlatButton style of having a visible background even when unfocused, and set the "next >" button to use it. (This is because this button is not actually focused: the dialogue balloon itself grabs focus, for reasons I don't fully understand.)

I chose to define the styles this way around because I plan to use the same style of button where only the focused one has a visible background for the main menu.

Fixes https://github.com/endlessm/threadbare/issues/291