### PR TITLE
simplify dialogue for learner stealth template when item is collected

### DIFF
--- a/scenes/quests/story_quests/template/1_stealth/collected.dialogue
+++ b/scenes/quests/story_quests/template/1_stealth/collected.dialogue
@@ -1,8 +1,5 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-You did it! You just collected the Memory item.
-To change which item type to collect, select the Collectible node and change "Item" in the Inspector.
-Selecting the Collectible node, you can also set which scene to go to after the collectible is picked.
-We are going to transition to that scene now...
+Select the CollectibleItem node and set "Next Scene" and "Item > Type" in the Inspector.
 => END

--- a/scenes/quests/story_quests/template/1_stealth/stealth.tscn
+++ b/scenes/quests/story_quests/template/1_stealth/stealth.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=17 format=4 uid="uid://coi4lvxir542y"]
 
-[ext_resource type="Script" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_eujsg"]
+[ext_resource type="Script" uid="uid://dnp0tjloec2d7" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_eujsg"]
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="2_cpt23"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="3_bvm3m"]
 [ext_resource type="SpriteFrames" uid="uid://vwf8e1v8brdp" path="res://scenes/quests/story_quests/template/components/player_template.tres" id="4_t0sci"]


### PR DESCRIPTION
Reduced the text to just give a slightly more simplified hint or breadcrumb for the learner as to where to go next. I also referred to the label is "Next Scene" instead of "Scene to Go To" because we will be adjusting that label going forward.