### PR TITLE
Fill game logic: Pass player to dialogue

### DIFF
--- a/scenes/game_logic/fill_game_logic.gd
+++ b/scenes/game_logic/fill_game_logic.gd
@@ -27,7 +27,8 @@ func _ready() -> void:
 	var filling_barrels: Array = get_tree().get_nodes_in_group("filling_barrels")
 	barrels_to_win = clampi(barrels_to_win, 0, filling_barrels.size())
 	if intro_dialogue:
-		DialogueManager.show_dialogue_balloon(intro_dialogue, "", [self])
+		var player: Player = get_tree().get_first_node_in_group("player")
+		DialogueManager.show_dialogue_balloon(intro_dialogue, "", [self, player])
 		await DialogueManager.dialogue_ended
 	start()
 


### PR DESCRIPTION
In case a learner references the player name through the placeholder in the dialogue. Like in other parts of the game, pass the player as namespace to the dialogue.

This was suggested in https://github.com/endlessm/threadbare/pull/456#discussion_r2075014885.