### PR TITLE
Fray's End: Fix invisible interact labels

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -298,7 +298,6 @@ position = Vector2(272, 898)
 sprite_frames = ExtResource("3_rti58")
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="."]
-visible = false
 
 [node name="MovementInputHints" type="Control" parent="ScreenOverlay"]
 layout_mode = 3


### PR DESCRIPTION
Commit b2535026207af1f1785438fd5f2525bb6d9b5c4b set the ScreenOverlay
CanvasLayer to be invisible, breaking interact labels and movement
hints.
