### PR TITLE
Add mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: NONE
+# SPDX-License-Identifier: CC0-1.0
+Heather Drolet <heather@endlessos.org>
+Heather Drolet <heather@endlessos.org> Heather <108750056+hydrolet@users.noreply.github.com>
+Justin Bourque <justin@endlessos.org>
+Manuel Quiñones <manuel.por.aca@gmail.com>
+Pablo de Haro <pablitar@gmail.com>
+Stephen Reid <stephen@endlessos.org>
+Phoenix Stroh <68404504+PhoenixStroh@users.noreply.github.com>


### PR DESCRIPTION
Several people have committed to the repo with a variety of names and email addresses.

Add a mailmap file to canonicalise these so that `git shortlog -se` shows just one name and email address per person.