### PR TITLE
Guards: Modify how variables are being exported

### DIFF
--- a/scenes/game_elements/characters/enemies/guard/guard.tscn
+++ b/scenes/game_elements/characters/enemies/guard/guard.tscn
@@ -30,6 +30,7 @@ collision_layer = 0
 collision_mask = 528
 motion_mode = 1
 script = ExtResource("1_g173s")
+AnimatedSprite2D__sprite_frames = ExtResource("5_ls1y7")
 
 [node name="GuardMovement" type="Node2D" parent="."]
 unique_name_in_owner = true

--- a/scenes/game_elements/props/buildings/house/house_1.tscn
+++ b/scenes/game_elements/props/buildings/house/house_1.tscn
@@ -8,7 +8,7 @@ size = Vector2(64.0002, 80)
 
 [node name="House_1" type="Node2D"]
 script = ExtResource("1_qufpk")
-house_sprite__texture = ExtResource("2_qufpk")
+HouseSprite__texture = ExtResource("2_qufpk")
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
 position = Vector2(1, -98)

--- a/scenes/game_elements/props/buildings/house/house_2.tscn
+++ b/scenes/game_elements/props/buildings/house/house_2.tscn
@@ -8,7 +8,7 @@ size = Vector2(62.7499, 97.0001)
 
 [node name="House_2" type="Node2D"]
 script = ExtResource("1_q48y4")
-house_sprite__texture = ExtResource("2_1mgcp")
+HouseSprite__texture = ExtResource("2_1mgcp")
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
 position = Vector2(1, -98)

--- a/scenes/game_elements/props/decoration/bush/bush.tscn
+++ b/scenes/game_elements/props/decoration/bush/bush.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=3 format=3 uid="uid://crqjcicx0vdu"]
 
-[ext_resource type="Script" path="res://scenes/game_elements/props/decoration/decoration.gd" id="1_a26qx"]
+[ext_resource type="Script" uid="uid://diknsuw3mtj1n" path="res://scenes/game_elements/props/decoration/decoration.gd" id="1_a26qx"]
 [ext_resource type="Texture2D" uid="uid://dtkpflrs22xyl" path="res://scenes/game_elements/props/decoration/bush/components/Bush1.png" id="1_p46yk"]
 
 [node name="Bush" type="Node2D"]
 script = ExtResource("1_a26qx")
-bush_sprite__texture = ExtResource("1_p46yk")
+BushSprite__texture = ExtResource("1_p46yk")
 
 [node name="BushSprite" type="Sprite2D" parent="."]
 position = Vector2(0, -14)

--- a/scenes/game_elements/props/decoration/spool/spool.tscn
+++ b/scenes/game_elements/props/decoration/spool/spool.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://bqhlguj2qmwx4"]
 
-[ext_resource type="Script" path="res://scenes/game_elements/props/decoration/decoration.gd" id="1_dh24t"]
+[ext_resource type="Script" uid="uid://diknsuw3mtj1n" path="res://scenes/game_elements/props/decoration/decoration.gd" id="1_dh24t"]
 [ext_resource type="Texture2D" uid="uid://b1dlp7j3rs6om" path="res://scenes/game_elements/props/decoration/spool/components/ThreadSpool1.png" id="2_dh24t"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_dh24t"]
@@ -8,7 +8,7 @@ radius = 21.3322
 
 [node name="Spool" type="Node2D"]
 script = ExtResource("1_dh24t")
-spool_sprite__texture = ExtResource("2_dh24t")
+SpoolSprite__texture = ExtResource("2_dh24t")
 
 [node name="SpoolSprite" type="Sprite2D" parent="."]
 position = Vector2(0, -19)

--- a/scenes/game_elements/props/tree/tree.tscn
+++ b/scenes/game_elements/props/tree/tree.tscn
@@ -8,8 +8,9 @@
 radius = 16.0312
 
 [node name="Tree" type="Node2D"]
+scale = Vector2(1.13321, 1.13563)
 script = ExtResource("1_7ot8u")
-tree__texture = ExtResource("2_2lvgq")
+Tree__texture = ExtResource("2_2lvgq")
 
 [node name="Tree" type="Sprite2D" parent="."]
 texture_filter = 1

--- a/scenes/globals/property_utils.gd
+++ b/scenes/globals/property_utils.gd
@@ -40,7 +40,7 @@ static func expose_children_property(
 		var property_dict: Dictionary = get_property_dict(child, property)
 		if not property_dict.is_empty():
 			property_dict = property_dict.duplicate()
-			property_dict["name"] = "%s__%s" % [child.name.to_snake_case(), property]
+			property_dict["name"] = "%s__%s" % [child.name, property]
 			properties.push_back(property_dict)
 
 	return properties
@@ -52,7 +52,7 @@ static func _resolve_child_property(parent: Node, child_property_name: String) -
 	if parts.size() < 2:
 		return {}
 
-	var child_name: String = parts[0].to_pascal_case()
+	var child_name: String = parts[0]
 	var child_property: String = parts[1]
 
 	var child: Node = parent.get_node_or_null(child_name)

--- a/scenes/globals/property_utils.gd
+++ b/scenes/globals/property_utils.gd
@@ -12,6 +12,12 @@ static func get_enum_hint_string(an_enum: Dictionary) -> String:
 	return ",".join(result)
 
 
+static func group(group_name: String, prefix: String = "") -> Dictionary:
+	return {
+		"name": group_name, "usage": PROPERTY_USAGE_GROUP, "type": TYPE_NIL, "hint_text": prefix
+	}
+
+
 static func enum_property(name: String, clazz: StringName, an_enum: Dictionary) -> Dictionary:
 	return {
 		"name": name,

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -159,26 +159,26 @@ y_sort_enabled = true
 
 [node name="House_1" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(1600, 815)
-house_sprite__texture = ExtResource("5_uhynt")
+HouseSprite__texture = ExtResource("5_uhynt")
 
 [node name="House_2" parent="Buildings" instance=ExtResource("15_uhynt")]
 position = Vector2(1760, 810)
-house_sprite__texture = ExtResource("5_uojly")
+HouseSprite__texture = ExtResource("5_uojly")
 
 [node name="House_3" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(316, 1043)
 
 [node name="House_4" parent="Buildings" instance=ExtResource("15_uhynt")]
 position = Vector2(352, 673)
-house_sprite__texture = ExtResource("6_uhynt")
+HouseSprite__texture = ExtResource("6_uhynt")
 
 [node name="House_5" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(731, 925)
-house_sprite__texture = ExtResource("6_ojp30")
+HouseSprite__texture = ExtResource("6_ojp30")
 
 [node name="House_6" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(227, 832)
-house_sprite__texture = ExtResource("5_uhynt")
+HouseSprite__texture = ExtResource("5_uhynt")
 
 [node name="House_7" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(1565, 1110)
@@ -188,11 +188,11 @@ position = Vector2(480, 1043)
 
 [node name="House_9" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(781, 1095)
-house_sprite__texture = ExtResource("5_uhynt")
+HouseSprite__texture = ExtResource("5_uhynt")
 
 [node name="House_10" parent="Buildings" instance=ExtResource("5_5jg1p")]
 position = Vector2(1758, 1185)
-house_sprite__texture = ExtResource("5_uhynt")
+HouseSprite__texture = ExtResource("5_uhynt")
 
 [node name="NPCs" type="Node2D" parent="."]
 y_sort_enabled = true
@@ -327,7 +327,7 @@ position = Vector2(-1, 120)
 y_sort_enabled = true
 position = Vector2(1377, 285)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree3" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-1051.28, 1556.47)
@@ -340,12 +340,12 @@ scale = Vector2(1.001, 1.001)
 [node name="Tree5" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-822.741, 1534.46)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree6" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-572.807, 1561.71)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree7" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-426.931, 1586.86)
@@ -378,7 +378,7 @@ scale = Vector2(1.001, 1.001)
 [node name="Tree15" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(13.6151, 1576.38)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree16" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-971.535, 11.5294)
@@ -399,17 +399,17 @@ scale = Vector2(1.001, 1.001)
 [node name="Tree19" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-885.954, -1.0481)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree73" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-885.954, -1.0481)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree20" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-628.24, 59.7433)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree21" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-826.631, -28.2994)
@@ -418,12 +418,12 @@ scale = Vector2(1.001, 1.001)
 [node name="Tree23" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-815.934, 40.877)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree71" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-27.972, 168.831)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree24" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-963.755, 1586.86)
@@ -464,7 +464,7 @@ scale = Vector2(1.001, 1.001)
 [node name="Tree38" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-1296.35, 1614.12)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree39" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-86.5532, 5.24063)
@@ -529,7 +529,7 @@ scale = Vector2(1.001, 1.001)
 [node name="Tree56" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(473.526, 423.576)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree57" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(88.4982, 1583.72)
@@ -542,7 +542,7 @@ scale = Vector2(1.001, 1.001)
 [node name="Tree59" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(241.182, 1588.96)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree60" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(118.646, 1592.1)
@@ -551,7 +551,7 @@ scale = Vector2(1.001, 1.001)
 [node name="Tree61" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(440.546, 1560.66)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree62" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(382.195, 1575.33)
@@ -572,20 +572,20 @@ scale = Vector2(1.001, 1.001)
 [node name="Tree66" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-561.137, 68.1282)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree72" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 y_sort_enabled = true
 position = Vector2(-1236.06, 758.844)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 metadata/_edit_pinned_properties_ = [&"scale"]
 
 [node name="Tree75" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 y_sort_enabled = true
 position = Vector2(-990.012, 622.587)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 metadata/_edit_pinned_properties_ = [&"scale"]
 
 [node name="Tree67" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
@@ -595,7 +595,7 @@ scale = Vector2(1.001, 1.001)
 [node name="Tree68" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-896.652, 1581.62)
 scale = Vector2(1.001, 1.001)
-tree__texture = ExtResource("12_780ok")
+Tree__texture = ExtResource("12_780ok")
 
 [node name="Tree69" parent="Trees/Tree" instance=ExtResource("7_7v00g")]
 position = Vector2(-1198.13, 1642.41)


### PR DESCRIPTION
While working in https://github.com/endlessm/threadbare/issues/260, I realised:
- we could have used `PropertyUtils.expose_children_properties` in https://github.com/endlessm/threadbare/pull/363 (so answering https://github.com/endlessm/threadbare/pull/363#pullrequestreview-2799972287, I actually forgot about that when I made that PR 😅 ).
- the way variables were exported in guards was different than in some other scenes (using category instead of export).
- `PropertyUtils.expose_children_properties` had a bug that made it not work for some properties names.

This PR addresses those 3 things and adds a helper to PropertyUtils to create groups.
