### PR TITLE
Throwing enemy: Make start idempotent

### DIFF
--- a/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
+++ b/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
@@ -78,6 +78,7 @@ var _initial_position: Vector2
 var _target_position: Vector2
 var _is_attacking: bool
 var _is_defeated: bool
+var _has_started: bool = false
 
 @onready var timer: Timer = %Timer
 @onready var projectile_marker: Marker2D = %ProjectileMarker
@@ -222,6 +223,11 @@ func _on_got_hit(body: Node2D) -> void:
 ## Start attacking and/or walking. The enemy will be idle until this is called.
 ## See [member autostart].
 func start() -> void:
+	if _has_started:
+		return
+	_has_started = true
+	if not is_node_ready():
+		await ready
 	timer.wait_time = throwing_period
 	timer.timeout.connect(_on_timeout)
 	hit_box.body_entered.connect(_on_got_hit)

--- a/scenes/game_logic/fill_game_logic.gd
+++ b/scenes/game_logic/fill_game_logic.gd
@@ -15,9 +15,7 @@ func start() -> void:
 	var player: Player = get_tree().get_first_node_in_group("player")
 	if player:
 		player.mode = Player.Mode.FIGHTING
-	for throwing_enemy: ThrowingEnemy in get_tree().get_nodes_in_group("throwing_enemy"):
-		if not throwing_enemy.autostart:
-			throwing_enemy.start()
+	get_tree().call_group("throwing_enemy", "start")
 	for filling_barrel: FillingBarrel in get_tree().get_nodes_in_group("filling_barrels"):
 		filling_barrel.completed.connect(_on_barrel_completed)
 	_update_allowed_colors()


### PR DESCRIPTION
So it can be called multiple times. Then there is no need to check if each enemy is set to autostart from the fill game logic.

This is to address this review comment: https://github.com/endlessm/threadbare/pull/456#discussion_r2075013068