### PR TITLE
Fix trees sway in sync

### DIFF
--- a/scenes/game_elements/props/tree/components/wind_affected_material.tres
+++ b/scenes/game_elements/props/tree/components/wind_affected_material.tres
@@ -3,10 +3,13 @@
 [ext_resource type="Shader" uid="uid://djspf45cxnom2" path="res://scenes/game_elements/props/tree/tree.gdshader" id="1_un8pg"]
 
 [sub_resource type="FastNoiseLite" id="FastNoiseLite_f0x1c"]
+frequency = 0.008
+fractal_lacunarity = 1.0
 
 [sub_resource type="NoiseTexture2D" id="NoiseTexture2D_f0x1c"]
 width = 1024
 height = 1024
+seamless = true
 noise = SubResource("FastNoiseLite_f0x1c")
 
 [sub_resource type="Curve" id="Curve_f0x1c"]

--- a/scenes/game_elements/props/tree/tree.gdshader
+++ b/scenes/game_elements/props/tree/tree.gdshader
@@ -3,7 +3,7 @@
 shader_type canvas_item;
 
 uniform sampler2D wind_affect_curve;
-uniform float phase_period : hint_range(1.0, 10000.0, 10.0) = 1000.0;
+uniform float phase_period : hint_range(1.0, 20000.0, 10.0) = 8000.0;
 uniform sampler2D phase_noise;
 uniform float max_wind_speed : hint_range(0.0, 50.0, 0.1) = 5.0;
 uniform float max_wind_intensity : hint_range(0.0, 10.0, 0.1) = 2.0;
@@ -16,7 +16,7 @@ void vertex() {
 }
 
 void fragment() {
-	float noise_value = texture(phase_noise, fract(world_pos)).x;
+	float noise_value = texture(phase_noise, fract(world_pos / phase_period)).x;
 	float wind_phase = noise_value * 100.0;
 	float wind_speed = noise_value * max_wind_speed;
 	float max_offset = sin(TIME * wind_speed + wind_phase) * max_wind_intensity;


### PR DESCRIPTION
In the trees shaders we use the world position as a parameter to sample a noise to get the wind parameters. There was an issue though: Since the textures get sampled using UVs, we need to convert the world coordinates into UV coordinates.

The use of the `fract` function was ok, but we should divide the world position by a "scale" which will decide how big or small is the projection of the texture on the world. That scale will decide how "uniform" is the movement of the trees, large values being more uniform, and small values less.

There's already a parameter for that called "phase_period" but it wasn't being used.

This commit makes use of that parameter fixing the "sway in sync" behaviur of the trees. Also, the noise of the wind of trees is tuned so the difference in wind is softer.

Fixes #307