### PR TITLE
Switch all res:// preload references to UID paths

### DIFF
--- a/scenes/game_elements/characters/enemies/guard/components/guard.gd
+++ b/scenes/game_elements/characters/enemies/guard/components/guard.gd
@@ -20,9 +20,7 @@ enum State {
 	RETURNING,
 }
 
-const DEFAULT_SPRITE_FRAMES = preload(
-	"res://scenes/game_elements/characters/enemies/guard/components/guard_sprite_frames.tres"
-)
+const DEFAULT_SPRITE_FRAMES = preload("uid://c4kqsgl2pcofo")
 
 const LOOK_AT_TURN_SPEED: float = 10.0
 

--- a/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
+++ b/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
@@ -7,9 +7,7 @@ extends CharacterBody2D
 
 enum State { IDLE, WALKING, ATTACKING, DEFEATED }
 
-const PROJECTILE_SCENE: PackedScene = preload(
-	"res://scenes/game_elements/props/projectile/projectile.tscn"
-)
+const PROJECTILE_SCENE: PackedScene = preload("uid://j8mqjkg0rvai")
 
 ## When targetting the next walking position, skip this slice of the circle.
 const WALK_TARGET_SKIP_ANGLE: float = PI / 4.

--- a/scenes/game_elements/characters/npcs/shared_components/npc.gd
+++ b/scenes/game_elements/characters/npcs/shared_components/npc.gd
@@ -4,9 +4,7 @@
 class_name NPC
 extends CharacterBody2D
 
-const DEFAULT_SPRITE_FRAME: SpriteFrames = preload(
-	"res://scenes/game_elements/characters/npcs/npc_prop/sprite_frames/fray_idle_purple.tres"
-)
+const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("uid://cpm5o35ede3qs")
 
 @export var look_at_side: Enums.LookAtSide = Enums.LookAtSide.LEFT:
 	set = _set_look_at_side

--- a/scenes/game_elements/characters/npcs/talker/components/talker.gd
+++ b/scenes/game_elements/characters/npcs/talker/components/talker.gd
@@ -4,9 +4,7 @@
 class_name Talker
 extends NPC
 
-const DEFAULT_DIALOGUE: DialogueResource = preload(
-	"res://scenes/game_elements/characters/npcs/talker/components/default.dialogue"
-)
+const DEFAULT_DIALOGUE: DialogueResource = preload("uid://cc3paugq4mma4")
 
 @export var npc_name: String
 @export var dialogue: DialogueResource = DEFAULT_DIALOGUE

--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -13,9 +13,7 @@ enum Mode {
 	FIGHTING,
 }
 
-const DEFAULT_SPRITE_FRAME: SpriteFrames = preload(
-	"res://scenes/game_elements/characters/shared_components/sprite_frames/story_weaver.tres"
-)
+const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("uid://dtoylirwywk0j")
 
 ## The character's name. This is used to highlight when the player's character
 ## is speaking during dialogue.

--- a/scenes/game_elements/props/filling_barrel/components/filling_barrel.gd
+++ b/scenes/game_elements/props/filling_barrel/components/filling_barrel.gd
@@ -7,9 +7,7 @@ extends StaticBody2D
 signal completed
 
 const NEEDED: int = 3
-const DEFAULT_TEXTURE: Texture2D = preload(
-	"res://scenes/game_elements/props/filling_barrel/components/inkwell-fill.png"
-)
+const DEFAULT_TEXTURE: Texture2D = preload("uid://b2nmajpf8dlh")
 
 ## Projectiles with this label fill the barrel.
 @export var label: String = "???"

--- a/scenes/game_elements/props/interact_area/components/interact_area.gd
+++ b/scenes/game_elements/props/interact_area/components/interact_area.gd
@@ -7,7 +7,7 @@ extends Area2D
 signal interaction_started(player: Player, from_right: bool)
 signal interaction_ended
 
-const EXAMPLE_INTERACTION_FONT = preload("res://assets/third_party/fonts/m6x11plus.ttf")
+const EXAMPLE_INTERACTION_FONT = preload("uid://d05uo8wmexkd8")
 const INTERACTABLE_LAYER = 6
 
 ## Vector2 that approximates the position in which the interact label would

--- a/scenes/game_elements/props/projectile/components/projectile.gd
+++ b/scenes/game_elements/props/projectile/components/projectile.gd
@@ -42,14 +42,10 @@ const ENEMY_HITBOX_LAYER: int = 7
 @export_group("FXs")
 
 ## A small visual effect used when the projectile collides with things.
-@export var small_fx_scene: PackedScene = preload(
-	"res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/splash/splash.tscn"
-)
+@export var small_fx_scene: PackedScene = preload("uid://clgisducnnh0a")
 
 ## A big visual effect used when the projectile explodes.
-@export var big_fx_scene: PackedScene = preload(
-	"res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/big_splash/big_splash.tscn"
-)
+@export var big_fx_scene: PackedScene = preload("uid://b4qu6wml5gd7a")
 
 @onready var visible_things: Node2D = %VisibleThings
 @onready var animation_player: AnimationPlayer = %AnimationPlayer

--- a/scenes/globals/game_state/inventory/inventory_item.gd
+++ b/scenes/globals/game_state/inventory/inventory_item.gd
@@ -11,15 +11,15 @@ enum ItemType {
 }
 
 const TEXTURES: Dictionary[ItemType, Texture2D] = {
-	ItemType.MEMORY: preload("res://assets/first_party/collectibles/memory.png"),
-	ItemType.IMAGINATION: preload("res://assets/first_party/collectibles/imagination.png"),
-	ItemType.SPIRIT: preload("res://assets/first_party/collectibles/spirit.png")
+	ItemType.MEMORY: preload("uid://brspc1u02oawt"),
+	ItemType.IMAGINATION: preload("uid://wyiamtqmp4gk"),
+	ItemType.SPIRIT: preload("uid://c4fefrg0tfkpl")
 }
 
 const WORLD_TEXTURES: Dictionary[ItemType, Texture2D] = {
-	ItemType.MEMORY: preload("res://assets/first_party/collectibles/world_memory.png"),
-	ItemType.IMAGINATION: preload("res://assets/first_party/collectibles/world_imagination.png"),
-	ItemType.SPIRIT: preload("res://assets/first_party/collectibles/world_spirit.png")
+	ItemType.MEMORY: preload("uid://5wscjc8yqqts"),
+	ItemType.IMAGINATION: preload("uid://6bf8rum68wq3"),
+	ItemType.SPIRIT: preload("uid://cepg1o3ihp055")
 }
 
 @export var name: String

--- a/scenes/globals/scene_switcher/transitions/transitions.gd
+++ b/scenes/globals/scene_switcher/transitions/transitions.gd
@@ -10,16 +10,10 @@ signal finished
 
 enum Effect { FADE, LEFT_TO_RIGHT_WIPE, RIGHT_TO_LEFT_WIPE, RADIAL }
 
-const FADE_TEXTURE: Texture = preload("res://scenes/globals/scene_switcher/transitions/Fade.png")
-const LEFT_TO_RIGHT_WIPE_TEXTURE: Texture = preload(
-	"res://scenes/globals/scene_switcher/transitions/LeftToRightWipe.png"
-)
-const RADIAL_TEXTURE: Texture = preload(
-	"res://scenes/globals/scene_switcher/transitions/Radial.png"
-)
-const RIGHT_TO_LEFT_WIPE_TEXTURE: Texture = preload(
-	"res://scenes/globals/scene_switcher/transitions/RightToLeftWipe.png"
-)
+const FADE_TEXTURE: Texture = preload("uid://cpvc4xmg7at7r")
+const LEFT_TO_RIGHT_WIPE_TEXTURE: Texture = preload("uid://wxf47acry7qc")
+const RADIAL_TEXTURE: Texture = preload("uid://dcwmaoqgu5t84")
+const RIGHT_TO_LEFT_WIPE_TEXTURE: Texture = preload("uid://b4lvabnu81em4")
 
 var _current_tween: Tween
 

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -7,7 +7,7 @@ extends Control
 signal play(quest: Quest)
 
 ## Template quest, which is expected to be blank and so is treated specially.
-const STORY_QUEST_TEMPLATE := preload("res://scenes/quests/story_quests/template/quest.tres")
+const STORY_QUEST_TEMPLATE := preload("uid://ddxn14xw66ud8")
 
 const QUEST_RESOURCE_NAME := "quest.tres"
 

--- a/scenes/ui_elements/cinematic/cinematic.gd
+++ b/scenes/ui_elements/cinematic/cinematic.gd
@@ -6,9 +6,7 @@ class_name Cinematic
 extends Node2D
 
 ## Dialogue for cinematic scene
-@export var dialogue: DialogueResource = preload(
-	"res://scenes/ui_elements/cinematic/cinematic_placeholder.dialogue"
-)
+@export var dialogue: DialogueResource = preload("uid://b7ad8nar1hmfs")
 
 ## Animation player, to be used from [member dialogue] (if needed)
 @export var animation_player: AnimationPlayer

--- a/scenes/ui_elements/story_quest_progress/components/story_quest_progress.gd
+++ b/scenes/ui_elements/story_quest_progress/components/story_quest_progress.gd
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 extends PanelContainer
 
-const ITEM_SLOT: PackedScene = preload(
-	"res://scenes/ui_elements/story_quest_progress/components/item_slot/item_slot.tscn"
-)
+const ITEM_SLOT: PackedScene = preload("uid://1mjm4atk2j6e")
 
 @export var amount_of_items_to_collect: int = 3
 @onready var items_container: HBoxContainer = %ItemsContainer


### PR DESCRIPTION
This makes the scripts immune to file renames.

It is also less readable, but the Godot editor understands these paths and you can Ctrl-click on them in the script editor to see the resource open in the Inspector. From there you can also use the top bar menu to show the file in the Filesystem dock. Or, if it is a scene, it opens in a new tab directly, then right-clicking in the root node it can be shown in the Filesystem dock.