### PR TITLE
Fill game: Face enemies toward player

### DIFF
--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/components/throwing_enemy/components/throwing_enemy.gd
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/components/throwing_enemy/components/throwing_enemy.gd
@@ -95,6 +95,12 @@ func _ready() -> void:
 	_initial_position = position
 	if Engine.is_editor_hint():
 		return
+	var player: Player = get_tree().get_first_node_in_group("player")
+	if is_instance_valid(player):
+		var direction: Vector2 = projectile_marker.global_position.direction_to(
+			player.global_position
+		)
+		scale.x = 1 if direction.x < 0 else -1
 	if autostart:
 		start()
 
@@ -186,6 +192,7 @@ func _on_timeout() -> void:
 	animated_sprite_2d.play(&"attack")
 	var projectile: Projectile = PROJECTILE_SCENE.instantiate()
 	projectile.direction = projectile_marker.global_position.direction_to(player.global_position)
+	scale.x = 1 if projectile.direction.x < 0 else -1
 	projectile.label = allowed_labels.pick_random()
 	if projectile.label in color_per_label:
 		projectile.color = color_per_label[projectile.label]


### PR DESCRIPTION
In two moments: when the enemy is ready, and when the enemy attacks.

The alternative is to do this every frame, but I think that's not needed.

Note: The way the enemy is flipped horizontally is by scaling the whole scene, not by using the AnimatedSprite2D flip_h property. This is because the marker used to place the spawned projectile needs to be flipped as well. Alternatively, we could store the initial marker position as the left position, and a mirrored marked position as the right position. Since scaling works and no regressions were found, I'd say let's try this instead.

Fix https://github.com/endlessm/threadbare/issues/277