### PR TITLE
Make background music continue between levels

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ GameState="*res://scenes/globals/game_state/game_state.tscn"
 SceneSwitcher="*res://scenes/globals/scene_switcher/scene_switcher.gd"
 Transitions="*res://scenes/globals/scene_switcher/transitions/transitions.tscn"
 PauseOverlay="*res://scenes/globals/pause/pause_overlay.tscn"
+MusicPlayer="*res://scenes/globals/music_player/music_player.tscn"
 
 [debug]
 

--- a/scenes/game_elements/props/background_music/background_music.tscn
+++ b/scenes/game_elements/props/background_music/background_music.tscn
@@ -3,8 +3,5 @@
 [ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="1_g25to"]
 
 [node name="BackgroundMusic" type="Node"]
+process_mode = 3
 script = ExtResource("1_g25to")
-
-[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
-unique_name_in_owner = true
-bus = &"Music"

--- a/scenes/globals/music_player/music_player.gd
+++ b/scenes/globals/music_player/music_player.gd
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+extends Node
+
+@onready var background_music_player: AudioStreamPlayer = %BackgroundMusicPlayer

--- a/scenes/globals/music_player/music_player.gd.uid
+++ b/scenes/globals/music_player/music_player.gd.uid
@@ -1,0 +1,1 @@
+uid://qjk0stcwto74

--- a/scenes/globals/music_player/music_player.tscn
+++ b/scenes/globals/music_player/music_player.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3 uid="uid://dfccb0pxhfmpe"]
+
+[ext_resource type="Script" uid="uid://qjk0stcwto74" path="res://scenes/globals/music_player/music_player.gd" id="1_xkpdo"]
+
+[node name="MusicPlayer" type="Node"]
+process_mode = 3
+script = ExtResource("1_xkpdo")
+
+[node name="BackgroundMusicPlayer" type="AudioStreamPlayer" parent="."]
+unique_name_in_owner = true
+bus = &"Music"

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1,6 +1,5 @@
 [gd_scene load_steps=27 format=4 uid="uid://7hoy2p14t6kc"]
 
-[ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="1_2pgn6"]
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_evicy"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="2_0ayb4"]
 [ext_resource type="PackedScene" uid="uid://ipvcfv2g0oi1" path="res://scenes/game_elements/characters/npcs/talker/talker.tscn" id="3_2pgn6"]
@@ -11,7 +10,7 @@
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="8_evicy"]
 [ext_resource type="PackedScene" uid="uid://dv30a1p74xgs1" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock_xylophone.tscn" id="8_u8pjn"]
 [ext_resource type="PackedScene" uid="uid://be4o3ythda4cu" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.tscn" id="9_evicy"]
-[ext_resource type="Script" uid="uid://d3nqiysmw6afc" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/trees.gd" id="13_0jy21"]
+[ext_resource type="Script" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/trees.gd" id="13_0jy21"]
 [ext_resource type="Resource" uid="uid://dd2bmyd2m745n" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/melody_musician.dialogue" id="13_2pgn6"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="13_inhg4"]
 [ext_resource type="Resource" uid="uid://bu1d4utqqrarv" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/river_musician.dialogue" id="14_2pgn6"]
@@ -51,13 +50,11 @@ noise = SubResource("FastNoiseLite_shbkg")
 resource_local_to_scene = true
 shader = ExtResource("21_nonj7")
 shader_parameter/cloud_texture = SubResource("NoiseTexture2D_mgtd3")
-shader_parameter/offset = Vector2(1133.02, 383.354)
+shader_parameter/offset = Vector2(0, 0)
 shader_parameter/scale = 0.2
 
 [node name="MusicPuzzle" type="Node2D"]
 texture_filter = 1
-
-[node name="BackgroundMusic" parent="." instance=ExtResource("1_2pgn6")]
 
 [node name="TileMapLayers" type="Node2D" parent="."]
 


### PR DESCRIPTION
Add a new global, MusicPlayer, that holds an AudioStreamPlayer that is accessible from everywhere.

Change the code in BackgroundMusic so it uses that AudioStreamPlayer instead of an internal one. Also, change the code so it checks if the AudioStream it will play is the same as the one that is currently playing, if that's the case, do nothing.

When transitioning out of a level, the BackgroundMusic node starts a tween that mutes the global AudioStreamPlayer by tweening its volume_db to -100 (linear_to_db(0.00001)). On _ready() of the next BackgroundMusic node, the AudioStreamPlayer volume_db would tween back to 0.0. This solves 2 things:
- We have fade out and fade in between scenes.
- If a level doesn't have background music, we don't have to do anything special in that level because the audio stream will be muted because of the volume_db. The only gotcha with this is that if we go from `level A` with `audio stream 1`, to `level B` with no music, to `level C` with `audio stream 1` again, the audio stream will resume where it was playing instead of starting again.

Fixes https://github.com/endlessm/threadbare/issues/335

# 🔊 

https://github.com/user-attachments/assets/cf51b608-292e-4825-8207-5635d215a3f8

