### PR TITLE
Simplify learner templates

### DIFF
--- a/scenes/game_elements/props/checkpoint/components/checkpoint.dialogue
+++ b/scenes/game_elements/props/checkpoint/components/checkpoint.dialogue
@@ -1,6 +1,11 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-KnitWitch: This is a checkpoint that can be used to save player progress.
-{{player_name}}: Thanks!
+KnitWitch: I have knitted your progress so far, {{player_name}}.
+%9
+%
+	{{player_name}}: Wow, you can talk!
+	KnitWitch: Wow, so can you. What a coincidence.
+	{{player_name}}: I didn't think scarecrows could talk.
+	KnitWitch: Maybe they just never had anything to say to you. Ever think of that?
 => END

--- a/scenes/game_elements/props/checkpoint/components/checkpoint.dialogue
+++ b/scenes/game_elements/props/checkpoint/components/checkpoint.dialogue
@@ -1,11 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-KnitWitch: I have knitted your progress so far, {{player_name}}.
-%9
-%
-	{{player_name}}: Wow, you can talk!
-	KnitWitch: Wow, so can you. What a coincidence.
-	{{player_name}}: I didn't think scarecrows could talk.
-	KnitWitch: Maybe they just never had anything to say to you. Ever think of that?
+KnitWitch: This is a checkpoint that can be used to save player progress.
+{{player_name}}: Thanks!
 => END

--- a/scenes/quests/story_quests/template/0_intro/intro.dialogue
+++ b/scenes/quests/story_quests/template/0_intro/intro.dialogue
@@ -4,9 +4,9 @@
 ~ start
 do animation_player.play(&"walk_on")
 do animation_player.animation_finished
-Change this text by selecting the Cinematic node and opening the Dialogue resource in the Inspector. 
-Press Enter to add a new line. Each line becomes a new dialogue box in-game. 
-Text can be placed during and after the walking animations. Try experimenting! 
+Change this text by selecting the Cinematic node and opening the Dialogue resource in the Inspector.
+Press Enter to add a new line. Each line becomes a new dialogue box in-game.
+Text can be placed during and after the walking animations. Try experimenting!
 do animation_player.play(&"walk_off")
 Set the next scene using the “Next Scene” property on the Cinematic node.
 => END

--- a/scenes/quests/story_quests/template/0_intro/intro.dialogue
+++ b/scenes/quests/story_quests/template/0_intro/intro.dialogue
@@ -1,13 +1,12 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
+
 ~ start
 do animation_player.play(&"walk_on")
 do animation_player.animation_finished
-Replace this text with the introduction to your story.
-Press enter in the dialogue editor to add new lines.
-Each new line will appear in a new dialogue box in your scene. 
-Do not remove the animation player lines unless you do not want the player to walk on and off the scene.
+Change this text by selecting the Cinematic node and opening the Dialogue resource in the Inspector. 
+Press Enter to add a new line. Each line becomes a new dialogue box in-game. 
+Text can be placed during and after the walking animations. Try experimenting! 
 do animation_player.play(&"walk_off")
-You can include one line here that shows after the player begins to walk off the screen.
-Finally, set the next scene by selecting the Cinematic node under Scene (left panel) and then setting "Next Scene" in the Inspector (right panel). We are going to transition to the next scene now...
+Set the next scene using the “Next Scene” property on the Cinematic node.
 => END

--- a/scenes/quests/story_quests/template/1_stealth/checkpoint.dialogue
+++ b/scenes/quests/story_quests/template/1_stealth/checkpoint.dialogue
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+~ start
+NPC Name: This is a checkpoint that can be used to save player progress.
+{{player_name}}: Thanks!
+=> END

--- a/scenes/quests/story_quests/template/1_stealth/checkpoint.dialogue.import
+++ b/scenes/quests/story_quests/template/1_stealth/checkpoint.dialogue.import
@@ -1,0 +1,16 @@
+[remap]
+
+importer="dialogue_manager"
+importer_version=15
+type="Resource"
+uid="uid://cppk2qynt485b"
+path="res://.godot/imported/checkpoint.dialogue-42c6909a92737df4038028de55bc5375.tres"
+
+[deps]
+
+source_file="res://scenes/quests/story_quests/template/1_stealth/checkpoint.dialogue"
+dest_files=["res://.godot/imported/checkpoint.dialogue-42c6909a92737df4038028de55bc5375.tres"]
+
+[params]
+
+defaults=true

--- a/scenes/quests/story_quests/template/1_stealth/stealth.dialogue
+++ b/scenes/quests/story_quests/template/1_stealth/stealth.dialogue
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-This simple stealth scene includes guards and a collectible. Use the ingredients in the scene tree to build a stealth level.
+This simple stealth scene includes guards and a collectible. Use the nodes in the scene tree to build a stealth level.
 Click a node, like "Player" or "Enemy Guard" and modify their properties in the inspector, or add new nodes.
 => END

--- a/scenes/quests/story_quests/template/1_stealth/stealth.tscn
+++ b/scenes/quests/story_quests/template/1_stealth/stealth.tscn
@@ -59,6 +59,7 @@ tile_set = ExtResource("2_cpt23")
 
 [node name="Player" parent="." instance=ExtResource("3_bvm3m")]
 position = Vector2(131, 463)
+player_name = "Player Name"
 sprite_frames = ExtResource("4_t0sci")
 
 [node name="Camera2D" type="Camera2D" parent="Player"]

--- a/scenes/quests/story_quests/template/1_stealth/stealth.tscn
+++ b/scenes/quests/story_quests/template/1_stealth/stealth.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=4 uid="uid://coi4lvxir542y"]
+[gd_scene load_steps=18 format=4 uid="uid://coi4lvxir542y"]
 
 [ext_resource type="Script" uid="uid://dnp0tjloec2d7" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_eujsg"]
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="2_cpt23"]
@@ -6,6 +6,7 @@
 [ext_resource type="SpriteFrames" uid="uid://vwf8e1v8brdp" path="res://scenes/quests/story_quests/template/components/player_template.tres" id="4_t0sci"]
 [ext_resource type="PackedScene" uid="uid://d37mebu7atru7" path="res://scenes/game_elements/characters/enemies/guard/guard.tscn" id="6_fg25g"]
 [ext_resource type="PackedScene" uid="uid://dua6mynlw2ptw" path="res://scenes/game_elements/props/checkpoint/checkpoint.tscn" id="7_b3fba"]
+[ext_resource type="Resource" uid="uid://cppk2qynt485b" path="res://scenes/quests/story_quests/template/1_stealth/checkpoint.dialogue" id="7_eujsg"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="8_gxd2f"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="9_v0n5i"]
 [ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="10_tbnoi"]
@@ -100,6 +101,7 @@ y_sort_enabled = true
 
 [node name="Checkpoint" parent="Checkpoints" instance=ExtResource("7_b3fba")]
 position = Vector2(1704, 451)
+dialogue = ExtResource("7_eujsg")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Checkpoints/Checkpoint"]
 position = Vector2(1, -2)

--- a/scenes/quests/story_quests/template/2_combat/combat.dialogue
+++ b/scenes/quests/story_quests/template/2_combat/combat.dialogue
@@ -2,13 +2,12 @@
 # SPDX-License-Identifier: MPL-2.0
 
 ~ start
-Something in this scene will throw projectiles at you. 
-Your goal is to hit them toward the targets. 
-Try this example first, then explore the Scene Tree in the editor. 
-You can add, change, or remove things to explore how that affects the gameplay. 
+Something in this scene will throw projectiles at you.
+Your goal is to hit them toward the targets.
+Try this example first, then explore the Scene Tree in the editor.
+You can add, change, or remove things to explore how that affects the gameplay.
 => END
 
 ~ well_done
 You can add text here after the player takes the collectible.
 => END
-

--- a/scenes/quests/story_quests/template/2_combat/combat.dialogue
+++ b/scenes/quests/story_quests/template/2_combat/combat.dialogue
@@ -1,16 +1,14 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
+
 ~ start
-In this simple combat scene the goal is to fill the barrels with projectiles.
-The enemy will throw projectiles to you, but you can redirect them to the barrels.
-Also the barrels and projectiles may have to match a label and color, but in this case they are all the same.
-OK, ready? Let's try to fill those barrels...
+Something in this scene will throw projectiles at you. 
+Your goal is to hit them toward the targets. 
+Try this example first, then explore the Scene Tree in the editor. 
+You can add, change, or remove things to explore how that affects the gameplay. 
 => END
 
 ~ well_done
-You did it! You just collected the Imagination item.
-If that was too easy, try making the level harder by moving things around or painting the tilemap.
-Also, you can bump the amount of barrels to win by selecting the FillGameLogic node.
-Or you can add barrels of different colors selecting a FillingBarrel node and changing its Label and Color.
-We are going to transition to the next scene now...
+You can add text here after the player takes the collectible.
 => END
+

--- a/scenes/quests/story_quests/template/2_combat/combat.tscn
+++ b/scenes/quests/story_quests/template/2_combat/combat.tscn
@@ -40,37 +40,38 @@ y_sort_enabled = true
 
 [node name="Player" parent="OnTheGround" instance=ExtResource("10_rcv3t")]
 position = Vector2(348, 335)
+player_name = "Player Name"
 sprite_frames = ExtResource("9_a6ony")
 
-[node name="ThrowingEnemy" parent="OnTheGround" instance=ExtResource("11_64btt")]
+[node name="ThrowingNPC" parent="OnTheGround" instance=ExtResource("11_64btt")]
 position = Vector2(857, 300)
 
-[node name="FillingBarrel" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
+[node name="Target" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
 position = Vector2(510, 164)
 label = "Cyan"
 color = Color(0, 1, 1, 1)
 
-[node name="FillingBarrel2" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
+[node name="Target2" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
 position = Vector2(766, 164)
 label = "Cyan"
 color = Color(0, 1, 1, 1)
 
-[node name="FillingBarrel3" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
+[node name="Target3" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
 position = Vector2(769, 497)
 label = "Cyan"
 color = Color(0, 1, 1, 1)
 
-[node name="FillingBarrel4" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
+[node name="Target4" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
 position = Vector2(640, 497)
 label = "Cyan"
 color = Color(0, 1, 1, 1)
 
-[node name="FillingBarrel5" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
+[node name="Target5" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
 position = Vector2(641, 164)
 label = "Cyan"
 color = Color(0, 1, 1, 1)
 
-[node name="FillingBarrel6" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
+[node name="Target6" parent="OnTheGround" instance=ExtResource("12_2eyq6")]
 position = Vector2(509, 497)
 label = "Cyan"
 color = Color(0, 1, 1, 1)
@@ -82,7 +83,7 @@ revealed = false
 next_scene = "uid://x3wm2ce0ax8i"
 item = SubResource("Resource_a51xm")
 collected_dialogue = ExtResource("2_3qn31")
-dialogue_title = &"well_done"
+dialogue_title = &""
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="."]
 

--- a/scenes/quests/story_quests/template/2_combat/combat.tscn
+++ b/scenes/quests/story_quests/template/2_combat/combat.tscn
@@ -83,7 +83,7 @@ revealed = false
 next_scene = "uid://x3wm2ce0ax8i"
 item = SubResource("Resource_a51xm")
 collected_dialogue = ExtResource("2_3qn31")
-dialogue_title = &""
+dialogue_title = &"well_done"
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="."]
 


### PR DESCRIPTION
I reduced the amount of text and simplified the guidance within the dialogue in the intro template, checkpoint, and combat template scenes just to keep the "instruction" there to a bare minimum of bread crumbs or hints. This is to go along with a previous PR where I adjusted the language of the collectible dialogue for the stealth template scene as well.

Within the combat scene and stealth scene I also generalized the player name property to just be **Player Name** instead of Storyweaver and a made a few nodes sound more generic to encourage more open creativity/ideation for learners about the potential these components have for their unique StoryQuests. 

- Barrels are targets
- ThrowingEnemy is a ThrowingNPC
- I left "Guards" alone in stealth but will review with others on this one as well. 