### PR TITLE
Fix mushrooms not hiding

### DIFF
--- a/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd
+++ b/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd
@@ -5,9 +5,11 @@ extends Node2D
 
 @export var is_hidden: bool = false:
 	set(val):
+		var was_hidden: bool = is_hidden
 		is_hidden = val
-		_update_hidden_state()
-		notify_property_list_changed()
+		if is_hidden != was_hidden:
+			_update_hidden_state()
+			notify_property_list_changed()
 
 @export var stay_hidden_or_revealed: bool = false
 
@@ -65,7 +67,7 @@ func _ready() -> void:
 
 
 func _on_player_detector_body_entered(body: Node2D) -> void:
-	if body.is_in_group(&"player") and is_hidden:
+	if body.is_in_group(&"player"):
 		_reveal_or_hide(true)
 
 


### PR DESCRIPTION
Given the different states of the mushrooms, sometimes it's difficult to know whether or not the hide or reveal animations should play.

This commit makes setting the "is_hidden" value idempotent and deletes a validation that caused an issue where the mushrooms wouldn't hide when the player was nearby.