### PR TITLE
Dialogue: Don't stretch scroll texture

### DIFF
--- a/scenes/ui_elements/dialogue/components/theme.tres
+++ b/scenes/ui_elements/dialogue/components/theme.tres
@@ -115,8 +115,8 @@ texture_margin_left = 64.0
 texture_margin_top = 64.0
 texture_margin_right = 64.0
 texture_margin_bottom = 64.0
-axis_stretch_horizontal = 2
-axis_stretch_vertical = 2
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_qmeow"]
 content_margin_bottom = 18.0


### PR DESCRIPTION
Previously, the background texture was set to "tile_fit" in both the horizontal and vertical axes. In the case where the width or height is not an exact multiple of the texture width/height (64px), this causes it to be stretched slightly so that the edges fit exactly to the border region.

Since the dialogue balloon resizes between lines of dialogue and each time the "next >" button is shown and hidden, this causes the background texture to visibly change constantly. I think it's ugly.

Instead, use "tile", which tiles the texture without deformation, even if that means truncating the last tile. I personally can't see the seam where it joins the outer section, and this means that the background never changes in a visible section of the balloon.