### PR TITLE
Fix attack animation getting stuck when changing modes

### DIFF
--- a/scenes/game_elements/characters/player/components/animation_player.gd
+++ b/scenes/game_elements/characters/player/components/animation_player.gd
@@ -9,10 +9,11 @@ const BLOW_ANTICIPATION_TIME: float = 0.3
 
 
 func _process(_delta: float) -> void:
-	if not player_fighting.is_fighting and current_animation != &"blow":
-		_process_walk_idle(_delta)
-	else:
-		_process_fighting(_delta)
+	match player.mode:
+		Player.Mode.COZY:
+			_process_walk_idle(_delta)
+		Player.Mode.FIGHTING:
+			_process_fighting(_delta)
 
 
 func _process_walk_idle(_delta: float) -> void:
@@ -22,10 +23,14 @@ func _process_walk_idle(_delta: float) -> void:
 		play(&"walk")
 
 
-func _process_fighting(_delta: float) -> void:
+func _process_fighting(delta: float) -> void:
 	if not player_fighting.is_fighting:
-		if current_animation == &"blow" and current_animation_position <= BLOW_ANTICIPATION_TIME:
-			stop()
+		# If the current animation is blow and it has passed the anticipation
+		# phase, it plays until the end.
+		if not (
+			current_animation == &"blow" and current_animation_position > BLOW_ANTICIPATION_TIME
+		):
+			_process_walk_idle(delta)
 		return
 
 	if current_animation != &"blow":


### PR DESCRIPTION
Previously, if the player's AnimationPlayer was set to the blow animation and it changed mode from FIGHTING to COZY, it would stay looping in the blow animation.

Changed the code so it can never be in a fighting animation if the mode is COZY by matching by the player_mode first.

Then, changed the logic of the fighting mode so it handles the cases in which the player should walk because they are not attacking that frame.

Finally, adding a comment to explain how if the blow animation is played, it's only cut off if it is at the anticipation phase.

Fixes https://github.com/endlessm/threadbare/issues/421