### PR TITLE
Tree: Randomize animation speed

### DIFF
--- a/scenes/game_elements/props/tree/components/tree.gd
+++ b/scenes/game_elements/props/tree/components/tree.gd
@@ -27,6 +27,7 @@ func _ready() -> void:
 		animated_sprite_2d.animation
 	)
 	animated_sprite_2d.frame = randi_range(0, frames_length)
+	animated_sprite_2d.speed_scale = randf_range(0.5, 1.0)
 
 
 func _notification(what: int) -> void:


### PR DESCRIPTION
Previously, the leaf animations on trees were started from random offsets but otherwise played in sync. This looks unnatural.

Scale the speed of the leaf animation on each tree by a random factor between 0.5× and 1.0×.