### PR TITLE
Link Sokoban puzzles to the Eternal Loom

### DIFF
--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
@@ -4,24 +4,51 @@ class_name EternalLoom
 extends Node2D
 
 const ETERNAL_LOOM_INTERACTION: DialogueResource = preload("uid://yafw7bf362gh")
-const ETERNAL_LOOM_SOKOBAN_PATH = "res://scenes/eternal_loom_sokoban/eternal_loom_sokoban.tscn"
+
+## Scenes that are the first of three Sokoban puzzles. A random one will be used
+## each time the player successfully interacts with the Loom.
+const SOKOBANS := [
+	"uid://b8mywvmgsxqb",
+	"uid://11cdlcqge3fu",
+	"uid://b64uft76tbblp",
+]
 
 @onready var interact_area: InteractArea = %InteractArea
 @onready var loom_offering_animation_player: AnimationPlayer = %LoomOfferingAnimationPlayer
 
 
-func _ready():
+func _ready() -> void:
 	interact_area.interaction_started.connect(self._on_interacted)
+
+	if GameState.incorporating_threads:
+		if Transitions.is_running():
+			await Transitions.finished
+
+		DialogueManager.show_dialogue_balloon(
+			ETERNAL_LOOM_INTERACTION, "threads_incorporated", [self]
+		)
+		await DialogueManager.dialogue_ended
+		GameState.incorporating_threads = false
 
 
 func _on_interacted(player: Player, _from_right: bool) -> void:
-	DialogueManager.show_dialogue_balloon(ETERNAL_LOOM_INTERACTION, "", [self, player])
+	var have_threads := is_item_offering_possible()
+
+	var title := "have_threads" if have_threads else "no_threads"
+	DialogueManager.show_dialogue_balloon(ETERNAL_LOOM_INTERACTION, title, [self, player])
 	await DialogueManager.dialogue_ended
 
 	interact_area.end_interaction()
 
+	if have_threads:
+		# Hide interact label during scene transition
+		interact_area.disabled = true
 
-func on_offering_succeeded():
+		GameState.incorporating_threads = true
+		SceneSwitcher.change_to_file_with_transition(SOKOBANS.pick_random())
+
+
+func on_offering_succeeded() -> void:
 	var items_collected: Array[InventoryItem] = GameState.items_collected()
 	loom_offering_animation_player.play(&"loom_offering")
 	await loom_offering_animation_player.animation_finished

--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom_interaction.dialogue
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom_interaction.dialogue
@@ -1,13 +1,21 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
-~ start
+~ welcome
 The Eternal Loom welcomes you, StoryWeaver. Threads you collect help to repair the fabric of our world.
-if is_item_offering_possible():
-	The Memory, Imagination, and Spirit threads are ready to be incorporated into the loom!
-	do on_offering_succeeded()
-	Elders: We thank you, StoryWeaver! The fabric of the world slowly heals!
-	Elders: Go forth: our world still needs your help.
-	=> END
-else:
-	It seems you are lacking the threads of Memory, Imagination, and Spirit... try coming back later.
-	=> END
+=> END
+
+~ no_threads
+=>< welcome
+It seems you are lacking the threads of Memory, Imagination, and Spirit... try coming back later.
+=> END
+
+~ have_threads
+=>< welcome
+The Memory, Imagination, and Spirit threads are ready to be incorporated into the loom!
+do on_offering_succeeded()
+=> END
+
+~ threads_incorporated
+Elders: We thank you, StoryWeaver! The fabric of the world slowly heals!
+Elders: Go forth: our world still needs your help.
+=> END

--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -23,6 +23,10 @@ signal collected_items_changed(updated_items: Array[InventoryItem])
 ## Quest's items. Used to track the progress withing a story quest.
 var story_quest_inventory: Inventory = Inventory.new()
 
+## Set when the loom transports the player to a trio of Sokoban puzzles, so that
+## when the player returns to Fray's End the loom can trigger a brief cutscene.
+var incorporating_threads: bool = false
+
 
 ## Resets the [member story_quest_inventory]. This needs to be called when
 ## a new story quest starts.


### PR DESCRIPTION
When the player interacts with the Eternal Loom while in possession of the threads of Memory, Imagination, and Spirit (after completing a quest) we previously played an animation of the threads entering the loom, and then some dialogue spoken by the Elders.

After the animation plays, switch scenes to a series of three Sokoban puzzles where the player repairs the loom using the threads they have collected. Once they have completed all three puzzles, return to Fray's End and play the Elder dialogue.

Fixes https://github.com/endlessm/threadbare/issues/440