### PR TITLE
Music puzzle: Only allow interacting with the next sign

### DIFF
--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.gd
@@ -18,12 +18,12 @@ enum Sign { FORWARD, BACK, BACK_UP, FORWARD_UP }
 		is_ignited = new_val
 		update_ignited_state()
 
-## If true, the player can interact with the sign to hear its melody, even when the fire is not
-## ignited. If false, the player must play the melody correctly before they are able to interact
-## with the fire to get a reminder of the melody they played.
-@export var can_interact_when_unlit: bool = true:
+## If true, the sign is interactive even when [member is_ignited] is [code]false[/code], allowing
+## the player to see a demo of the corresponding sequence before solving it. Otherwise, the sign is
+## only interactive once ignited.
+var interactive_hint: bool = false:
 	set(new_value):
-		can_interact_when_unlit = new_value
+		interactive_hint = new_value
 		update_ignited_state()
 
 @onready var fire: AnimatedSprite2D = %Fire
@@ -43,7 +43,7 @@ func update_ignited_state() -> void:
 	if not was_node_ready:
 		await ready
 	fire.play(&"burning" if is_ignited else &"default")
-	interact_area.disabled = not (puzzle and (is_ignited or can_interact_when_unlit))
+	interact_area.disabled = not (puzzle and (is_ignited or interactive_hint))
 	## We don't want to play the fire start sound if the bonfire started on.
 	fire_start_sound.playing = is_ignited and was_node_ready
 	fire_continuous_sound.playing = is_ignited

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.tscn
@@ -178,6 +178,7 @@ position = Vector2(0, -2)
 rotation = -1.57079
 scale = Vector2(1.4, 1)
 shape = SubResource("CapsuleShape2D_qkb0b")
+debug_color = Color(0.994024, 0, 0.22864, 0.42)
 
 [node name="InteractArea" parent="." instance=ExtResource("5_1po6h")]
 unique_name_in_owner = true

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.tscn
@@ -183,6 +183,8 @@ debug_color = Color(0.994024, 0, 0.22864, 0.42)
 [node name="InteractArea" parent="." instance=ExtResource("5_1po6h")]
 unique_name_in_owner = true
 position = Vector2(-2, 1)
+collision_layer = 0
+disabled = true
 action = "Listen"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
@@ -8,6 +8,12 @@ signal solved
 ## The order in which the player must interact with rocks to solve each step of the puzzle
 @export var steps: Array[SequencePuzzleStep]
 
+## If enabled, the [BonfireSign] for the current step of the puzzle will be interactive, allowing
+## the player to interact with the sign to see a demo of the corresponding sequence. If false, the
+## signs are only interactive once the player has solved the corresponding step, which makes the
+## puzzle harder!
+@export var interactive_hints: bool = true
+
 ## If enabled, show messages in the console describing the player's progress (or not) in the puzzle
 @export var debug: bool = false
 
@@ -58,6 +64,9 @@ func _update_current_step() -> void:
 			_position = 0
 		else:
 			break
+
+	if interactive_hints and _current_step < steps.size():
+		steps[_current_step].hint_sign.interactive_hint = true
 
 
 func _debug(fmt: String, args: Array = []) -> void:


### PR DESCRIPTION
Commit c4bdddc changed the signs' default behaviour so that each sign can be interacted with before it is lit, allowing the player to see a demo of the corresponding melody. This is a deliberate choice to make the puzzle easier, although it was made configurable in case someone wants a harder puzzle.

However, that change introduced a problem. At the start of the puzzle, only the melody for the first sign is accepted as input, but all four signs were interactive, misleading the player.

Add an interactive_hints property to the MusicPuzzle logic node, controlling whether the sign for the current step of the puzzle should be interactive. Add code to propagate this through to the BonfireSigns. Rename the corresponding property on BonfireSign and stop exporting it – this is now a whole-puzzle setting, not a per-sign setting.

Fixes #523
