### PR TITLE
Pre commit: Only exclude the Dialogue Manager addon

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,5 +21,5 @@ repos:
     exclude: script_templates/
 exclude: |
   (?x)^(
-    addons/(.*)
+    addons/dialogue_manager/(.*)
   )$


### PR DESCRIPTION
Other addons can be managed by us, so we can apply the same checks as the project files to those.