### PR TITLE
Stealth logic: Remove global instant detection

### DIFF
--- a/scenes/game_logic/stealth_game_logic.gd
+++ b/scenes/game_logic/stealth_game_logic.gd
@@ -4,8 +4,6 @@
 class_name StealthGameLogic
 extends Node
 
-@export var player_instantly_loses_on_sight: bool = false:
-	set = _set_player_instantly_loses_on_sight
 @export_range(0.5, 3.0, 0.1, "or_greater", "or_less") var zoom: float = 1.0:
 	set = _set_zoom
 
@@ -13,7 +11,6 @@ extends Node
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
-	_set_player_instantly_loses_on_sight(player_instantly_loses_on_sight)
 	_set_zoom(zoom)
 	for guard: Guard in get_tree().get_nodes_in_group(&"guard_enemy"):
 		guard.player_detected.connect(self._on_player_detected)
@@ -23,14 +20,6 @@ func _on_player_detected(player: Node2D) -> void:
 	player.process_mode = ProcessMode.PROCESS_MODE_DISABLED
 	await get_tree().create_timer(2.0).timeout
 	SceneSwitcher.reload_with_transition(Transition.Effect.FADE, Transition.Effect.FADE)
-
-
-func _set_player_instantly_loses_on_sight(new_value: bool) -> void:
-	player_instantly_loses_on_sight = new_value
-	if not is_node_ready():
-		return
-	for guard: Guard in get_tree().get_nodes_in_group(&"guard_enemy"):
-		guard.player_instantly_detected_on_sight = player_instantly_loses_on_sight
 
 
 func _set_zoom(new_value: float) -> void:

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=71 format=4 uid="uid://db6vhi7s2f37c"]
 
-[ext_resource type="Script" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_f6lvl"]
+[ext_resource type="Script" uid="uid://dnp0tjloec2d7" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_f6lvl"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="1_t8tj0"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="2_1b8xw"]
 [ext_resource type="AudioStream" uid="uid://qnqpd21qyfnc" path="res://assets/first_party/music/Threadbare_Stealth.ogg" id="2_p2u32"]


### PR DESCRIPTION
This was setting every guard to instant player detection to true or false since commit 67c81f46. But that prevents mixing guards with instant detection in the same scene, making the modding inflexible. With this change, the 2 guards next to the bridge in the Lore Stealth game should detect the player instantly. Thus this fixes the regression.

Fix https://github.com/endlessm/threadbare/issues/502