### PR TITLE
Template: Use straight double quotes in dialogue

### DIFF
--- a/scenes/quests/story_quests/template/0_intro/intro.dialogue
+++ b/scenes/quests/story_quests/template/0_intro/intro.dialogue
@@ -8,5 +8,5 @@ Change this text by selecting the Cinematic node and opening the Dialogue resour
 Press Enter to add a new line. Each line becomes a new dialogue box in-game.
 Text can be placed during and after the walking animations. Try experimenting!
 do animation_player.play(&"walk_off")
-Set the next scene using the “Next Scene” property on the Cinematic node.
+Set the next scene using the "Next Scene" property on the Cinematic node.
 => END


### PR DESCRIPTION
The font we are currently using does not have glyphs for “curly quotes” and on the web platform Godot does not fall back to system fonts.

Fixes https://github.com/endlessm/threadbare/issues/576