### PR TITLE
SceneSwitcher: Call load() at blank point of transition

### DIFF
--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -66,9 +66,8 @@ func change_to_file_with_transition(
 	enter_transition: Transition.Effect = Transition.Effect.RIGHT_TO_LEFT_WIPE,
 	exit_transition: Transition.Effect = Transition.Effect.LEFT_TO_RIGHT_WIPE
 ) -> void:
-	var scene: PackedScene = load(scene_path)
 	Transitions.pause_and_do_transition(
-		change_to_packed.bind(scene, spawn_point), enter_transition, exit_transition
+		change_to_file.bind(scene_path, spawn_point), enter_transition, exit_transition
 	)
 
 


### PR DESCRIPTION
Previously, change_to_file_with_transition() would load() the given scene path before beginning the transition. For scenes that take a non-trivial amount of time to load, like Fray's End, this leads to a highly visible delay before starting the transition.

Instead, call load() at the blank point of the transition.

Helps https://github.com/endlessm/threadbare/issues/368