### PR TITLE
Player: Fix storyweaver red color variant

### DIFF
--- a/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_red.tres
+++ b/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_red.tres
@@ -1,149 +1,149 @@
-[gd_resource type="SpriteFrames" load_steps=41 format=3 uid="uid://dtoylirwywk0j"]
+[gd_resource type="SpriteFrames" load_steps=41 format=3 uid="uid://cxjwwgm86d6it"]
 
-[ext_resource type="Texture2D" uid="uid://cktsg0p8rli0k" path="res://scenes/game_elements/characters/player/components/storyweaver_red_attack_01.png" id="1_fmekh"]
-[ext_resource type="Texture2D" uid="uid://b1hipda8467yv" path="res://scenes/game_elements/characters/player/components/storyweaver_red_attack_02.png" id="2_5c6ie"]
-[ext_resource type="Texture2D" uid="uid://c7445jh6xfvge" path="res://scenes/game_elements/characters/player/components/storyweaver_red_defeated.png" id="3_tcdtl"]
-[ext_resource type="Texture2D" uid="uid://dcolxb7p4oyob" path="res://scenes/game_elements/characters/player/components/storyweaver_red_idle.png" id="4_8a2yc"]
-[ext_resource type="Texture2D" uid="uid://b0rbcdewdt5sq" path="res://scenes/game_elements/characters/player/components/storyweaver_red_walk.png" id="5_0k2r4"]
+[ext_resource type="Texture2D" uid="uid://cktsg0p8rli0k" path="res://scenes/game_elements/characters/player/components/storyweaver_red_attack_01.png" id="1_bn0m5"]
+[ext_resource type="Texture2D" uid="uid://b1hipda8467yv" path="res://scenes/game_elements/characters/player/components/storyweaver_red_attack_02.png" id="2_4ljpj"]
+[ext_resource type="Texture2D" uid="uid://c7445jh6xfvge" path="res://scenes/game_elements/characters/player/components/storyweaver_red_defeated.png" id="3_pt1gv"]
+[ext_resource type="Texture2D" uid="uid://dcolxb7p4oyob" path="res://scenes/game_elements/characters/player/components/storyweaver_red_idle.png" id="4_3nggq"]
+[ext_resource type="Texture2D" uid="uid://b0rbcdewdt5sq" path="res://scenes/game_elements/characters/player/components/storyweaver_red_walk.png" id="5_6yxbf"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_8410a"]
-atlas = ExtResource("1_fmekh")
+atlas = ExtResource("1_bn0m5")
 region = Rect2(0, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_xol17"]
-atlas = ExtResource("1_fmekh")
+atlas = ExtResource("1_bn0m5")
 region = Rect2(192, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_iflks"]
-atlas = ExtResource("1_fmekh")
+atlas = ExtResource("1_bn0m5")
 region = Rect2(384, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_71e06"]
-atlas = ExtResource("1_fmekh")
+atlas = ExtResource("1_bn0m5")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_kpp0b"]
-atlas = ExtResource("2_5c6ie")
+atlas = ExtResource("2_4ljpj")
 region = Rect2(0, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_7f782"]
-atlas = ExtResource("2_5c6ie")
+atlas = ExtResource("2_4ljpj")
 region = Rect2(192, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_nemgu"]
-atlas = ExtResource("2_5c6ie")
+atlas = ExtResource("2_4ljpj")
 region = Rect2(384, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_kgewq"]
-atlas = ExtResource("2_5c6ie")
+atlas = ExtResource("2_4ljpj")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_g4r0o"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(0, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_n7yeu"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(192, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_d7n2g"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(384, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_sb01d"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_e8sdo"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(768, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_tbrtj"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(960, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_ctern"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(1152, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_qnq1y"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(1344, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0mu80"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(1536, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_vef0h"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(1728, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_d4gba"]
-atlas = ExtResource("3_tcdtl")
+atlas = ExtResource("3_pt1gv")
 region = Rect2(1920, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_3rycg"]
-atlas = ExtResource("4_8a2yc")
+atlas = ExtResource("4_3nggq")
 region = Rect2(0, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_4px61"]
-atlas = ExtResource("4_8a2yc")
+atlas = ExtResource("4_3nggq")
 region = Rect2(192, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_orb3n"]
-atlas = ExtResource("4_8a2yc")
+atlas = ExtResource("4_3nggq")
 region = Rect2(384, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_3hj6h"]
-atlas = ExtResource("4_8a2yc")
+atlas = ExtResource("4_3nggq")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_b61fw"]
-atlas = ExtResource("4_8a2yc")
+atlas = ExtResource("4_3nggq")
 region = Rect2(768, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_irfo8"]
-atlas = ExtResource("4_8a2yc")
+atlas = ExtResource("4_3nggq")
 region = Rect2(960, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_kb1ks"]
-atlas = ExtResource("4_8a2yc")
+atlas = ExtResource("4_3nggq")
 region = Rect2(1152, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_ptv4t"]
-atlas = ExtResource("4_8a2yc")
+atlas = ExtResource("4_3nggq")
 region = Rect2(1344, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_mwvrp"]
-atlas = ExtResource("4_8a2yc")
+atlas = ExtResource("4_3nggq")
 region = Rect2(1536, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_5mcty"]
-atlas = ExtResource("4_8a2yc")
+atlas = ExtResource("4_3nggq")
 region = Rect2(1728, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_qf2al"]
-atlas = ExtResource("5_0k2r4")
+atlas = ExtResource("5_6yxbf")
 region = Rect2(0, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_cpf2l"]
-atlas = ExtResource("5_0k2r4")
+atlas = ExtResource("5_6yxbf")
 region = Rect2(192, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_eroc3"]
-atlas = ExtResource("5_0k2r4")
+atlas = ExtResource("5_6yxbf")
 region = Rect2(384, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_tl6j7"]
-atlas = ExtResource("5_0k2r4")
+atlas = ExtResource("5_6yxbf")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_tifxf"]
-atlas = ExtResource("5_0k2r4")
+atlas = ExtResource("5_6yxbf")
 region = Rect2(768, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_3r4ur"]
-atlas = ExtResource("5_0k2r4")
+atlas = ExtResource("5_6yxbf")
 region = Rect2(960, 0, 192, 192)
 
 [resource]


### PR DESCRIPTION
The SpriteFrames resource file was copied externally from the blue, so it had the same UID as the blue variant.

Fix it by:
- Duplicating the resource file to a temporary file name in Godot (this changes UID and internal IDs)
- Remove the red file.
- Rename the temporary name to the red file name.

See https://github.com/endlessm/threadbare/pull/508#issuecomment-2863282680