### PR TITLE
Transitions: Hide by default

### DIFF
--- a/scenes/globals/scene_switcher/transitions/transitions.tscn
+++ b/scenes/globals/scene_switcher/transitions/transitions.tscn
@@ -13,6 +13,7 @@ shader_parameter/mask = ExtResource("3_ij4f6")
 [node name="Transitions" type="CanvasLayer"]
 process_mode = 3
 layer = 10
+visible = false
 script = ExtResource("1_ij4f6")
 
 [node name="TransitionMask" type="ColorRect" parent="."]


### PR DESCRIPTION
Previously, the Transitions scene (a CanvasLayer with a ColorRect covering the viewport) was initially visible, although the ColorRect itself has a material that makes it fully transparent. At the start of any transition, it is explicitly made visible, then hidden at the end of the transition.

This means that on the first scene played, an invisible CanvasLayer swallows all clicks on the scene; and so if you play an individual scene, mouse input does not work until you switch to another scene. It is desirable that clicks (and other input) are blocked during a transition, but not outside one.

Set the scene's visible property to false by default.