### PR TITLE
Title: Add credits scene

### DIFF
--- a/scenes/menus/title/components/credits.gd
+++ b/scenes/menus/title/components/credits.gd
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Control
+
+signal back
+
+@onready var back_button: Button = %BackButton
+
+
+func _ready() -> void:
+	_on_visibility_changed()
+
+
+## Open links in user's default browser
+func _on_rich_text_label_meta_clicked(meta: Variant) -> void:
+	OS.shell_open(str(meta))
+
+
+func _on_visibility_changed() -> void:
+	if visible and back_button:
+		back_button.grab_focus()
+
+
+func _on_back_button_pressed() -> void:
+	back.emit()

--- a/scenes/menus/title/components/credits.gd.uid
+++ b/scenes/menus/title/components/credits.gd.uid
@@ -1,0 +1,1 @@
+uid://be1hcrmr5qtdu

--- a/scenes/menus/title/components/credits.tscn
+++ b/scenes/menus/title/components/credits.tscn
@@ -1,0 +1,146 @@
+[gd_scene load_steps=3 format=3 uid="uid://6s70kur03rjk"]
+
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/dialogue/components/theme.tres" id="1_gmidg"]
+[ext_resource type="Script" uid="uid://be1hcrmr5qtdu" path="res://scenes/menus/title/components/credits.gd" id="2_3tvx1"]
+
+[node name="Credits" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_gmidg")
+script = ExtResource("2_3tvx1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+scale = Vector2(1, 1.03033)
+theme_override_constants/margin_left = 64
+theme_override_constants/margin_top = 32
+theme_override_constants/margin_right = 64
+theme_override_constants/margin_bottom = 64
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+alignment = 1
+
+[node name="Authors" type="PanelContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/Authors"]
+layout_mode = 2
+
+[node name="TitlePanel" type="PanelContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/Authors/VBoxContainer"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 0
+theme_type_variation = &"PlayerRibbon"
+
+[node name="Title" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer/Authors/VBoxContainer/TitlePanel"]
+layout_mode = 2
+mouse_filter = 1
+text = "Authors"
+horizontal_alignment = 1
+
+[node name="Body" type="RichTextLabel" parent="MarginContainer/VBoxContainer/HBoxContainer/Authors/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+text = "Andrea Victoria Pavón
+Cassidy James Blaede
+Heather Drolet
+Juan Manuel Fernandes dos Santos
+Justin Bourque
+Manuel Quiñones
+Pablo de Haro
+Phoenix Stroh
+Rita Brederson
+Stephen Reid
+Tobías Romero
+Will Thompson"
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Art" type="PanelContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Art"]
+layout_mode = 2
+
+[node name="TitlePanel" type="PanelContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Art/VBoxContainer"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 0
+theme_type_variation = &"NPCRibbon"
+
+[node name="Title" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Art/VBoxContainer/TitlePanel"]
+layout_mode = 2
+mouse_filter = 1
+text = "Art and Music"
+horizontal_alignment = 1
+
+[node name="Body" type="RichTextLabel" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Art/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+text = "Additional original art by [url=https://pixelfrog-assets.itch.io/]Pixel Frog[/url]
+
+Original music by John Wright"
+
+[node name="ThirdPartyComponents" type="PanelContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ThirdPartyComponents"]
+layout_mode = 2
+
+[node name="TitlePanel" type="PanelContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ThirdPartyComponents/VBoxContainer"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 0
+theme_type_variation = &"NPCRibbon"
+
+[node name="Title" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ThirdPartyComponents/VBoxContainer/TitlePanel"]
+layout_mode = 2
+mouse_filter = 1
+text = "Third-Party Components"
+horizontal_alignment = 1
+
+[node name="Body" type="RichTextLabel" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ThirdPartyComponents/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+bbcode_enabled = true
+text = "Built with [url=https://godotengine.org/]Godot Engine[/url] ([url=https://godotengine.org/license/]MIT license[/url])
+
+Uses [url=https://dialogue.nathanhoad.net/]Godot Dialogue Manager[/url] by Nathan Hoad ([url=https://github.com/nathanhoad/godot_dialogue_manager/blob/main/LICENSE]MIT license[/url])"
+
+[node name="BackButton" type="Button" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"BigFlatButton"
+text = "< back"
+flat = true
+
+[connection signal="meta_clicked" from="MarginContainer/VBoxContainer/HBoxContainer/Authors/VBoxContainer/Body" to="." method="_on_rich_text_label_meta_clicked"]
+[connection signal="meta_clicked" from="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Art/VBoxContainer/Body" to="." method="_on_rich_text_label_meta_clicked"]
+[connection signal="visibility_changed" from="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Art/VBoxContainer/Body" to="." method="_on_visibility_changed"]
+[connection signal="meta_clicked" from="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ThirdPartyComponents/VBoxContainer/Body" to="." method="_on_rich_text_label_meta_clicked"]
+[connection signal="visibility_changed" from="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ThirdPartyComponents/VBoxContainer/Body" to="." method="_on_visibility_changed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]

--- a/scenes/menus/title/components/main_menu.gd
+++ b/scenes/menus/title/components/main_menu.gd
@@ -7,9 +7,14 @@ signal credits_pressed
 
 @onready var button_box: VBoxContainer = %ButtonBox
 @onready var start_button: Button = %StartButton
+@onready var quit_button: Button = %QuitButton
 
 
 func _ready() -> void:
+	# Hide the quit button on the web: handling the quit request requires
+	# custom code in the HTML shell that we do not have yet.
+	quit_button.visible = OS.get_name() != "Web"
+
 	# Wait for fade-in transition to finish before grabbing focus, so that the
 	# start button does not appear interactive while input is blocked.
 	if Transitions.is_running():

--- a/scenes/menus/title/components/main_menu.gd
+++ b/scenes/menus/title/components/main_menu.gd
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends HBoxContainer
+
+signal start_pressed
+signal credits_pressed
+
+@onready var button_box: VBoxContainer = %ButtonBox
+@onready var start_button: Button = %StartButton
+
+
+func _ready() -> void:
+	# Wait for fade-in transition to finish before grabbing focus, so that the
+	# start button does not appear interactive while input is blocked.
+	if Transitions.is_running():
+		await Transitions.finished
+
+	_on_visibility_changed()
+
+
+func _on_start_button_pressed() -> void:
+	start_pressed.emit()
+
+
+func _on_credits_button_pressed() -> void:
+	credits_pressed.emit()
+
+
+func _on_quit_button_pressed() -> void:
+	get_tree().quit()
+
+
+func _on_visibility_changed() -> void:
+	if visible and start_button:
+		start_button.grab_focus()

--- a/scenes/menus/title/components/main_menu.gd.uid
+++ b/scenes/menus/title/components/main_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://bkl8j1as8ylag

--- a/scenes/menus/title/components/main_menu.tscn
+++ b/scenes/menus/title/components/main_menu.tscn
@@ -1,0 +1,71 @@
+[gd_scene load_steps=4 format=3 uid="uid://wgmdsj1sbmja"]
+
+[ext_resource type="Texture2D" uid="uid://kalfq1qem3ak" path="res://assets/logo/threadbare-logo.png" id="1_hgbs1"]
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/dialogue/components/theme.tres" id="1_vmxej"]
+[ext_resource type="Script" uid="uid://bkl8j1as8ylag" path="res://scenes/menus/title/components/main_menu.gd" id="1_xuf5f"]
+
+[node name="MainMenu" type="HBoxContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_vmxej")
+script = ExtResource("1_xuf5f")
+
+[node name="LogoContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 128
+
+[node name="Logo" type="TextureRect" parent="LogoContainer"]
+custom_minimum_size = Vector2(1200, 0)
+layout_mode = 2
+size_flags_vertical = 4
+texture = ExtResource("1_hgbs1")
+expand_mode = 5
+stretch_mode = 4
+
+[node name="ButtonBoxMargins" type="MarginContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 8
+theme_override_constants/margin_left = 128
+theme_override_constants/margin_right = 128
+
+[node name="ButtonBox" type="VBoxContainer" parent="ButtonBoxMargins"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 4
+
+[node name="StartButton" type="Button" parent="ButtonBoxMargins/ButtonBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_type_variation = &"BigFlatButton"
+text = "Start"
+flat = true
+
+[node name="OptionsButton" type="Button" parent="ButtonBoxMargins/ButtonBox"]
+visible = false
+layout_mode = 2
+theme_type_variation = &"BigFlatButton"
+text = "Options"
+flat = true
+
+[node name="CreditsButton" type="Button" parent="ButtonBoxMargins/ButtonBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_type_variation = &"BigFlatButton"
+text = "Credits"
+flat = true
+
+[node name="QuitButton" type="Button" parent="ButtonBoxMargins/ButtonBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_type_variation = &"BigFlatButton"
+text = "Exit Game"
+flat = true
+
+[connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
+[connection signal="pressed" from="ButtonBoxMargins/ButtonBox/StartButton" to="." method="_on_start_button_pressed"]
+[connection signal="pressed" from="ButtonBoxMargins/ButtonBox/CreditsButton" to="." method="_on_credits_button_pressed"]
+[connection signal="pressed" from="ButtonBoxMargins/ButtonBox/QuitButton" to="." method="_on_quit_button_pressed"]

--- a/scenes/menus/title/components/title_screen.gd
+++ b/scenes/menus/title/components/title_screen.gd
@@ -4,18 +4,11 @@ extends Control
 
 @export var next_scene: PackedScene
 
-@onready var button_box: VBoxContainer = %ButtonBox
-@onready var start_button: Button = %StartButton
+@onready var main_menu: Control = %MainMenu
+@onready var credits: Control = %Credits
 
 
-func _ready() -> void:
-	if Transitions.is_running():
-		await Transitions.finished
-
-	start_button.grab_focus()
-
-
-func _on_start_button_pressed() -> void:
+func _on_start_pressed() -> void:
 	(
 		SceneSwitcher
 		. change_to_packed_with_transition(
@@ -27,5 +20,9 @@ func _on_start_button_pressed() -> void:
 	)
 
 
-func _on_quit_button_pressed() -> void:
-	get_tree().quit()
+func _on_main_menu_credits_pressed() -> void:
+	credits.show()
+
+
+func _on_credits_back() -> void:
+	main_menu.show()

--- a/scenes/menus/title/components/title_screen.gd
+++ b/scenes/menus/title/components/title_screen.gd
@@ -8,6 +8,11 @@ extends Control
 @onready var credits: Control = %Credits
 
 
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed(&"pause"):
+		get_viewport().set_input_as_handled()
+
+
 func _on_start_pressed() -> void:
 	(
 		SceneSwitcher

--- a/scenes/menus/title/title_screen.tscn
+++ b/scenes/menus/title/title_screen.tscn
@@ -1,12 +1,15 @@
-[gd_scene load_steps=8 format=3 uid="uid://stdqc6ttomff"]
+[gd_scene load_steps=10 format=3 uid="uid://stdqc6ttomff"]
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/dialogue/components/theme.tres" id="1_kj1pq"]
 [ext_resource type="Script" uid="uid://c6nc0jka32ow2" path="res://scenes/menus/title/components/title_screen.gd" id="2_0vy2n"]
 [ext_resource type="PackedScene" uid="uid://dow5vc7yb5k2c" path="res://scenes/menus/intro/intro.tscn" id="3_0vy2n"]
 [ext_resource type="Texture2D" uid="uid://bvlx57seuur65" path="res://assets/intro/background.png" id="3_2ijyo"]
-[ext_resource type="Texture2D" uid="uid://kalfq1qem3ak" path="res://assets/logo/threadbare-logo.png" id="4_3gkcv"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="4_c6kyi"]
+[ext_resource type="PackedScene" uid="uid://wgmdsj1sbmja" path="res://scenes/menus/title/components/main_menu.tscn" id="5_0vy2n"]
 [ext_resource type="AudioStream" uid="uid://davnfkvtb3edk" path="res://assets/music/Threadbare_Main_Quiet.ogg" id="5_5uobg"]
+[ext_resource type="PackedScene" uid="uid://6s70kur03rjk" path="res://scenes/menus/title/components/credits.tscn" id="6_2ijyo"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_2ijyo"]
 
 [node name="TitleScreen" type="Control"]
 layout_mode = 3
@@ -33,68 +36,28 @@ texture = ExtResource("3_2ijyo")
 expand_mode = 3
 stretch_mode = 6
 
-[node name="LogoContainer" type="MarginContainer" parent="."]
+[node name="Pages" type="TabContainer" parent="."]
 layout_mode = 1
-anchors_preset = 4
-anchor_top = 0.5
-anchor_bottom = 0.5
-offset_top = -442.415
-offset_right = 1344.0
-offset_bottom = 442.415
-grow_vertical = 2
-theme_override_constants/margin_left = 128
-
-[node name="Logo" type="TextureRect" parent="LogoContainer"]
-custom_minimum_size = Vector2(1200, 0)
-layout_mode = 2
-texture = ExtResource("4_3gkcv")
-expand_mode = 5
-stretch_mode = 4
-
-[node name="ButtonBoxMargins" type="MarginContainer" parent="."]
-layout_mode = 1
-anchors_preset = 11
-anchor_left = 1.0
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -584.0
-grow_horizontal = 0
+grow_horizontal = 2
 grow_vertical = 2
-size_flags_horizontal = 3
-theme_override_constants/margin_left = 128
-theme_override_constants/margin_right = 128
+theme_override_styles/panel = SubResource("StyleBoxEmpty_2ijyo")
+current_tab = 0
+tabs_visible = false
 
-[node name="ButtonBox" type="VBoxContainer" parent="ButtonBoxMargins"]
+[node name="MainMenu" parent="Pages" instance=ExtResource("5_0vy2n")]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_vertical = 4
+metadata/_tab_index = 0
 
-[node name="StartButton" type="Button" parent="ButtonBoxMargins/ButtonBox"]
+[node name="Credits" parent="Pages" instance=ExtResource("6_2ijyo")]
 unique_name_in_owner = true
-layout_mode = 2
-theme_type_variation = &"BigFlatButton"
-text = "Start"
-flat = true
-
-[node name="OptionsButton" type="Button" parent="ButtonBoxMargins/ButtonBox"]
 visible = false
 layout_mode = 2
-theme_type_variation = &"BigFlatButton"
-text = "Options"
-flat = true
+metadata/_tab_index = 1
 
-[node name="CreditsButton" type="Button" parent="ButtonBoxMargins/ButtonBox"]
-visible = false
-layout_mode = 2
-theme_type_variation = &"BigFlatButton"
-text = "Credits"
-flat = true
-
-[node name="QuitButton" type="Button" parent="ButtonBoxMargins/ButtonBox"]
-layout_mode = 2
-theme_type_variation = &"BigFlatButton"
-text = "Exit Game"
-flat = true
-
-[connection signal="pressed" from="ButtonBoxMargins/ButtonBox/StartButton" to="." method="_on_start_button_pressed"]
-[connection signal="pressed" from="ButtonBoxMargins/ButtonBox/QuitButton" to="." method="_on_quit_button_pressed"]
+[connection signal="credits_pressed" from="Pages/MainMenu" to="." method="_on_main_menu_credits_pressed"]
+[connection signal="start_pressed" from="Pages/MainMenu" to="." method="_on_start_pressed"]
+[connection signal="back" from="Pages/Credits" to="." method="_on_credits_back"]


### PR DESCRIPTION
Factor the main menu out of the title screen, placing it into a TabContainer without visible tabs or background to use as a view switcher.

Add a credits scene, with one panel for contributors to the game itself and another for third-party components for which attribution is required. Initially the text of each is hardcoded rather than being derived from the source tree in some way.

Fixes https://github.com/endlessm/threadbare/issues/53