### PR TITLE
Load next scene asynchronously during transition

### DIFF
--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -66,8 +66,15 @@ func change_to_file_with_transition(
 	enter_transition: Transition.Effect = Transition.Effect.RIGHT_TO_LEFT_WIPE,
 	exit_transition: Transition.Effect = Transition.Effect.LEFT_TO_RIGHT_WIPE
 ) -> void:
+	var err := ResourceLoader.load_threaded_request(scene_path)
+	if err != OK:
+		push_error("Failed to start loading %s: %s" % [scene_path, error_string(err)])
+		return
+
 	Transitions.pause_and_do_transition(
-		change_to_file.bind(scene_path, spawn_point), enter_transition, exit_transition
+		func(): change_to_packed(ResourceLoader.load_threaded_get(scene_path), spawn_point),
+		enter_transition,
+		exit_transition
 	)
 
 

--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -66,9 +66,8 @@ func change_to_file_with_transition(
 	enter_transition: Transition.Effect = Transition.Effect.RIGHT_TO_LEFT_WIPE,
 	exit_transition: Transition.Effect = Transition.Effect.LEFT_TO_RIGHT_WIPE
 ) -> void:
-	var scene: PackedScene = load(scene_path)
 	Transitions.pause_and_do_transition(
-		change_to_packed.bind(scene, spawn_point), enter_transition, exit_transition
+		change_to_file.bind(scene_path, spawn_point), enter_transition, exit_transition
 	)
 
 


### PR DESCRIPTION
Previously, the target scene was loaded in full before starting the fade-out transition.

Instead, start loading the scene asynchronously at this point, then start the transition. Only wait for the scene to be fully loaded at the blank point of the transition. This means the transition starts immediately, and if the scene takes longer than 1 second to load, the pause is at the blank point: a natural place for it.

Helps #368 