### PR TITLE
Music puzzle: Represent steps as nodes

### DIFF
--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bard.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bard.gd
@@ -10,10 +10,6 @@ extends Talker
 var first_conversation: bool = true
 
 
-func play(note: String) -> void:
-	await puzzle.play_demo_note(note)
-
-
 func advance_hint_level() -> void:
 	var progress := puzzle.get_progress()
 	puzzle.hint_levels[progress] = puzzle.hint_levels.get(progress, 0) + 1

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.gd
@@ -6,8 +6,7 @@ extends StaticBody2D
 
 enum Sign { FORWARD, BACK, BACK_UP, FORWARD_UP }
 
-# This is a NodePath instead of just a node reference to be able to initialize it to ..
-@export_node_path("MusicPuzzle") var puzzle_path: NodePath = ^".."
+@export var puzzle: MusicPuzzle
 
 @export var sign: Sign = Sign.FORWARD:
 	set(new_sign):
@@ -31,18 +30,16 @@ enum Sign { FORWARD, BACK, BACK_UP, FORWARD_UP }
 @onready var interact_area: InteractArea = %InteractArea
 @onready var sign_sprite: AnimatedSprite2D = %SignSprite
 
-@onready var puzzle: MusicPuzzle = get_node(puzzle_path)
-
 
 func _ready() -> void:
 	update_ignited_state()
 
 
-func update_ignited_state():
+func update_ignited_state() -> void:
 	if is_instance_valid(fire):
 		fire.play(&"burning" if is_ignited else &"default")
 	if is_instance_valid(interact_area):
-		interact_area.disabled = not (is_ignited or can_interact_when_unlit)
+		interact_area.disabled = not (puzzle and (is_ignited or can_interact_when_unlit))
 
 	update_sign_sprite()
 

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.tscn
@@ -177,8 +177,6 @@ shape = SubResource("CapsuleShape2D_qkb0b")
 [node name="InteractArea" parent="." instance=ExtResource("5_1po6h")]
 unique_name_in_owner = true
 position = Vector2(-2, 1)
-collision_layer = 0
-disabled = true
 action = "Listen"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
@@ -28,8 +28,6 @@ var _last_hint_rock: MusicalRock = null
 var _current_melody: int = 0
 var _position: int = 0
 
-var _is_demo: bool = false
-
 
 func _ready() -> void:
 	if Engine.is_editor_hint():
@@ -75,7 +73,7 @@ func _debug(fmt: String, args: Array = []) -> void:
 
 
 func _on_note_played(note: String) -> void:
-	if _is_demo or _current_melody >= melodies.size():
+	if _current_melody >= melodies.size():
 		return
 
 	var melody: String = melodies[_current_melody]
@@ -143,11 +141,9 @@ func _get_rock_for_note(note: String) -> MusicalRock:
 
 
 func play_demo_note(note: String) -> void:
-	_is_demo = true
 	var rock := _get_rock_for_note(note)
 	if rock:
 		await rock.play()
-	_is_demo = false
 
 
 func play_demo_melody_of_fire(fire: BonfireSign) -> void:

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
@@ -1,16 +1,12 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
-@tool
 class_name MusicPuzzle
 extends Node2D
 
 signal solved
 
-## Melodies expressed with the letters ABCDEFG.
-@export var melodies: Array[String]
-
-## A fire corresponding to each melody, ignited when the correct melody is played (in order).
-@export var fires: Array[BonfireSign]
+## The order in which the player must interact with rocks to solve each step of the puzzle
+@export var steps: Array[SequencePuzzleStep]
 
 ## If enabled, show messages in the console describing the player's progress (or not) in the puzzle
 @export var debug: bool = false
@@ -25,14 +21,11 @@ var hint_levels: Dictionary = {}
 var _rocks: Array[MusicalRock]
 
 var _last_hint_rock: MusicalRock = null
-var _current_melody: int = 0
+var _current_step: int = 0
 var _position: int = 0
 
 
 func _ready() -> void:
-	if Engine.is_editor_hint():
-		return
-
 	_find_rocks()
 
 	hint_timer.one_shot = true
@@ -40,9 +33,9 @@ func _ready() -> void:
 	hint_timer.timeout.connect(_on_hint_timer_timeout)
 	add_child(hint_timer)
 
-	_update_current_melody()
+	_update_current_step()
 
-	for i in range(melodies.size()):
+	for i in range(steps.size()):
 		if not hint_levels.has(i):
 			hint_levels[i] = 0
 
@@ -54,14 +47,14 @@ func _find_rocks() -> void:
 		if self.is_ancestor_of(object) and object is MusicalRock:
 			var rock := object as MusicalRock
 			_rocks.append(rock)
-			rock.note_played.connect(_on_note_played.bind(rock.note))
+			rock.note_played.connect(_on_note_played.bind(rock))
 
 
-func _update_current_melody():
-	for i in range(_current_melody, fires.size()):
-		# We find the next fire that is not ignited, and that's the _current_melody
-		if fires[i].is_ignited:
-			_current_melody = i + 1
+func _update_current_step() -> void:
+	for i in range(_current_step, steps.size()):
+		# We find the next fire that is not ignited, and that's the _current_step
+		if steps[i].hint_sign.is_ignited:
+			_current_step = i + 1
 			_position = 0
 		else:
 			break
@@ -72,64 +65,54 @@ func _debug(fmt: String, args: Array = []) -> void:
 		print((fmt % args) if args else fmt)
 
 
-func _on_note_played(note: String) -> void:
-	if _current_melody >= melodies.size():
+func _on_note_played(rock: MusicalRock) -> void:
+	if _current_step >= steps.size():
 		return
 
-	var melody: String = melodies[_current_melody]
+	var step := steps[_current_step]
+	var sequence := step.sequence
 	_debug(
-		"Current melody %s position %d expecting %s, received %s",
-		[melody, _position, melody[_position], note],
+		"Current sequence %s position %d expecting %s, received %s",
+		[sequence, _position, sequence[_position], rock],
 	)
-	if _position != 0 and melody[_position] != note:
+	if _position != 0 and sequence[_position] != rock:
 		_debug("Didn't match")
 		_position = 0
-		_debug("Matching again at start of melody...")
+		_debug("Matching again at start of sequence...")
 
-	if melody[_position] != note:
+	if sequence[_position] != rock:
 		_debug("Didn't match")
-		for rock: MusicalRock in _rocks:
-			rock.stop_hint()
+		for r: MusicalRock in _rocks:
+			r.stop_hint()
 		if hint_levels.get(get_progress(), 0) >= wobble_hint_min_level:
 			hint_timer.start()
 		return
 
 	_position += 1
 	hint_timer.start()
-	if _position != melody.length():
-		_debug("Played %s, awaiting %s", [melody.left(_position), melody.right(-_position)])
+	if _position != sequence.size():
+		_debug("Played %s, awaiting %s", [sequence.slice(0, _position), sequence.slice(_position)])
 		return
 
-	_debug("Finished melody")
-	fires[_current_melody].ignite()
-	_update_current_melody()
+	_debug("Finished sequnce")
+	step.hint_sign.ignite()
+	_update_current_step()
 
 	_clear_last_hint_rock()
 
-	if _current_melody == melodies.size():
-		_debug("All melodies played")
+	if _current_step == steps.size():
+		_debug("All sequences played")
 		solved.emit()
 	else:
-		_debug("Next melody: %s", [melodies[_current_melody]])
-
-
-func _get_configuration_warnings() -> PackedStringArray:
-	if melodies.size() != fires.size():
-		var fmt: String = """
-			There should be one fire for each melody, \
-			but currently there are %d melodies and %d fires.
-		"""
-		return [fmt.strip_edges() % [melodies.size(), fires.size()]]
-
-	return []
+		_debug("Next sequence: %s", [steps[_current_step]])
 
 
 func get_progress() -> int:
-	return _current_melody
+	return _current_step
 
 
 func is_solved() -> bool:
-	return _current_melody == melodies.size()
+	return _current_step == steps.size()
 
 
 func _get_rock_for_note(note: String) -> MusicalRock:
@@ -146,23 +129,20 @@ func play_demo_note(note: String) -> void:
 		await rock.play()
 
 
-func play_demo_melody_of_fire(fire: BonfireSign) -> void:
-	await play_demo_melody(fires.find(fire))
-
-
-func play_demo_melody(melody: int) -> void:
-	for note in melodies[melody]:
-		await play_demo_note(note)
+func play_demo_melody_of_fire(hint_sign: BonfireSign) -> void:
+	for step in steps:
+		if step.hint_sign == hint_sign:
+			for rock in step.sequence:
+				await rock.play()
+			return
 
 
 func _on_hint_timer_timeout() -> void:
-	if _current_melody >= melodies.size():
+	if _current_step >= steps.size():
 		return
 
-	var melody: String = melodies[_current_melody]
-	var expected_note := melody[_position]
-
-	var rock := _get_rock_for_note(expected_note)
+	var sequence := steps[_current_step].sequence
+	var rock := sequence[_position]
 	if rock:
 		if rock != _last_hint_rock:
 			_clear_last_hint_rock()
@@ -187,5 +167,5 @@ func stop_hints() -> void:
 
 func reset_hint_timer() -> void:
 	hint_timer.stop()
-	if _current_melody < melodies.size():
+	if _current_step < steps.size():
 		hint_timer.start()

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/sequence_puzzle_step.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/sequence_puzzle_step.gd
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name SequencePuzzleStep
+extends Node2D
+
+## The sequence of objects the player must interact with to solve this step of the puzzle.
+@export var sequence: Array[MusicalRock]:
+	set(new_value):
+		sequence = new_value
+		update_configuration_warnings()
+
+## An optional sign, showing a hint for this step and whether it has been solved.
+@export var hint_sign: BonfireSign:
+	set(new_value):
+		hint_sign = new_value
+		update_configuration_warnings()
+
+
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings: PackedStringArray
+	if sequence.is_empty():
+		warnings.append("Sequence is empty")
+
+	if sequence.find(null) != -1:
+		warnings.append("Sequence contains unset elements")
+
+	if not hint_sign:
+		warnings.append("Hint Sign not set")
+
+	return warnings

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/sequence_puzzle_step.gd.uid
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/sequence_puzzle_step.gd.uid
@@ -1,0 +1,1 @@
+uid://ccc78coj2b1li

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd
@@ -3,6 +3,7 @@
 class_name MusicalRock
 extends StaticBody2D
 
+## Emitted when the rock is struck by the player.
 signal note_played
 
 const NOTES: String = "ABCDEFG"
@@ -22,12 +23,13 @@ func _ready() -> void:
 
 
 func _on_interaction_started(_player: Player, _from_right: bool) -> void:
+	note_played.emit()
 	play()
 	interact_area.interaction_ended.emit()
 
 
+## Act as if the rock was struck by the player. Does not emit [member note_played].
 func play() -> void:
-	note_played.emit()
 	animated_sprite.play(&"struck")
 	audio_stream_player_2d.play()
 	await audio_stream_player_2d.finished

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd
@@ -6,11 +6,6 @@ extends StaticBody2D
 ## Emitted when the rock is struck by the player.
 signal note_played
 
-const NOTES: String = "ABCDEFG"
-
-## Note
-@export_enum("A", "B", "C", "D", "E", "F", "G") var note: String = "C"
-
 @export var audio_stream: AudioStream
 
 @onready var animated_sprite: AnimatedSprite2D = %AnimatedSprite2D

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=4 uid="uid://7hoy2p14t6kc"]
+[gd_scene load_steps=34 format=4 uid="uid://7hoy2p14t6kc"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_evicy"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="2_0ayb4"]
@@ -22,6 +22,7 @@
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="16_ytxvq"]
 [ext_resource type="PackedScene" uid="uid://crqjcicx0vdu" path="res://scenes/game_elements/props/decoration/bush/bush.tscn" id="17_wasqo"]
 [ext_resource type="SpriteFrames" uid="uid://bgckvdkxuxrgh" path="res://scenes/game_elements/props/decoration/bush/components/bush_spriteframes_red_large.tres" id="18_l4i5r"]
+[ext_resource type="Script" uid="uid://ccc78coj2b1li" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/sequence_puzzle_step.gd" id="20_thpfs"]
 [ext_resource type="Texture2D" uid="uid://ol20om7xc1o7" path="res://scenes/game_elements/props/buildings/house/components/House_Wool_Red_Stage1.png" id="20_wasqo"]
 [ext_resource type="PackedScene" uid="uid://b8sok264erfoc" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.tscn" id="22_0awvw"]
 [ext_resource type="AudioStream" uid="uid://cg57q82pb243w" path="res://assets/third_party/xylophone-sampler-pack/xylophone-c3.ogg" id="23_306df"]
@@ -1386,12 +1387,11 @@ dialogue = ExtResource("6_l4i5r")
 look_at_side = 1
 sprite_frames = ExtResource("4_8nm0x")
 
-[node name="MusicPuzzle" type="Node2D" parent="OnTheGround" node_paths=PackedStringArray("fires")]
+[node name="MusicPuzzle" type="Node2D" parent="OnTheGround" node_paths=PackedStringArray("steps")]
 y_sort_enabled = true
 position = Vector2(1410, 950)
 script = ExtResource("7_nonj7")
-melodies = Array[String](["CDEG", "DEFA", "AFED", "GEDC"])
-fires = [NodePath("BonfireSign"), NodePath("BonfireSign2"), NodePath("BonfireSign3"), NodePath("BonfireSign4")]
+steps = [NodePath("Steps/SequencePuzzleStep1"), NodePath("Steps/SequencePuzzleStep2"), NodePath("Steps/SequencePuzzleStep3"), NodePath("Steps/SequencePuzzleStep4")]
 
 [node name="Sign" parent="OnTheGround/MusicPuzzle" instance=ExtResource("8_evicy")]
 position = Vector2(-1211, -44)
@@ -1437,24 +1437,57 @@ position = Vector2(400, -40)
 note = "A"
 audio_stream = ExtResource("28_0wfv2")
 
-[node name="BonfireSign" parent="OnTheGround/MusicPuzzle" instance=ExtResource("9_evicy")]
+[node name="Bonfires" type="Node2D" parent="OnTheGround/MusicPuzzle"]
+y_sort_enabled = true
+
+[node name="BonfireSign1" parent="OnTheGround/MusicPuzzle/Bonfires" node_paths=PackedStringArray("puzzle") instance=ExtResource("9_evicy")]
 position = Vector2(-1057, -196)
 scale = Vector2(1.2, 1.2)
+puzzle = NodePath("../..")
 
-[node name="BonfireSign2" parent="OnTheGround/MusicPuzzle" instance=ExtResource("9_evicy")]
+[node name="BonfireSign2" parent="OnTheGround/MusicPuzzle/Bonfires" node_paths=PackedStringArray("puzzle") instance=ExtResource("9_evicy")]
 position = Vector2(-931, -221)
 scale = Vector2(1.2, 1.2)
+puzzle = NodePath("../..")
 sign = 3
 
-[node name="BonfireSign3" parent="OnTheGround/MusicPuzzle" instance=ExtResource("9_evicy")]
+[node name="BonfireSign3" parent="OnTheGround/MusicPuzzle/Bonfires" node_paths=PackedStringArray("puzzle") instance=ExtResource("9_evicy")]
 position = Vector2(-803, -223)
 scale = Vector2(1.2, 1.2)
+puzzle = NodePath("../..")
 sign = 2
 
-[node name="BonfireSign4" parent="OnTheGround/MusicPuzzle" instance=ExtResource("9_evicy")]
+[node name="BonfireSign4" parent="OnTheGround/MusicPuzzle/Bonfires" node_paths=PackedStringArray("puzzle") instance=ExtResource("9_evicy")]
 position = Vector2(-672, -196)
 scale = Vector2(1.2, 1.2)
+puzzle = NodePath("../..")
 sign = 1
+
+[node name="Steps" type="Node2D" parent="OnTheGround/MusicPuzzle"]
+
+[node name="SequencePuzzleStep1" type="Node2D" parent="OnTheGround/MusicPuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
+script = ExtResource("20_thpfs")
+sequence = [NodePath("../../Rocks/C"), NodePath("../../Rocks/D"), NodePath("../../Rocks/E"), NodePath("../../Rocks/G")]
+hint_sign = NodePath("../../Bonfires/BonfireSign1")
+metadata/_custom_type_script = "uid://ccc78coj2b1li"
+
+[node name="SequencePuzzleStep2" type="Node2D" parent="OnTheGround/MusicPuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
+script = ExtResource("20_thpfs")
+sequence = [NodePath("../../Rocks/D"), NodePath("../../Rocks/E"), NodePath("../../Rocks/F"), NodePath("../../Rocks/A")]
+hint_sign = NodePath("../../Bonfires/BonfireSign2")
+metadata/_custom_type_script = "uid://ccc78coj2b1li"
+
+[node name="SequencePuzzleStep3" type="Node2D" parent="OnTheGround/MusicPuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
+script = ExtResource("20_thpfs")
+sequence = [NodePath("../../Rocks/A"), NodePath("../../Rocks/F"), NodePath("../../Rocks/E"), NodePath("../../Rocks/D")]
+hint_sign = NodePath("../../Bonfires/BonfireSign3")
+metadata/_custom_type_script = "uid://ccc78coj2b1li"
+
+[node name="SequencePuzzleStep4" type="Node2D" parent="OnTheGround/MusicPuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
+script = ExtResource("20_thpfs")
+sequence = [NodePath("../../Rocks/G"), NodePath("../../Rocks/E"), NodePath("../../Rocks/D"), NodePath("../../Rocks/C")]
+hint_sign = NodePath("../../Bonfires/BonfireSign4")
+metadata/_custom_type_script = "uid://ccc78coj2b1li"
 
 [node name="CollectibleItem" parent="OnTheGround/MusicPuzzle" instance=ExtResource("14_src2c")]
 position = Vector2(-525, 40)

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1410,31 +1410,26 @@ audio_stream = ExtResource("23_306df")
 [node name="D" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(80, -8)
-note = "D"
 audio_stream = ExtResource("24_l8fgn")
 
 [node name="E" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(160, -16)
-note = "E"
 audio_stream = ExtResource("25_crvxf")
 
 [node name="F" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.2937, 0.89, 0.634451, 1)
 position = Vector2(240, -24)
-note = "F"
 audio_stream = ExtResource("26_qswm5")
 
 [node name="G" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(320, -32)
-note = "G"
 audio_stream = ExtResource("27_pnt3a")
 
 [node name="A" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(400, -40)
-note = "A"
 audio_stream = ExtResource("28_0wfv2")
 
 [node name="Bonfires" type="Node2D" parent="OnTheGround/MusicPuzzle"]

--- a/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.dialogue
+++ b/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.dialogue
@@ -3,7 +3,7 @@
 ~ start
 This simple puzzle scene includes a xylophone made of musical rocks.
 You will need to play the two melodies that ignite the sign's fire.
-To change the melodies, select the "MuzicPuzzle" and then change the Melodies array in the Inspector.
+To change the melodies, select each of the "SequencePuzzleStep" nodes and then change the "Sequence" array.
 The first melody is set to "CDEFGA". This means that you should play all notes from left to right.
 Can you guess which is the second melody without looking at the Inspector?
 => END

--- a/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
@@ -63,31 +63,26 @@ audio_stream = ExtResource("6_111wc")
 [node name="D" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(80, -8)
-note = "D"
 audio_stream = ExtResource("7_h3jv3")
 
 [node name="E" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(160, -16)
-note = "E"
 audio_stream = ExtResource("8_l74h8")
 
 [node name="F" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0.2937, 0.89, 0.634451, 1)
 position = Vector2(240, -24)
-note = "F"
 audio_stream = ExtResource("9_bmpi1")
 
 [node name="G" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(320, -32)
-note = "G"
 audio_stream = ExtResource("10_wywhp")
 
 [node name="A" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(400, -40)
-note = "A"
 audio_stream = ExtResource("11_s88gu")
 
 [node name="Signs" type="Node2D" parent="OnTheGround/MusicPuzzle"]

--- a/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=4 uid="uid://x3wm2ce0ax8i"]
+[gd_scene load_steps=21 format=4 uid="uid://x3wm2ce0ax8i"]
 
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="1_0gc84"]
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_v7mls"]
@@ -18,6 +18,7 @@
 [ext_resource type="Resource" uid="uid://bb1g8ftnxjhvh" path="res://scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.dialogue" id="9_dj471"]
 [ext_resource type="AudioStream" uid="uid://6oahn2ucxxjv" path="res://assets/third_party/xylophone-sampler-pack/xylophone-g3.ogg" id="10_wywhp"]
 [ext_resource type="AudioStream" uid="uid://bdboi4ndapqec" path="res://assets/third_party/xylophone-sampler-pack/xylophone-a3.ogg" id="11_s88gu"]
+[ext_resource type="Script" uid="uid://ccc78coj2b1li" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/sequence_puzzle_step.gd" id="13_111wc"]
 
 [sub_resource type="Resource" id="Resource_u8qfb"]
 script = ExtResource("6_u8qfb")
@@ -44,11 +45,11 @@ y_sort_enabled = true
 position = Vector2(383, 371)
 sprite_frames = ExtResource("2_eeb0f")
 
-[node name="MusicPuzzle" type="Node2D" parent="OnTheGround" node_paths=PackedStringArray("fires")]
+[node name="MusicPuzzle" type="Node2D" parent="OnTheGround" node_paths=PackedStringArray("steps")]
+y_sort_enabled = true
 position = Vector2(-1, 0)
 script = ExtResource("2_1jr3w")
-melodies = Array[String](["CDEFGA", "AGFEDC"])
-fires = [NodePath("BonfireSign"), NodePath("BonfireSign2")]
+steps = [NodePath("Steps/SequencePuzzleStep1"), NodePath("Steps/SequencePuzzleStep2")]
 metadata/_custom_type_script = "uid://c68oh8dtr21ti"
 
 [node name="Rocks" type="Node2D" parent="OnTheGround/MusicPuzzle"]
@@ -89,12 +90,31 @@ position = Vector2(400, -40)
 note = "A"
 audio_stream = ExtResource("11_s88gu")
 
-[node name="BonfireSign" parent="OnTheGround/MusicPuzzle" instance=ExtResource("4_td70e")]
-position = Vector2(506, 210)
+[node name="Signs" type="Node2D" parent="OnTheGround/MusicPuzzle"]
+y_sort_enabled = true
 
-[node name="BonfireSign2" parent="OnTheGround/MusicPuzzle" instance=ExtResource("4_td70e")]
+[node name="BonfireSign1" parent="OnTheGround/MusicPuzzle/Signs" node_paths=PackedStringArray("puzzle") instance=ExtResource("4_td70e")]
+position = Vector2(506, 210)
+puzzle = NodePath("../..")
+
+[node name="BonfireSign2" parent="OnTheGround/MusicPuzzle/Signs" node_paths=PackedStringArray("puzzle") instance=ExtResource("4_td70e")]
 position = Vector2(593, 200)
+puzzle = NodePath("../..")
 sign = 1
+
+[node name="Steps" type="Node2D" parent="OnTheGround/MusicPuzzle"]
+
+[node name="SequencePuzzleStep1" type="Node2D" parent="OnTheGround/MusicPuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
+script = ExtResource("13_111wc")
+sequence = [NodePath("../../Rocks/C"), NodePath("../../Rocks/D"), NodePath("../../Rocks/E"), NodePath("../../Rocks/F"), NodePath("../../Rocks/G"), NodePath("../../Rocks/A")]
+hint_sign = NodePath("../../Signs/BonfireSign1")
+metadata/_custom_type_script = "uid://ccc78coj2b1li"
+
+[node name="SequencePuzzleStep2" type="Node2D" parent="OnTheGround/MusicPuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
+script = ExtResource("13_111wc")
+sequence = [NodePath("../../Rocks/A"), NodePath("../../Rocks/G"), NodePath("../../Rocks/F"), NodePath("../../Rocks/E"), NodePath("../../Rocks/D"), NodePath("../../Rocks/C")]
+hint_sign = NodePath("../../Signs/BonfireSign2")
+metadata/_custom_type_script = "uid://ccc78coj2b1li"
 
 [node name="CollectibleItem" parent="OnTheGround" instance=ExtResource("6_el8ux")]
 position = Vector2(861, 282)


### PR DESCRIPTION
Conceptually this music/sequence puzzle is a series of steps. Each step
has a sequence of nodes that the player must interact with in that
order, and a sign which provides a hint and lights up when that step is
solved. When all steps have been solved, the puzzle as a whole is
solved.

Previously, the sequences were represented as a string containing the
names of musical notes, which corresponded to a note property on
MusicalRock nodes. This makes the puzzle specific to musical melodies,
and is also error-prone: nothing prevented the level designer entering
the string "Sausages" as a "melody".

There was also a requirement that there be the same number of melodies
as bonfire signs, enforced with a warning in the editor.

Introduce a SequencePuzzleStep node, which contains the sequence for
this step and the corresponding bonfire sign. The sequence is
represented as an array of MusicalRock node references. This makes it
much more difficult to implement an unsolvable puzzle, and provides a
natural way to refer to the objects in the sequence directly. It also
makes it harder to get a mismatched number of signs and sequences. (But
not impossible: you could assign the same sign to multiple sequences.)

BonfireSign previously hardcoded a NodePath to its parent to find the
puzzle, which was convenient but error-prone – instead use a normal
reference, and disable interactivity if it is not provided.

Update both instances of the puzzle for these changes, and tweak the
template dialogue.

Fixes #522