### PR TITLE
Music Puzzle: On wrong note, match again at start of melody

### DIFF
--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
@@ -71,10 +71,13 @@ func _on_note_played(note: String) -> void:
 		"Current melody %s position %d expecting %s, received %s",
 		[melody, _position, melody[_position], note],
 	)
-	if melody[_position] != note:
+	if _position != 0 and melody[_position] != note:
 		_debug("Didn't match")
 		_position = 0
 		_debug("Matching again at start of melody...")
+
+	if melody[_position] != note:
+		_debug("Didn't match")
 		xylophone.stop_all_hints()
 		if hint_levels.get(get_progress(), 0) >= wobble_hint_min_level:
 			hint_timer.start()


### PR DESCRIPTION
Suppose that the sequence of notes that you have to play is C D E G, and you play C D C D E G. This should be accepted as a valid solution, because although the third note played is wrong for the 3rd note of the melody, it's the correct first note. But this regressed in commit bf96e5f.

After failing to match the note in the middle of the melody, match it again at the start.

Fixes https://github.com/endlessm/threadbare/issues/437