### PR TITLE
Cloud overlay resets shader's offset parameter on save

### DIFF
--- a/scenes/game_elements/props/clouds_overlay/components/clouds_overlay.gd
+++ b/scenes/game_elements/props/clouds_overlay/components/clouds_overlay.gd
@@ -44,3 +44,9 @@ func update_noise_color_ramp() -> void:
 
 	var noise_texture: NoiseTexture2D = material.get_shader_parameter("cloud_texture")
 	noise_texture.color_ramp = new_color_ramp
+
+
+func _notification(what: int) -> void:
+	match what:
+		NOTIFICATION_EDITOR_PRE_SAVE:
+			material.set_shader_parameter("offset", 0.0)

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -60,7 +60,7 @@ noise = SubResource("FastNoiseLite_shbkg")
 resource_local_to_scene = true
 shader = ExtResource("34_opcsp")
 shader_parameter/cloud_texture = SubResource("NoiseTexture2D_thm8h")
-shader_parameter/offset = Vector2(14.4599, 7.22995)
+shader_parameter/offset = Vector2(0, 0)
 shader_parameter/scale = 0.2
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_h30yx"]


### PR DESCRIPTION
Previously, since the cloud overlay was running in the inspector, the offset of the clouds would change every frame. That's great to see how it looks, but since that's a value that is persisted in the scene, it was causing changes in the frays_end scene file.

Now, the clouds will still move across the level as usual, but on save the offset parameter of the shader gets reset to 0 so it's always the same value and we don't commit new unwanted changes to fray's end by mistake.