### PR TITLE
Filling Barrel: Fix it was possible to fill it twice

### DIFF
--- a/scenes/game_elements/props/filling_barrel/components/filling_barrel.gd
+++ b/scenes/game_elements/props/filling_barrel/components/filling_barrel.gd
@@ -27,6 +27,8 @@ var _amount: int = 0
 
 @onready var sprite_2d: Sprite2D = %Sprite2D
 @onready var animation_player: AnimationPlayer = %AnimationPlayer
+@onready var collision_shape_2d: CollisionShape2D = %CollisionShape2D
+@onready var hit_box: StaticBody2D = %HitBox
 
 
 func _set_color(new_color: Color) -> void:
@@ -57,12 +59,20 @@ func _ready() -> void:
 ## Increment the amount by one and play the fill animation. If completed, also play the completed
 ## animation and remove this barrel from the current scene.
 func fill() -> void:
+	if _amount >= NEEDED:
+		return
 	animation_player.play(&"fill")
 	_amount += 1
 	sprite_2d.frame += 1
 	if _amount >= NEEDED:
+		_disable_collisions.call_deferred()
 		await animation_player.animation_finished
 		animation_player.play(&"completed")
 		await animation_player.animation_finished
 		queue_free()
 		completed.emit()
+
+
+func _disable_collisions() -> void:
+	hit_box.process_mode = Node.PROCESS_MODE_DISABLED
+	collision_shape_2d.disabled = true

--- a/scenes/game_elements/props/filling_barrel/filling_barrel.tscn
+++ b/scenes/game_elements/props/filling_barrel/filling_barrel.tscn
@@ -167,6 +167,7 @@ texture = ExtResource("2_vr013")
 vframes = 4
 
 [node name="HitBox" type="StaticBody2D" parent="."]
+unique_name_in_owner = true
 position = Vector2(2, -18)
 collision_layer = 16
 collision_mask = 256
@@ -176,6 +177,7 @@ position = Vector2(-2, 5)
 shape = SubResource("RectangleShape2D_8tegq")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+unique_name_in_owner = true
 rotation = -1.5708
 shape = SubResource("CapsuleShape2D_3vyb7")
 


### PR DESCRIPTION
Previously, an already filled barrel would still execute the fill logic if it was hit by a projectile during its completed animation. This allowed clearing an ink combat challenge without actually filling all barrels.

Now, if the filling barrel has been filled and gets hit by a projectile, it doesn't do anything.

The filling barrel collisions are also disabled, but the early return is also there just in case more than one projectile hit the filling barrel in the same frame.

Fixes https://github.com/endlessm/threadbare/issues/442