### PR TITLE
MusicalRock: Remove automatic modulation by note (PropertyUtils version)

### DIFF
--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
+@tool
 class_name MusicalRock
 extends StaticBody2D
 
@@ -8,27 +9,30 @@ signal note_played
 const NOTES: String = "ABCDEFG"
 
 ## Note
-@export_enum("A", "B", "C", "D", "E", "F", "G") var note: String = "C":
-	set(_new_value):
-		note = _new_value
-		_modulate_rock()
+@export_enum("A", "B", "C", "D", "E", "F", "G") var note: String = "C"
 
 @export var audio_stream: AudioStream
 
-@onready var animated_sprite: AnimatedSprite2D = %AnimatedSprite2D
+@onready var animated_sprite: AnimatedSprite2D = %Sprite
 @onready var interact_area: InteractArea = %InteractArea
 @onready var audio_stream_player_2d: AudioStreamPlayer2D = %AudioStreamPlayer2D
 
 
+func _set(property: StringName, value: Variant) -> bool:
+	return PropertyUtils.set_child_property(self, property, value)
+
+
+func _get(property: StringName) -> Variant:
+	return PropertyUtils.get_child_property(self, property)
+
+
+func _get_property_list() -> Array[Dictionary]:
+	return PropertyUtils.expose_children_property(self, "modulate", "AnimatedSprite2D")
+
+
 func _ready() -> void:
-	_modulate_rock()
-	audio_stream_player_2d.stream = audio_stream
-
-
-func _modulate_rock() -> void:
-	if animated_sprite:
-		var i: int = NOTES.find(note)
-		animated_sprite.modulate = Color.from_hsv(i * 100.0 / NOTES.length(), 0.67, 0.89)
+	if not Engine.is_editor_hint():
+		audio_stream_player_2d.stream = audio_stream
 
 
 func _on_interaction_started(_player: Player, _from_right: bool) -> void:

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.tscn
@@ -51,7 +51,7 @@ size = Vector2(45, 45)
 [node name="MusicalRock" type="StaticBody2D" groups=["sequence_object"]]
 script = ExtResource("1_kw7av")
 
-[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+[node name="Sprite" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
 scale = Vector2(0.7, 0.7)
 sprite_frames = SubResource("SpriteFrames_htvu1")

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1405,31 +1405,37 @@ position = Vector2(-1069, -65)
 
 [node name="C" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 audio_stream = ExtResource("23_306df")
+sprite__modulate = Color(0.2937, 0.634442, 0.89, 1)
 
 [node name="D" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 position = Vector2(80, -8)
 note = "D"
 audio_stream = ExtResource("24_l8fgn")
+sprite__modulate = Color(0.89, 0.2937, 0.804817, 1)
 
 [node name="E" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 position = Vector2(160, -16)
 note = "E"
 audio_stream = ExtResource("25_crvxf")
+sprite__modulate = Color(0.89, 0.804817, 0.2937, 1)
 
 [node name="F" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 position = Vector2(240, -24)
 note = "F"
 audio_stream = ExtResource("26_qswm5")
+sprite__modulate = Color(0.2937, 0.89, 0.634451, 1)
 
 [node name="G" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 position = Vector2(320, -32)
 note = "G"
 audio_stream = ExtResource("27_pnt3a")
+sprite__modulate = Color(0.464066, 0.2937, 0.89, 1)
 
 [node name="A" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 position = Vector2(400, -40)
 note = "A"
 audio_stream = ExtResource("28_0wfv2")
+sprite__modulate = Color(0.89, 0.2937, 0.2937, 1)
 
 [node name="BonfireSign" parent="OnTheGround/MusicPuzzle" instance=ExtResource("9_evicy")]
 position = Vector2(-1057, -196)

--- a/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
@@ -57,31 +57,37 @@ position = Vector2(356, 453)
 
 [node name="C" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 audio_stream = ExtResource("6_111wc")
+sprite__modulate = Color(0.2937, 0.634442, 0.89, 1)
 
 [node name="D" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 position = Vector2(80, -8)
 note = "D"
 audio_stream = ExtResource("7_h3jv3")
+sprite__modulate = Color(0.89, 0.2937, 0.804817, 1)
 
 [node name="E" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 position = Vector2(160, -16)
 note = "E"
 audio_stream = ExtResource("8_l74h8")
+sprite__modulate = Color(0.89, 0.804817, 0.2937, 1)
 
 [node name="F" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 position = Vector2(240, -24)
 note = "F"
 audio_stream = ExtResource("9_bmpi1")
+sprite__modulate = Color(0.2937, 0.89, 0.634451, 1)
 
 [node name="G" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 position = Vector2(320, -32)
 note = "G"
 audio_stream = ExtResource("10_wywhp")
+sprite__modulate = Color(0.464066, 0.2937, 0.89, 1)
 
 [node name="A" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 position = Vector2(400, -40)
 note = "A"
 audio_stream = ExtResource("11_s88gu")
+sprite__modulate = Color(0.89, 0.2937, 0.2937, 1)
 
 [node name="BonfireSign" parent="OnTheGround/MusicPuzzle" instance=ExtResource("4_td70e")]
 position = Vector2(506, 210)


### PR DESCRIPTION
Previously, the colour of each MusicalRock was set in the rock's script, which set the modulate property on the sprite. The colour was chosen by picking 7 evenly-spaced hues for the 7 possible notes, and the same saturation and value for each.

This was convenient, especially since we only have one rock asset. But it makes it harder to have different appearances in different instances of the musical-rock/sequence puzzle. For example, you may want the objects to be four different shapes, not recoloured versions of the same asset.

Remove the logic that recolours the rock based on its note. Instead, export a `sprite__modulate` property (proxying the AnimatedSprite2D's modulate property) and, in each scene that uses the rocks, set this property to the value that was previously generated from the note.

musical_rock.gd must be made a `@tool` script in order for PropertyUtils to work; so guard the code in _ready() which modifies the AudioStreamPlayer2D's stream.

I renamed the AnimatedSprite2D to Sprite because otherwise the generated property name is animated_sprite_2d__modulate, rendered as Animated Sprite 2D Modulate in the inspector, which is long and ugly.

Fixes https://github.com/endlessm/threadbare/issues/520