### PR TITLE
Parameterise player name in default dialogue

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -33,7 +33,7 @@ gdscript/warnings/untyped_declaration=1
 editor/new_file_template="# SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-Elder: [[Hi|Hello|Howdy]], StoryWeaver.
+{{npc_name}}: [[Hi|Hello|Greetings]], {{player_name}}
 => END
 "
 runtime/balloon_path="uid://dhydhpp43urah"

--- a/scenes/game_elements/characters/npcs/talker/components/default.dialogue
+++ b/scenes/game_elements/characters/npcs/talker/components/default.dialogue
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-{{npc_name}}: [[Hi|Hello|Greetings]], StoryWeaver.
+{{npc_name}}: [[Hi|Hello|Greetings]], {{player_name}}.
 => END

--- a/scenes/game_elements/props/checkpoint/components/checkpoint.dialogue
+++ b/scenes/game_elements/props/checkpoint/components/checkpoint.dialogue
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-KnitWitch: I have knitted your progress so far, StoryWeaver.
+KnitWitch: I have knitted your progress so far, {{player_name}}.
 %9
 %
-	StoryWeaver: Wow, you can talk!
+	{{player_name}}: Wow, you can talk!
 	KnitWitch: Wow, so can you. What a coincidence.
-	StoryWeaver: I didn't think scarecrows could talk.
+	{{player_name}}: I didn't think scarecrows could talk.
 	KnitWitch: Maybe they just never had anything to say to you. Ever think of that?
 => END

--- a/scenes/game_elements/props/checkpoint/components/checkpoint.gd
+++ b/scenes/game_elements/props/checkpoint/components/checkpoint.gd
@@ -4,9 +4,9 @@ class_name Checkpoint
 extends Area2D
 ## A place where the player respawns if the current scene is reloaded.
 
-const DIALOGUE: DialogueResource = preload(
-	"res://scenes/game_elements/props/checkpoint/components/checkpoint.dialogue"
-)
+## Dialogue to trigger when the player interacts with the checkpoint. If empty, the player will not
+## be able to interact with the checkpoint.
+@export var dialogue: DialogueResource = preload("uid://bug2aqd47jgyu")
 
 ## The point where the player will spawn.
 @onready var spawn_point: SpawnPoint = %SpawnPoint
@@ -31,10 +31,11 @@ func activate() -> void:
 	GameState.current_spawn_point = owner.get_path_to(spawn_point)
 	sprite.visible = true
 	collision_shape.set_deferred(&"disabled", false)
-	interact_area.disabled = false
+	interact_area.disabled = dialogue == null
 
 
 func _on_interaction_started(player: Player, _from_right: bool) -> void:
-	DialogueManager.show_dialogue_balloon(DIALOGUE, "", [self, player])
+	DialogueManager.show_dialogue_balloon(dialogue, "", [self, player])
 	await DialogueManager.dialogue_ended
+
 	interact_area.interaction_ended.emit()


### PR DESCRIPTION
I noticed a few places where the name "StoryWeaver" is hardcoded in dialogue that will, by default, be used in StoryQuests if certain components are used there without customisation – namely, stealth challenge checkpoints and default NPC dialogue.

Update all of these to get the player name dynamically, and make it possible to customise the checkpoint dialogue in any case.