### PR TITLE
MusicalRock: Remove automatic modulation by note

### DIFF
--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd
@@ -8,10 +8,7 @@ signal note_played
 const NOTES: String = "ABCDEFG"
 
 ## Note
-@export_enum("A", "B", "C", "D", "E", "F", "G") var note: String = "C":
-	set(_new_value):
-		note = _new_value
-		_modulate_rock()
+@export_enum("A", "B", "C", "D", "E", "F", "G") var note: String = "C"
 
 @export var audio_stream: AudioStream
 
@@ -21,14 +18,7 @@ const NOTES: String = "ABCDEFG"
 
 
 func _ready() -> void:
-	_modulate_rock()
 	audio_stream_player_2d.stream = audio_stream
-
-
-func _modulate_rock() -> void:
-	if animated_sprite:
-		var i: int = NOTES.find(note)
-		animated_sprite.modulate = Color.from_hsv(i * 100.0 / NOTES.length(), 0.67, 0.89)
 
 
 func _on_interaction_started(_player: Player, _from_right: bool) -> void:

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1404,29 +1404,35 @@ y_sort_enabled = true
 position = Vector2(-1069, -65)
 
 [node name="C" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
+modulate = Color(0.2937, 0.634442, 0.89, 1)
 audio_stream = ExtResource("23_306df")
 
 [node name="D" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
+modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(80, -8)
 note = "D"
 audio_stream = ExtResource("24_l8fgn")
 
 [node name="E" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
+modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(160, -16)
 note = "E"
 audio_stream = ExtResource("25_crvxf")
 
 [node name="F" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
+modulate = Color(0.2937, 0.89, 0.634451, 1)
 position = Vector2(240, -24)
 note = "F"
 audio_stream = ExtResource("26_qswm5")
 
 [node name="G" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
+modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(320, -32)
 note = "G"
 audio_stream = ExtResource("27_pnt3a")
 
 [node name="A" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
+modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(400, -40)
 note = "A"
 audio_stream = ExtResource("28_0wfv2")

--- a/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
@@ -56,29 +56,35 @@ y_sort_enabled = true
 position = Vector2(356, 453)
 
 [node name="C" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
+modulate = Color(0.2937, 0.634442, 0.89, 1)
 audio_stream = ExtResource("6_111wc")
 
 [node name="D" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
+modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(80, -8)
 note = "D"
 audio_stream = ExtResource("7_h3jv3")
 
 [node name="E" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
+modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(160, -16)
 note = "E"
 audio_stream = ExtResource("8_l74h8")
 
 [node name="F" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
+modulate = Color(0.2937, 0.89, 0.634451, 1)
 position = Vector2(240, -24)
 note = "F"
 audio_stream = ExtResource("9_bmpi1")
 
 [node name="G" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
+modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(320, -32)
 note = "G"
 audio_stream = ExtResource("10_wywhp")
 
 [node name="A" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
+modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(400, -40)
 note = "A"
 audio_stream = ExtResource("11_s88gu")


### PR DESCRIPTION
Previously, the colour of each MusicalRock was set in the rock's script, which set the modulate property on the sprite. The colour was chosen by picking 7 evenly-spaced hues for the 7 possible notes, and the same saturation and value for each.

This was convenient, especially since we only have one rock asset. But it makes it harder to have different appearances in different instances of the musical-rock/sequence puzzle. For example, you may want the objects to be four different shapes, not recoloured versions of the same asset.

Remove the logic that recolours the rock based on its note. Instead, modulate each rock in the scene that uses it, using the same colour that was previously generated from the note in code.

This looks a bit weird in the editor because the rock's collision shapes and "kick" interaction label also get modulated. But at runtime the collision shapes are invisible, and the label is not actually used – it just sets the position where the label belonging to the player will be positioned. And I consider modulating the sprite to be a temporary measure; it would be better to recolour the rocks.

(I [tried using PropertyUtils](https://github.com/endlessm/threadbare/pull/537) to export the modulate property of the AnimatedSprite2D. It solved this problem but in my opinion the cure was worse than the disease: it added more complexity to what is otherwise a very simple scene, and the resulting "Sprite Modulate" property in the inspector had no documentation.)

Fixes https://github.com/endlessm/threadbare/issues/520