### PR TITLE
Add storybook to select a StoryQuest to play

### DIFF
--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name Quest
+extends Resource
+## Information that defines a playable quest
+
+## The quest's title. This should be short, like the title of a novel.
+@export var title: String:
+	set(new_value):
+		title = new_value.strip_edges()
+
+## A short description of the quest. This should be a single paragraph of around 2–3 sentences.
+@export_multiline var description: String
+
+## The names of the people who created this quest: artists, writers, designers, developers, etc.
+@export var authors: Array[String]
+
+## Optional affiliation of the authors, such as a university, game jam, or community group.
+## Leave blank if not needed.
+@export var affiliation: String
+
+@export_group("Advanced")
+
+## The path to the first scene of the quest. If you are following the structure of the template,
+## leave this as the default path. The path can be absolute (beginning with [code]res://[/code])
+## or relative to the folder where this quest resource is saved.
+@export_file("*.tscn") var first_scene: String = "0_intro/intro.tscn"
+
+
+func _to_string() -> String:
+	return '<Quest %s: "%s">' % [resource_path]
+
+
+## Returns [member title] if set, or a placeholder identifying the quest otherwise.
+func get_title() -> String:
+	if title:
+		return title
+
+	return resource_path.get_base_dir().get_file()
+
+
+## Resolves [member first_scene] relative to the directory this Quest is stored in, if necessary.
+func get_first_scene_path() -> String:
+	if first_scene.is_absolute_path():
+		return first_scene
+
+	return resource_path.get_base_dir().path_join(first_scene)

--- a/scenes/menus/storybook/components/quest.gd.uid
+++ b/scenes/menus/storybook/components/quest.gd.uid
@@ -1,0 +1,1 @@
+uid://dts1hwdy3phin

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Control
+## Offers a choice of quests by scanning a given [member quest_directory].
+
+## Emitted when the player chooses to play the given quest
+signal play(quest: Quest)
+
+## Template quest, which is expected to be blank and so is treated specially.
+const STORY_QUEST_TEMPLATE := preload("res://scenes/quests/story_quests/template/quest.tres")
+
+const QUEST_RESOURCE_NAME := "quest.tres"
+
+## Directory to scan for quests. This directory should have 1 or more subdirectories, each of which
+## have a [code]quest.tres[/code] file within.
+@export_dir var quest_directory: String = "res://scenes/quests/story_quests"
+
+var _selected_quest: Quest
+
+@onready var quest_list: VBoxContainer = %QuestList
+@onready var title: Label = %Title
+@onready var description: Label = %Description
+@onready var authors: Label = %Authors
+@onready var play_button: Button = %PlayButton
+
+
+func _enumerate_quests() -> Array[Quest]:
+	var has_template: bool = false
+	var quests: Array[Quest]
+
+	for dir in ResourceLoader.list_directory(quest_directory):
+		var quest_path := quest_directory.path_join(dir).path_join(QUEST_RESOURCE_NAME)
+		if ResourceLoader.exists(quest_path, "Quest"):
+			var quest: Quest = ResourceLoader.load(quest_path, "Quest")
+			if quest == STORY_QUEST_TEMPLATE:
+				has_template = true
+			else:
+				quests.append(quest)
+
+	if has_template:
+		quests.append(STORY_QUEST_TEMPLATE)
+
+	return quests
+
+
+func _ready() -> void:
+	var previous_button: Button = null
+	for quest in _enumerate_quests():
+		var button := Button.new()
+		button.text = quest.get_title()
+		button.theme_type_variation = "FlatButton"
+		quest_list.add_child(button)
+
+		button.focus_entered.connect(_on_button_focused.bind(button, quest))
+		button.focus_next = play_button.get_path()
+		button.focus_previous = play_button.get_path()
+
+		if previous_button:
+			button.focus_neighbor_top = previous_button.get_path()
+			previous_button.focus_neighbor_bottom = button.get_path()
+		else:
+			button.grab_focus()
+
+		previous_button = button
+
+	previous_button.focus_neighbor_bottom = previous_button.get_path()
+
+
+func _on_button_focused(button: Button, quest: Quest) -> void:
+	play_button.focus_next = button.get_path()
+	play_button.focus_previous = button.get_path()
+	play_button.focus_neighbor_left = button.get_path()
+	_selected_quest = quest
+
+	if quest == STORY_QUEST_TEMPLATE:
+		title.text = "StoryQuest Template"
+		description.text = "This is the template for your own StoryQuests."
+		authors.text = "A story by the Threadbare Authors"
+		return
+
+	title.text = quest.title
+
+	if quest.description:
+		description.text = quest.description
+	else:
+		description.text = "It is a mystery"
+
+	match quest.authors.size():
+		0:
+			authors.text = "An anonymous story"
+		1:
+			authors.text = "A story by " + quest.authors[0]
+		_:
+			authors.text = (
+				" "
+				. join(
+					[
+						"A story by",
+						", ".join(quest.authors.slice(0, -1)),
+						"and",
+						quest.authors[-1],
+					]
+				)
+			)
+
+	if quest.affiliation:
+		authors.text += " of " + quest.affiliation
+
+
+func _on_play_button_pressed() -> void:
+	play.emit(_selected_quest)

--- a/scenes/menus/storybook/components/storybook.gd.uid
+++ b/scenes/menus/storybook/components/storybook.gd.uid
@@ -1,0 +1,1 @@
+uid://5bt5um5g1g3p

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -1,0 +1,83 @@
+[gd_scene load_steps=3 format=3 uid="uid://bhm7fdjvppt8b"]
+
+[ext_resource type="Script" uid="uid://5bt5um5g1g3p" path="res://scenes/menus/storybook/components/storybook.gd" id="1_gw8hn"]
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/dialogue/components/theme.tres" id="1_rdgd0"]
+
+[node name="Storybook" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_rdgd0")
+script = ExtResource("1_gw8hn")
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer"]
+layout_mode = 2
+
+[node name="LeftPage" type="MarginContainer" parent="PanelContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="QuestList" type="VBoxContainer" parent="PanelContainer/HBoxContainer/LeftPage"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="VSeparator" type="VSeparator" parent="PanelContainer/HBoxContainer"]
+layout_mode = 2
+
+[node name="RightPage" type="MarginContainer" parent="PanelContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/HBoxContainer/RightPage"]
+layout_mode = 2
+
+[node name="TitleBox" type="PanelContainer" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_type_variation = &"PlayerRibbon"
+
+[node name="Title" type="Label" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer/TitleBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Title of the Quest"
+
+[node name="Description" type="Label" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 64)
+layout_mode = 2
+text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pulvinar, erat non consectetur cursus, erat erat lobortis massa, quis mattis purus dolor ac lorem. In hac habitasse platea dictumst. Suspendisse vulputate felis purus, ac scelerisque mauris tristique sit amet. Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+autowrap_mode = 2
+
+[node name="Authors" type="Label" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 64)
+layout_mode = 2
+size_flags_vertical = 1
+text = "by Jane Bloggs, Erika Mustermann and Jóna Jónsdóttir"
+autowrap_mode = 2
+
+[node name="Spacer" type="Control" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="PlayButton" type="Button" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+focus_neighbor_top = NodePath(".")
+focus_neighbor_bottom = NodePath(".")
+theme_type_variation = &"FlatButton"
+text = "Play"
+
+[connection signal="pressed" from="PanelContainer/HBoxContainer/RightPage/VBoxContainer/PlayButton" to="." method="_on_play_button_pressed"]

--- a/scenes/quests/story_quests/template/quest.tres
+++ b/scenes/quests/story_quests/template/quest.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="Quest" load_steps=2 format=3 uid="uid://ddxn14xw66ud8"]
+
+[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_y02x1"]
+
+[resource]
+script = ExtResource("1_y02x1")
+title = ""
+description = ""
+authors = Array[String]([])
+affiliation = ""
+first_scene = "0_intro/intro.tscn"
+metadata/_custom_type_script = "uid://dts1hwdy3phin"


### PR DESCRIPTION
This is not actually wired up to the game, because there is currently only one StoryQuest in the source tree. The intention is that, once we have more than one, interacting with the StoryQuest elder would give you this interface (or an improved version of it) to choose which one to play.

The purpose of adding this now is to define the "Quest" resource type and place it in the StoryQuest template directory.

This could also be used to populate the Credits screen (https://github.com/endlessm/threadbare/issues/402).

Fixes https://github.com/endlessm/threadbare/issues/470