### PR TITLE
Indicate checkpoints visually

### DIFF
--- a/scenes/game_elements/props/checkpoint/checkpoint.tscn
+++ b/scenes/game_elements/props/checkpoint/checkpoint.tscn
@@ -1,7 +1,11 @@
-[gd_scene load_steps=3 format=3 uid="uid://dua6mynlw2ptw"]
+[gd_scene load_steps=5 format=3 uid="uid://dua6mynlw2ptw"]
 
 [ext_resource type="Script" uid="uid://bk5ri1yoakaqp" path="res://scenes/game_elements/props/checkpoint/components/checkpoint.gd" id="1_kkoqv"]
 [ext_resource type="Script" uid="uid://0enyu5v4ra34" path="res://scenes/game_elements/props/spawn_point/components/spawn_point.gd" id="2_s5d1s"]
+[ext_resource type="Texture2D" uid="uid://7afi18x3x1dm" path="res://assets/third_party/tiny-swords/Deco/18.png" id="3_wd3ro"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_wd3ro"]
+radius = 11.4018
 
 [node name="Checkpoint" type="Area2D"]
 collision_layer = 0
@@ -10,3 +14,19 @@ script = ExtResource("1_kkoqv")
 [node name="SpawnPoint" type="Marker2D" parent="." groups=["spawn_point"]]
 unique_name_in_owner = true
 script = ExtResource("2_s5d1s")
+
+[node name="Sprite" type="Sprite2D" parent="."]
+unique_name_in_owner = true
+position = Vector2(0, -64)
+texture = ExtResource("3_wd3ro")
+
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
+collision_layer = 16
+collision_mask = 0
+
+[node name="CollisionShape" type="CollisionShape2D" parent="StaticBody2D"]
+unique_name_in_owner = true
+position = Vector2(1, -4)
+shape = SubResource("CircleShape2D_wd3ro")
+disabled = true
+debug_color = Color(0.744429, 0.463578, 0, 0.42)

--- a/scenes/game_elements/props/checkpoint/checkpoint.tscn
+++ b/scenes/game_elements/props/checkpoint/checkpoint.tscn
@@ -1,11 +1,15 @@
-[gd_scene load_steps=5 format=3 uid="uid://dua6mynlw2ptw"]
+[gd_scene load_steps=7 format=3 uid="uid://dua6mynlw2ptw"]
 
 [ext_resource type="Script" uid="uid://bk5ri1yoakaqp" path="res://scenes/game_elements/props/checkpoint/components/checkpoint.gd" id="1_kkoqv"]
 [ext_resource type="Script" uid="uid://0enyu5v4ra34" path="res://scenes/game_elements/props/spawn_point/components/spawn_point.gd" id="2_s5d1s"]
 [ext_resource type="Texture2D" uid="uid://7afi18x3x1dm" path="res://assets/third_party/tiny-swords/Deco/18.png" id="3_wd3ro"]
+[ext_resource type="PackedScene" uid="uid://dutgnbiy7xalb" path="res://scenes/game_elements/props/interact_area/interact_area.tscn" id="4_cukws"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_wd3ro"]
 radius = 11.4018
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_3xcwf"]
+radius = 48.0
 
 [node name="Checkpoint" type="Area2D"]
 collision_layer = 0
@@ -30,3 +34,15 @@ position = Vector2(1, -4)
 shape = SubResource("CircleShape2D_wd3ro")
 disabled = true
 debug_color = Color(0.744429, 0.463578, 0, 0.42)
+
+[node name="InteractArea" parent="." instance=ExtResource("4_cukws")]
+unique_name_in_owner = true
+collision_layer = 0
+interact_label_position = Vector2(0, -128)
+disabled = true
+action = "Admire"
+
+[node name="CollisionShape" type="CollisionShape2D" parent="InteractArea"]
+position = Vector2(1, -4)
+shape = SubResource("CircleShape2D_3xcwf")
+debug_color = Color(0, 0.606449, 0.661205, 0.42)

--- a/scenes/game_elements/props/checkpoint/components/checkpoint.dialogue
+++ b/scenes/game_elements/props/checkpoint/components/checkpoint.dialogue
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+~ start
+KnitWitch: I have knitted your progress so far, StoryWeaver.
+%9
+%
+	StoryWeaver: Wow, you can talk!
+	KnitWitch: Wow, so can you. What a coincidence.
+	StoryWeaver: I didn't think scarecrows could talk.
+	KnitWitch: Maybe they just never had anything to say to you. Ever think of that?
+=> END

--- a/scenes/game_elements/props/checkpoint/components/checkpoint.dialogue.import
+++ b/scenes/game_elements/props/checkpoint/components/checkpoint.dialogue.import
@@ -1,0 +1,16 @@
+[remap]
+
+importer="dialogue_manager"
+importer_version=15
+type="Resource"
+uid="uid://bug2aqd47jgyu"
+path="res://.godot/imported/checkpoint.dialogue-6cb1fcad38bf52f5e1b089b4445c4a1d.tres"
+
+[deps]
+
+source_file="res://scenes/game_elements/props/checkpoint/components/checkpoint.dialogue"
+dest_files=["res://.godot/imported/checkpoint.dialogue-6cb1fcad38bf52f5e1b089b4445c4a1d.tres"]
+
+[params]
+
+defaults=true

--- a/scenes/game_elements/props/checkpoint/components/checkpoint.gd
+++ b/scenes/game_elements/props/checkpoint/components/checkpoint.gd
@@ -4,6 +4,10 @@ class_name Checkpoint
 extends Area2D
 ## A place where the player respawns if the current scene is reloaded.
 
+const DIALOGUE: DialogueResource = preload(
+	"res://scenes/game_elements/props/checkpoint/components/checkpoint.dialogue"
+)
+
 ## The point where the player will spawn.
 @onready var spawn_point: SpawnPoint = %SpawnPoint
 
@@ -13,10 +17,13 @@ extends Area2D
 ## The collision shape for the sprite, when this checkpoint is activated
 @onready var collision_shape: CollisionShape2D = %CollisionShape
 
+@onready var interact_area: InteractArea = %InteractArea
+
 
 func _ready() -> void:
 	sprite.visible = false
 	body_entered.connect(func(_body: Node2D) -> void: self.activate())
+	interact_area.interaction_started.connect(_on_interaction_started)
 
 
 ## Makes this the active checkpoint.
@@ -24,3 +31,10 @@ func activate() -> void:
 	GameState.current_spawn_point = owner.get_path_to(spawn_point)
 	sprite.visible = true
 	collision_shape.set_deferred(&"disabled", false)
+	interact_area.disabled = false
+
+
+func _on_interaction_started(player: Player, _from_right: bool) -> void:
+	DialogueManager.show_dialogue_balloon(DIALOGUE, "", [self, player])
+	await DialogueManager.dialogue_ended
+	interact_area.interaction_ended.emit()

--- a/scenes/game_elements/props/checkpoint/components/checkpoint.gd
+++ b/scenes/game_elements/props/checkpoint/components/checkpoint.gd
@@ -1,17 +1,26 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
-class_name Checkpoint extends Area2D
-
+class_name Checkpoint
+extends Area2D
 ## A place where the player respawns if the current scene is reloaded.
 
 ## The point where the player will spawn.
 @onready var spawn_point: SpawnPoint = %SpawnPoint
 
+## The sprite displayed when this checkpoint is activated
+@onready var sprite: Sprite2D = %Sprite
+
+## The collision shape for the sprite, when this checkpoint is activated
+@onready var collision_shape: CollisionShape2D = %CollisionShape
+
 
 func _ready() -> void:
+	sprite.visible = false
 	body_entered.connect(func(_body: Node2D) -> void: self.activate())
 
 
 ## Makes this the active checkpoint.
 func activate() -> void:
 	GameState.current_spawn_point = owner.get_path_to(spawn_point)
+	sprite.visible = true
+	collision_shape.set_deferred(&"disabled", false)

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -995,7 +995,7 @@ texture = ExtResource("22_djpoe")
 y_sort_enabled = true
 
 [node name="Checkpoint" parent="Checkpoints" instance=ExtResource("11_idy4y")]
-position = Vector2(1357, 284)
+position = Vector2(1293, 284)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Checkpoints/Checkpoint"]
 position = Vector2(-14, 36.5)

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -238,7 +238,7 @@ point_count = 2
 size = Vector2(115, 379)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_xtu6t"]
-size = Vector2(382, 126)
+size = Vector2(254, 212)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_oyx4c"]
 size = Vector2(200, 188.5)
@@ -250,7 +250,7 @@ size = Vector2(96, 190)
 size = Vector2(137, 126)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_n0bwe"]
-size = Vector2(117, 254)
+size = Vector2(212, 254)
 
 [sub_resource type="Resource" id="Resource_idy4y"]
 script = ExtResource("3_idy4y")
@@ -995,10 +995,10 @@ texture = ExtResource("22_djpoe")
 y_sort_enabled = true
 
 [node name="Checkpoint" parent="Checkpoints" instance=ExtResource("11_idy4y")]
-position = Vector2(1357, 300)
+position = Vector2(1357, 284)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Checkpoints/Checkpoint"]
-position = Vector2(-14, 20.5)
+position = Vector2(-14, 36.5)
 shape = SubResource("RectangleShape2D_idy4y")
 debug_color = Color(0, 0, 0, 0.42)
 
@@ -1006,7 +1006,7 @@ debug_color = Color(0, 0, 0, 0.42)
 position = Vector2(2420, 419)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Checkpoints/Checkpoint2"]
-position = Vector2(13, 95)
+position = Vector2(77, 52)
 shape = SubResource("RectangleShape2D_xtu6t")
 debug_color = Color(0, 0, 0, 0.42)
 
@@ -1039,7 +1039,7 @@ debug_color = Color(0, 0, 0, 0.42)
 position = Vector2(5516, 1184)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Checkpoints/Checkpoint6"]
-position = Vector2(-99.5, -33)
+position = Vector2(-52, -33)
 shape = SubResource("RectangleShape2D_n0bwe")
 debug_color = Color(0, 0, 0, 0.42)
 

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -992,6 +992,7 @@ scale = Vector2(0.8, 0.8)
 texture = ExtResource("22_djpoe")
 
 [node name="Checkpoints" type="Node2D" parent="."]
+y_sort_enabled = true
 
 [node name="Checkpoint" parent="Checkpoints" instance=ExtResource("11_idy4y")]
 position = Vector2(1357, 300)

--- a/scenes/quests/story_quests/template/1_stealth/stealth_template.tscn
+++ b/scenes/quests/story_quests/template/1_stealth/stealth_template.tscn
@@ -101,6 +101,7 @@ position = Vector2(1947, 473)
 curve = SubResource("Curve2D_hejm3")
 
 [node name="Checkpoints" type="Node2D" parent="."]
+y_sort_enabled = true
 
 [node name="Checkpoint" parent="Checkpoints" instance=ExtResource("6_yi1jk")]
 position = Vector2(1704, 451)


### PR DESCRIPTION
Previously, there was no visible indication that there are checkpoints in the stealth level, or that you have reached one. In playtesting, some players suggested that we should add checkpoints to the stealth level, not realising that they were already present.

Add a sprite to the checkpoint scene. Hide it until the player enters the checkpoint area.

Add a small collision shape to it, so that the player can't walk through it. Deactivate that collision shape when the sprite is invisible.

Enable y-sorting on the parent node of all the checkpoints in the two stealth levels currently in the source tree.

For now, a scarecrow is used to indicate the checkpoint, as a placeholder. I have not added any kind of animation or sound effect when the checkpoint is reached.

You can interact with the scarecrow to trigger a brief bit of dialogue that explains, in-game, what it does. The (first line of) dialogue is taken from #240.

Adjust a few checkpoint areas and positions, as explained in each commit message.

Fixes #240
