### PR TITLE
Intro: Fix unsightly line break before ellipsis

### DIFF
--- a/scenes/menus/intro/components/intro.dialogue
+++ b/scenes/menus/intro/components/intro.dialogue
@@ -8,5 +8,5 @@ do animation_player.animation_finished
 do animation_player.play(&"sketches")
 [speed=0.5]You know that feeling you get when you wrap yourself in your favorite blanket? Like a cozy hug from a loved one.
 [speed=0.5]What if I told you there is a world made of fabric, not too far away and not too near, that used to feel just like that hug?
-[speed=0.5]This world was made of stitches and stories, and people were happy. Until ...
+[speed=0.5]This world was made of stitches and stories, and people were happy. Until[char=00A0]...
 => END


### PR DESCRIPTION
Previously there was a regular (breaking) space character before the ellipsis at the end of the last line of the intro dialogue. Because of the dimensions of the dialogue balloon, the font size, and the text being displayed, it just so happens that a line break gets inserted between the word "Until" and the ellipsis. This looks bad.

My personal preference is not to use a space before an ellipsis when it indicates that the speaker is trailing off at the end of a sentence:

> Until...

However style guides vary considerably on this, and it seems more common in US English style guides to require a space before it.

Use a non-breaking space character between "Until" and "..." to avoid wrapping text in between the two. Use the BBCode tag for an arbitrary Unicode character to make the nature of the space visible. (Annoyingly, while Godot's BBCode has special tags for other invisible characters (e.g. `[zwnj]`), it does not have a `[nbsp]` tag.)