### PR TITLE
Lore on top of template

### DIFF
--- a/scenes/game_elements/characters/enemies/guard/components/guard.gd
+++ b/scenes/game_elements/characters/enemies/guard/components/guard.gd
@@ -20,7 +20,7 @@ enum State {
 	RETURNING,
 }
 
-const DEFAULT_SPRITE_FRAMES = preload("uid://c4kqsgl2pcofo")
+const DEFAULT_SPRITE_FRAMES = preload("uid://ovu5wqo15s5g")
 
 const LOOK_AT_TURN_SPEED: float = 10.0
 

--- a/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
+++ b/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
@@ -13,7 +13,7 @@ const REQUIRED_ANIMATIONS: Array[StringName] = [
 	&"idle", &"walk", &"attack", &"attack anticipation", &"defeated"
 ]
 
-const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("uid://b3r84ksew5djp")
+const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("uid://deosvk5k4su5f")
 
 ## When targetting the next walking position, skip this slice of the circle.
 const WALK_TARGET_SKIP_ANGLE: float = PI / 4.

--- a/scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn
+++ b/scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=14 format=3 uid="uid://b82nsrh332syj"]
 
 [ext_resource type="Script" uid="uid://dfj3625owet5p" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd" id="1_ffq0m"]
-[ext_resource type="SpriteFrames" uid="uid://b3r84ksew5djp" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_purple.tres" id="2_knmau"]
-[ext_resource type="AudioStream" uid="uid://qf2d38rabx8o" path="res://assets/third_party/sounds/enemies/throwing_enemy/Wings.ogg" id="3_s20gv"]
-[ext_resource type="AudioStream" uid="uid://fcmjf1srys7n" path="res://assets/third_party/sounds/enemies/throwing_enemy/Spit.ogg" id="4_uvwc5"]
+[ext_resource type="SpriteFrames" uid="uid://deosvk5k4su5f" path="res://scenes/quests/story_quests/template/components/throwing_enemy_template.tres" id="2_cvpou"]
+[ext_resource type="AudioStream" uid="uid://qf2d38rabx8o" path="res://assets/third_party/sounds/characters/enemies/throwing_enemy/Wings.ogg" id="3_s20gv"]
+[ext_resource type="AudioStream" uid="uid://fcmjf1srys7n" path="res://assets/third_party/sounds/characters/enemies/throwing_enemy/Spit.ogg" id="4_uvwc5"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_3vyb7"]
 height = 42.0
@@ -72,6 +72,89 @@ tracks/4/keys = {
 "transitions": PackedFloat32Array(1),
 "update": 1,
 "values": [false]
+}
+
+[sub_resource type="Animation" id="Animation_u0rnr"]
+resource_name = "attack"
+step = 0.05
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:animation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.7),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [&"attack anticipation", &"attack"]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("AnimatedSprite2D:frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.65, 0.7, 1),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [0, 3, 0, 3]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Sounds/AttackSound:playing")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/3/type = "method"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath(".")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0.7),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"shoot_projectile"
+}]
+}
+
+[sub_resource type="Animation" id="Animation_cvpou"]
+resource_name = "defeated"
+length = 0.7
+step = 0.1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:frame")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.7),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [0, 8]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("AnimatedSprite2D:animation")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [&"defeated"]
 }
 
 [sub_resource type="Animation" id="Animation_ffq0m"]
@@ -147,89 +230,6 @@ tracks/0/keys = {
 "values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
 }
 
-[sub_resource type="Animation" id="Animation_cvpou"]
-resource_name = "defeated"
-length = 0.7
-step = 0.1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("AnimatedSprite2D:frame")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.7),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [0, 8]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("AnimatedSprite2D:animation")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [&"defeated"]
-}
-
-[sub_resource type="Animation" id="Animation_u0rnr"]
-resource_name = "attack"
-step = 0.05
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("AnimatedSprite2D:animation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.7),
-"transitions": PackedFloat32Array(1, 1),
-"update": 1,
-"values": [&"attack anticipation", &"attack"]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("AnimatedSprite2D:frame")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.65, 0.7, 1),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 0,
-"values": [0, 3, 0, 3]
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("Sounds/AttackSound:playing")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [true]
-}
-tracks/3/type = "method"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath(".")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0.7),
-"transitions": PackedFloat32Array(1),
-"values": [{
-"args": [],
-"method": &"shoot_projectile"
-}]
-}
-
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_fbb2g"]
 _data = {
 &"RESET": SubResource("Animation_xcanh"),
@@ -248,7 +248,7 @@ script = ExtResource("1_ffq0m")
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
 position = Vector2(0, -30)
-sprite_frames = ExtResource("2_knmau")
+sprite_frames = ExtResource("2_cvpou")
 animation = &"walk"
 autoplay = "idle"
 flip_h = true

--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -19,11 +19,11 @@ const REQUIRED_ANIMATION_FRAMES: Dictionary[StringName, int] = {
 	&"attack_01": 4,
 	&"attack_02": 4,
 }
-const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("uid://dtoylirwywk0j")
+const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("uid://vwf8e1v8brdp")
 
 ## The character's name. This is used to highlight when the player's character
 ## is speaking during dialogue.
-@export var player_name: String = "StoryWeaver"
+@export var player_name: String = "Player Name"
 
 ## Controls how the player can interact with the world around them.
 @export var mode: Mode = Mode.COZY:

--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=26 format=3 uid="uid://iu2q66clupc6"]
 
 [ext_resource type="Script" uid="uid://bwllxup305eib" path="res://scenes/game_elements/characters/player/components/player.gd" id="1_g2els"]
-[ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_blue.tres" id="2_3in67"]
+[ext_resource type="SpriteFrames" uid="uid://vwf8e1v8brdp" path="res://scenes/quests/story_quests/template/components/player_template.tres" id="2_blfj0"]
 [ext_resource type="Script" uid="uid://bpu6jo4kvehlg" path="res://scenes/game_elements/characters/player/components/player_interaction.gd" id="3_dqkch"]
 [ext_resource type="Script" uid="uid://qro4uo83ba8f" path="res://scenes/game_elements/characters/player/components/player_sprite.gd" id="3_qlg0r"]
 [ext_resource type="Script" uid="uid://necvar42rnih" path="res://scenes/game_elements/characters/player/components/interact_zone.gd" id="6_3in67"]
@@ -10,7 +10,7 @@
 [ext_resource type="Script" uid="uid://kni2yl26matc" path="res://scenes/game_elements/characters/player/components/player_fighting.gd" id="7_5gtgg"]
 [ext_resource type="Texture2D" uid="uid://dda0lxfswrncy" path="res://scenes/game_elements/characters/player/components/blow.png" id="9_je7p5"]
 [ext_resource type="AudioStream" uid="uid://crfylo055wa8e" path="res://scenes/game_elements/characters/player/components/blow.wav" id="10_fm80t"]
-[ext_resource type="AudioStream" uid="uid://cx6jv2cflrmqu" path="res://assets/third_party/sounds/player/Foot.ogg" id="11_blfj0"]
+[ext_resource type="AudioStream" uid="uid://cx6jv2cflrmqu" path="res://assets/third_party/sounds/characters/player/Foot.ogg" id="11_blfj0"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_3vyb7"]
 height = 42.0
@@ -371,7 +371,7 @@ script = ExtResource("1_g2els")
 [node name="PlayerSprite" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
 position = Vector2(0, -17)
-sprite_frames = ExtResource("2_3in67")
+sprite_frames = ExtResource("2_blfj0")
 animation = &"idle"
 autoplay = "idle"
 script = ExtResource("3_qlg0r")

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd
@@ -7,7 +7,7 @@ extends StaticBody2D
 ## Emitted when the rock is struck by the player.
 signal note_played
 
-const DEFAULT_SPRITE_FRAMES: SpriteFrames = preload("uid://7ul4p7v1ve0p")
+const DEFAULT_SPRITE_FRAMES: SpriteFrames = preload("uid://b41l3fs3yj2fc")
 
 ## The animations which must be defined for [member sprite_frames]. The [code]default[/code]
 ## animation is used when the object is idle; [code]struck[/code] is used when the player interacts

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=6 format=3 uid="uid://b8sok264erfoc"]
 
 [ext_resource type="Script" uid="uid://bjl6cydoln71k" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.gd" id="1_kw7av"]
-[ext_resource type="SpriteFrames" uid="uid://7ul4p7v1ve0p" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock_sprite_frames.tres" id="2_cltuv"]
+[ext_resource type="SpriteFrames" uid="uid://b41l3fs3yj2fc" path="res://scenes/quests/story_quests/template/3_music_puzzle/object.tres" id="2_cltuv"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/components/interact_area.gd" id="3_55nmp"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_kw7av"]

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=45 format=4 uid="uid://7hoy2p14t6kc"]
+[gd_scene load_steps=47 format=4 uid="uid://7hoy2p14t6kc"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_evicy"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="2_0ayb4"]
@@ -18,6 +18,7 @@
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="13_inhg4"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="14_src2c"]
 [ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="15_rxyid"]
+[ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_blue.tres" id="15_s3slv"]
 [ext_resource type="SpriteFrames" uid="uid://djwymcffy83" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_red.tres" id="16_8nm0x"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="16_ytxvq"]
 [ext_resource type="PackedScene" uid="uid://crqjcicx0vdu" path="res://scenes/game_elements/props/decoration/bush/bush.tscn" id="17_wasqo"]
@@ -27,6 +28,7 @@
 [ext_resource type="PackedScene" uid="uid://b8sok264erfoc" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.tscn" id="22_0awvw"]
 [ext_resource type="Script" uid="uid://cwib5mjkfc07q" path="res://scenes/game_elements/props/player_follower/player_follower.gd" id="22_nonj7"]
 [ext_resource type="AudioStream" uid="uid://cg57q82pb243w" path="res://assets/third_party/xylophone-sampler-pack/xylophone-c3.ogg" id="23_306df"]
+[ext_resource type="SpriteFrames" uid="uid://7ul4p7v1ve0p" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock_sprite_frames.tres" id="23_fgtmq"]
 [ext_resource type="AudioStream" uid="uid://vgr28w2aalr1" path="res://assets/first_party/sounds/ambient/ForestAmbient.ogg" id="23_mgtd3"]
 [ext_resource type="SpriteFrames" uid="uid://b6doys1c3yelx" path="res://scenes/game_elements/props/decoration/bush/components/bush_spriteframes_red_small.tres" id="23_u8pjn"]
 [ext_resource type="AudioStream" uid="uid://b83x8h0ob5mpq" path="res://assets/third_party/xylophone-sampler-pack/xylophone-d3.ogg" id="24_l8fgn"]
@@ -1389,6 +1391,8 @@ texture = ExtResource("9_nonj7")
 
 [node name="Player" parent="OnTheGround" instance=ExtResource("2_0ayb4")]
 position = Vector2(539, 1972)
+player_name = "StoryWeaver"
+sprite_frames = ExtResource("15_s3slv")
 
 [node name="Camera2D" type="Camera2D" parent="OnTheGround/Player"]
 zoom = Vector2(2, 2)
@@ -1426,31 +1430,37 @@ position = Vector2(-1069, -65)
 
 [node name="C" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.2937, 0.634442, 0.89, 1)
+sprite_frames = ExtResource("23_fgtmq")
 audio_stream = ExtResource("23_306df")
 
 [node name="D" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(80, -8)
+sprite_frames = ExtResource("23_fgtmq")
 audio_stream = ExtResource("24_l8fgn")
 
 [node name="E" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(160, -16)
+sprite_frames = ExtResource("23_fgtmq")
 audio_stream = ExtResource("25_crvxf")
 
 [node name="F" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.2937, 0.89, 0.634451, 1)
 position = Vector2(240, -24)
+sprite_frames = ExtResource("23_fgtmq")
 audio_stream = ExtResource("26_qswm5")
 
 [node name="G" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(320, -32)
+sprite_frames = ExtResource("23_fgtmq")
 audio_stream = ExtResource("27_pnt3a")
 
 [node name="A" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("22_0awvw")]
 modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(400, -40)
+sprite_frames = ExtResource("23_fgtmq")
 audio_stream = ExtResource("28_0wfv2")
 
 [node name="Bonfires" type="Node2D" parent="OnTheGround/MusicPuzzle"]
@@ -1490,25 +1500,21 @@ solved_ambient_sound = ExtResource("31_ink4c")
 script = ExtResource("20_thpfs")
 sequence = [NodePath("../../Rocks/C"), NodePath("../../Rocks/D"), NodePath("../../Rocks/E"), NodePath("../../Rocks/G")]
 hint_sign = NodePath("../../Bonfires/BonfireSign1")
-metadata/_custom_type_script = "uid://ccc78coj2b1li"
 
 [node name="SequencePuzzleStep2" type="Node2D" parent="OnTheGround/MusicPuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
 script = ExtResource("20_thpfs")
 sequence = [NodePath("../../Rocks/D"), NodePath("../../Rocks/E"), NodePath("../../Rocks/F"), NodePath("../../Rocks/A")]
 hint_sign = NodePath("../../Bonfires/BonfireSign2")
-metadata/_custom_type_script = "uid://ccc78coj2b1li"
 
 [node name="SequencePuzzleStep3" type="Node2D" parent="OnTheGround/MusicPuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
 script = ExtResource("20_thpfs")
 sequence = [NodePath("../../Rocks/A"), NodePath("../../Rocks/F"), NodePath("../../Rocks/E"), NodePath("../../Rocks/D")]
 hint_sign = NodePath("../../Bonfires/BonfireSign3")
-metadata/_custom_type_script = "uid://ccc78coj2b1li"
 
 [node name="SequencePuzzleStep4" type="Node2D" parent="OnTheGround/MusicPuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
 script = ExtResource("20_thpfs")
 sequence = [NodePath("../../Rocks/G"), NodePath("../../Rocks/E"), NodePath("../../Rocks/D"), NodePath("../../Rocks/C")]
 hint_sign = NodePath("../../Bonfires/BonfireSign4")
-metadata/_custom_type_script = "uid://ccc78coj2b1li"
 
 [node name="CollectibleItem" parent="OnTheGround/MusicPuzzle" instance=ExtResource("14_src2c")]
 position = Vector2(-525, 40)

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_1.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_1.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=4 uid="uid://c764br4tplkb2"]
+[gd_scene load_steps=20 format=4 uid="uid://c764br4tplkb2"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_wrx86"]
 [ext_resource type="Resource" uid="uid://cmhcuoms2kh1a" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/dialogues/ink_well.dialogue" id="2_o41k0"]
@@ -12,6 +12,9 @@
 [ext_resource type="PackedScene" uid="uid://crqjcicx0vdu" path="res://scenes/game_elements/props/decoration/bush/bush.tscn" id="5_nlryc"]
 [ext_resource type="PackedScene" uid="uid://y8ha8abfyap2" path="res://scenes/game_elements/props/filling_barrel/filling_barrel.tscn" id="6_v7ikp"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="9_na0be"]
+[ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_blue.tres" id="10_hlahk"]
+[ext_resource type="SpriteFrames" uid="uid://b3r84ksew5djp" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_purple.tres" id="12_h7w4n"]
+[ext_resource type="SpriteFrames" uid="uid://bhamin2pby7tq" path="res://scenes/game_elements/props/projectile/components/inkblob_spriteframes.tres" id="13_gn6oy"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="13_hlahk"]
 
 [sub_resource type="Animation" id="Animation_nlryc"]
@@ -127,9 +130,9 @@ position = Vector2(0, -25)
 collision_layer = 4
 script = ExtResource("5_lmnu5")
 next_scene = "uid://cgemeabsewy1f"
-spawn_point_path = NodePath("")
-exit_transition = 3
 enter_transition = 3
+exit_transition = 3
+spawn_point_path = NodePath("")
 metadata/_custom_type_script = "uid://hqdquinbimce"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/LevelExit/Teleporter"]
@@ -138,6 +141,8 @@ shape = SubResource("RectangleShape2D_lmnu5")
 
 [node name="Player" parent="OnTheGround" instance=ExtResource("3_v7ikp")]
 position = Vector2(28, 487)
+player_name = "StoryWeaver"
+sprite_frames = ExtResource("10_hlahk")
 
 [node name="Door Enter" parent="OnTheGround" instance=ExtResource("5_bxnsu")]
 position = Vector2(32, 574)
@@ -145,6 +150,8 @@ scale = Vector2(1.1, 1.1)
 
 [node name="ThrowingEnemy" parent="OnTheGround" instance=ExtResource("5_h0i4r")]
 position = Vector2(857, 300)
+sprite_frames = ExtResource("12_h7w4n")
+projectile_sprite_frames = ExtResource("13_gn6oy")
 
 [node name="FillingBarrel" parent="OnTheGround" instance=ExtResource("6_v7ikp")]
 position = Vector2(528, 164)

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_2.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_2.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=4 uid="uid://cgemeabsewy1f"]
+[gd_scene load_steps=19 format=4 uid="uid://cgemeabsewy1f"]
 
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="2_wqron"]
 [ext_resource type="AudioStream" uid="uid://dgwihwibc8ah6" path="res://assets/first_party/music/Threadbare_Combat.ogg" id="3_0kd4s"]
@@ -8,11 +8,13 @@
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="5_bk6nl"]
 [ext_resource type="PackedScene" uid="uid://b82nsrh332syj" path="res://scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn" id="6_e81yh"]
 [ext_resource type="PackedScene" uid="uid://y8ha8abfyap2" path="res://scenes/game_elements/props/filling_barrel/filling_barrel.tscn" id="7_btlpg"]
+[ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_blue.tres" id="9_bk6nl"]
 [ext_resource type="SpriteFrames" uid="uid://bs0idpewu2plj" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_yellow.tres" id="10_0kd4s"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="10_muw2v"]
 [ext_resource type="PackedScene" uid="uid://lgu7aeqa7o3r" path="res://scenes/game_elements/props/door/door.tscn" id="10_wqron"]
 [ext_resource type="Script" uid="uid://hqdquinbimce" path="res://scenes/game_elements/props/teleporter/teleporter/components/teleporter.gd" id="11_0kd4s"]
 [ext_resource type="SpriteFrames" uid="uid://dnq8cw1cio2we" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_green.tres" id="11_bk6nl"]
+[ext_resource type="SpriteFrames" uid="uid://bhamin2pby7tq" path="res://scenes/game_elements/props/projectile/components/inkblob_spriteframes.tres" id="12_e81yh"]
 
 [sub_resource type="Animation" id="Animation_nlryc"]
 resource_name = "goal_completed"
@@ -110,9 +112,9 @@ position = Vector2(0, -25)
 collision_layer = 4
 script = ExtResource("11_0kd4s")
 next_scene = "uid://bo6qfusag3fae"
-spawn_point_path = NodePath("")
-exit_transition = 3
 enter_transition = 3
+exit_transition = 3
+spawn_point_path = NodePath("")
 metadata/_custom_type_script = "uid://hqdquinbimce"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/LevelExit/Teleporter"]
@@ -121,16 +123,20 @@ shape = SubResource("RectangleShape2D_e81yh")
 
 [node name="Player" parent="OnTheGround" instance=ExtResource("5_bk6nl")]
 position = Vector2(414, 501)
+player_name = "StoryWeaver"
+sprite_frames = ExtResource("9_bk6nl")
 
 [node name="ThrowingEnemy" parent="OnTheGround" instance=ExtResource("6_e81yh")]
 position = Vector2(59, 264)
 autostart = true
 sprite_frames = ExtResource("10_0kd4s")
+projectile_sprite_frames = ExtResource("12_e81yh")
 
 [node name="ThrowingEnemy2" parent="OnTheGround" instance=ExtResource("6_e81yh")]
 position = Vector2(62, 410)
 autostart = true
 sprite_frames = ExtResource("11_bk6nl")
+projectile_sprite_frames = ExtResource("12_e81yh")
 
 [node name="FillingBarrel" parent="OnTheGround" instance=ExtResource("7_btlpg")]
 position = Vector2(839, 248)
@@ -145,7 +151,6 @@ color = Color(1, 0.972549, 0, 1)
 [node name="Door Enter" parent="OnTheGround" instance=ExtResource("10_wqron")]
 position = Vector2(417, 592)
 scale = Vector2(1.1, 1.1)
-play_victory_fanfare_on_open = false
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="."]
 

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=4 uid="uid://bo6qfusag3fae"]
+[gd_scene load_steps=20 format=4 uid="uid://bo6qfusag3fae"]
 
 [ext_resource type="Resource" uid="uid://cmhcuoms2kh1a" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/dialogues/ink_well.dialogue" id="2_fgs83"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="2_je2ou"]
@@ -9,10 +9,12 @@
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="5_k5uk8"]
 [ext_resource type="PackedScene" uid="uid://b82nsrh332syj" path="res://scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn" id="6_te0v3"]
 [ext_resource type="PackedScene" uid="uid://y8ha8abfyap2" path="res://scenes/game_elements/props/filling_barrel/filling_barrel.tscn" id="7_1srav"]
+[ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_blue.tres" id="7_te0v3"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="8_hyj3v"]
 [ext_resource type="SpriteFrames" uid="uid://3ujiuhj7wpm2" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_red.tres" id="8_k5uk8"]
 [ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="9_rww0x"]
 [ext_resource type="SpriteFrames" uid="uid://dxbt7cgoq3dg5" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_blue.tres" id="9_te0v3"]
+[ext_resource type="SpriteFrames" uid="uid://bhamin2pby7tq" path="res://scenes/game_elements/props/projectile/components/inkblob_spriteframes.tres" id="10_1srav"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="10_i5hhc"]
 
 [sub_resource type="Animation" id="Animation_k5uk8"]
@@ -108,6 +110,8 @@ scale = Vector2(1.1, 1.1)
 
 [node name="Player" parent="OnTheGround" instance=ExtResource("5_k5uk8")]
 position = Vector2(542, 591)
+player_name = "StoryWeaver"
+sprite_frames = ExtResource("7_te0v3")
 
 [node name="ThrowingEnemy" parent="OnTheGround" instance=ExtResource("6_te0v3")]
 position = Vector2(110, 477)
@@ -118,6 +122,7 @@ sprite_frames = ExtResource("8_k5uk8")
 projectile_speed = 20.0
 projectile_duration = 10.0
 projectile_follows_player = true
+projectile_sprite_frames = ExtResource("10_1srav")
 walking_range = 0.0
 walking_speed = 20.0
 
@@ -129,6 +134,7 @@ autostart = true
 sprite_frames = ExtResource("9_te0v3")
 projectile_duration = 10.0
 projectile_follows_player = true
+projectile_sprite_frames = ExtResource("10_1srav")
 walking_range = 0.0
 walking_speed = 20.0
 

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=71 format=4 uid="uid://db6vhi7s2f37c"]
+[gd_scene load_steps=73 format=4 uid="uid://db6vhi7s2f37c"]
 
 [ext_resource type="Script" uid="uid://dnp0tjloec2d7" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_f6lvl"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="1_t8tj0"]
@@ -27,8 +27,10 @@
 [ext_resource type="Texture2D" uid="uid://bmhrkna5uimd4" path="res://assets/third_party/tiny-swords/Deco/08.png" id="20_djpoe"]
 [ext_resource type="Texture2D" uid="uid://ddxakjtgamrjj" path="res://assets/third_party/tiny-swords/Resources/Resources/W_Idle.png" id="21_7kcq2"]
 [ext_resource type="Texture2D" uid="uid://fas6gxj6up3p" path="res://assets/first_party/towers/Tower_Patchwork_Ruined2.png" id="21_foy1n"]
+[ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_blue.tres" id="21_p2u32"]
 [ext_resource type="Texture2D" uid="uid://dl6o7vcf2fyc" path="res://assets/first_party/towers/Tower_Patchwork_Ruined1.png" id="22_djpoe"]
 [ext_resource type="Texture2D" uid="uid://bh2iffvp0g1yv" path="res://assets/third_party/tiny-swords/Terrain/Water/Rocks/Rocks_01.png" id="22_wtfsj"]
+[ext_resource type="SpriteFrames" uid="uid://c4kqsgl2pcofo" path="res://scenes/game_elements/characters/enemies/guard/components/guard_sprite_frames.tres" id="23_5q0mi"]
 [ext_resource type="Texture2D" uid="uid://c6sxykigjd1ls" path="res://assets/third_party/tiny-swords/Terrain/Water/Rocks/Rocks_02.png" id="23_ulxtw"]
 [ext_resource type="Texture2D" uid="uid://drfnq08l2wbgy" path="res://assets/third_party/tiny-swords/Deco/03.png" id="24_wtfsj"]
 [ext_resource type="PackedScene" uid="uid://lgu7aeqa7o3r" path="res://scenes/game_elements/props/door/door.tscn" id="25_ulxtw"]
@@ -824,6 +826,8 @@ texture = ExtResource("18_u5bfq")
 
 [node name="Player" parent="." instance=ExtResource("3_1b8xw")]
 position = Vector2(159, 105)
+player_name = "StoryWeaver"
+sprite_frames = ExtResource("21_p2u32")
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 unique_name_in_owner = true
@@ -839,6 +843,7 @@ y_sort_enabled = true
 
 [node name="Guard-GoingBackAndForth" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(928, 95)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard-PatrolPath")
 move_speed = 200.0
 
@@ -849,6 +854,7 @@ curve = SubResource("Curve2D_vnsq3")
 
 [node name="Guard2-GoingInCircles" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(1567, 101.949)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard2-PatrolPath")
 wait_time = 0.8
 move_speed = 250.0
@@ -860,6 +866,7 @@ curve = SubResource("Curve2D_m6h06")
 
 [node name="Guard3-GoingBackAndForth" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(3165, 611)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard3-PatrolPath")
 wait_time = 0.3
 move_speed = 200.0
@@ -870,6 +877,7 @@ curve = SubResource("Curve2D_x2hsm")
 
 [node name="Guard4-GoingBackAndForth" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(2338, 792)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard4-PatrolPath")
 wait_time = 0.3
 move_speed = 200.0
@@ -880,6 +888,7 @@ curve = SubResource("Curve2D_frfu0")
 
 [node name="Guard5-AlternatingDirection" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(2875, 1203)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard5-PatrolPath")
 wait_time = 5.0
 move_speed = 300.0
@@ -891,6 +900,7 @@ curve = SubResource("Curve2D_d2jm8")
 
 [node name="Guard6-RunningInCircles" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(3550, 1307)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard6-PatrolPath")
 wait_time = 0.3
 move_speed = 1000.0
@@ -902,6 +912,7 @@ curve = SubResource("Curve2D_46hcm")
 
 [node name="Guard7-GoingBackAndForth" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(4607, 990)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard7-PatrolPath")
 player_instantly_detected_on_sight = true
 time_to_detect_player = 0.5
@@ -913,6 +924,7 @@ curve = SubResource("Curve2D_jgsr2")
 
 [node name="Guard8-GoingBackAndForth" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(4703, 1348)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard8-PatrolPath")
 wait_time = 1.5
 player_instantly_detected_on_sight = true
@@ -925,6 +937,7 @@ curve = SubResource("Curve2D_f6lvl")
 
 [node name="Guard9-GoingBackAndForth" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(6353, 1189)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard9-PatrolPath")
 wait_time = 1.5
 move_speed = 400.0
@@ -937,6 +950,7 @@ curve = SubResource("Curve2D_ww60d")
 
 [node name="Guard10-RunningInCircles" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(5728.01, 670)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard10-PatrolPath")
 wait_time = 0.0
 move_speed = 600.0
@@ -949,6 +963,7 @@ curve = SubResource("Curve2D_1b8xw")
 
 [node name="Guard11-RunningBackAndForth" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(6053.16, 1244.44)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard11-PatrolPath")
 wait_time = 0.5
 move_speed = 500.0
@@ -960,6 +975,7 @@ curve = SubResource("Curve2D_idy4y")
 
 [node name="Guard12-RunningBackAndForth" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("8_lbv6i")]
 position = Vector2(6179.21, 670.264)
+sprite_frames = ExtResource("23_5q0mi")
 patrol_path = NodePath("../Guard12-PatrolPath")
 wait_time = 0.5
 move_speed = 450.0

--- a/scenes/quests/story_quests/template/1_stealth/stealth.tscn
+++ b/scenes/quests/story_quests/template/1_stealth/stealth.tscn
@@ -1,10 +1,8 @@
-[gd_scene load_steps=19 format=4 uid="uid://coi4lvxir542y"]
+[gd_scene load_steps=17 format=4 uid="uid://coi4lvxir542y"]
 
 [ext_resource type="Script" uid="uid://dnp0tjloec2d7" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_eujsg"]
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="2_cpt23"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="3_bvm3m"]
-[ext_resource type="SpriteFrames" uid="uid://vwf8e1v8brdp" path="res://scenes/quests/story_quests/template/components/player_template.tres" id="4_t0sci"]
-[ext_resource type="SpriteFrames" uid="uid://ovu5wqo15s5g" path="res://scenes/quests/story_quests/template/components/guard_enemy_template.tres" id="6_cpt23"]
 [ext_resource type="PackedScene" uid="uid://d37mebu7atru7" path="res://scenes/game_elements/characters/enemies/guard/guard.tscn" id="6_fg25g"]
 [ext_resource type="PackedScene" uid="uid://dua6mynlw2ptw" path="res://scenes/game_elements/props/checkpoint/checkpoint.tscn" id="7_b3fba"]
 [ext_resource type="Resource" uid="uid://cppk2qynt485b" path="res://scenes/quests/story_quests/template/1_stealth/checkpoint.dialogue" id="7_eujsg"]
@@ -61,8 +59,6 @@ tile_set = ExtResource("2_cpt23")
 
 [node name="Player" parent="." instance=ExtResource("3_bvm3m")]
 position = Vector2(131, 463)
-player_name = "Player Name"
-sprite_frames = ExtResource("4_t0sci")
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 process_mode = 3
@@ -77,7 +73,6 @@ y_sort_enabled = true
 
 [node name="Guard1-GoingBackAndForth" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("6_fg25g")]
 position = Vector2(526, 470)
-sprite_frames = ExtResource("6_cpt23")
 patrol_path = NodePath("../Guard1-PatrolPath")
 move_speed = 200.0
 
@@ -89,7 +84,6 @@ curve = SubResource("Curve2D_vnsq3")
 
 [node name="Guard2-RunningInCircles" parent="EnemyGuards" node_paths=PackedStringArray("patrol_path") instance=ExtResource("6_fg25g")]
 position = Vector2(2435, 382)
-sprite_frames = ExtResource("6_cpt23")
 patrol_path = NodePath("../Guard2-RunningPath")
 wait_time = 0.3
 move_speed = 1000.0

--- a/scenes/quests/story_quests/template/2_combat/combat.tscn
+++ b/scenes/quests/story_quests/template/2_combat/combat.tscn
@@ -1,11 +1,8 @@
-[gd_scene load_steps=14 format=4 uid="uid://thwcu5akkqp5"]
+[gd_scene load_steps=11 format=4 uid="uid://thwcu5akkqp5"]
 
 [ext_resource type="Resource" uid="uid://3vrn5jdxov37" path="res://scenes/quests/story_quests/template/2_combat/combat.dialogue" id="2_3qn31"]
 [ext_resource type="Script" uid="uid://cp54mgi54nywo" path="res://scenes/game_logic/fill_game_logic.gd" id="5_4win1"]
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="6_34ay3"]
-[ext_resource type="SpriteFrames" uid="uid://deosvk5k4su5f" path="res://scenes/quests/story_quests/template/components/throwing_enemy_template.tres" id="7_3qn31"]
-[ext_resource type="SpriteFrames" uid="uid://b00dcfe4dtvkh" path="res://scenes/quests/story_quests/template/components/projectile_template_spriteframes.tres" id="8_54rnm"]
-[ext_resource type="SpriteFrames" uid="uid://vwf8e1v8brdp" path="res://scenes/quests/story_quests/template/components/player_template.tres" id="9_a6ony"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="10_a6ony"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="10_rcv3t"]
 [ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="11_4lmqk"]
@@ -42,13 +39,9 @@ y_sort_enabled = true
 
 [node name="Player" parent="OnTheGround" instance=ExtResource("10_rcv3t")]
 position = Vector2(348, 335)
-player_name = "Player Name"
-sprite_frames = ExtResource("9_a6ony")
 
 [node name="ThrowingNPC" parent="OnTheGround" instance=ExtResource("11_64btt")]
 position = Vector2(857, 300)
-sprite_frames = ExtResource("7_3qn31")
-projectile_sprite_frames = ExtResource("8_54rnm")
 projectile_small_fx_scene = null
 projectile_big_fx_scene = null
 projectile_trail_fx_scene = null

--- a/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
@@ -1,15 +1,13 @@
-[gd_scene load_steps=23 format=4 uid="uid://x3wm2ce0ax8i"]
+[gd_scene load_steps=21 format=4 uid="uid://x3wm2ce0ax8i"]
 
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="1_0gc84"]
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_v7mls"]
 [ext_resource type="Script" uid="uid://c68oh8dtr21ti" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd" id="2_1jr3w"]
-[ext_resource type="SpriteFrames" uid="uid://vwf8e1v8brdp" path="res://scenes/quests/story_quests/template/components/player_template.tres" id="2_eeb0f"]
 [ext_resource type="PackedScene" uid="uid://be4o3ythda4cu" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign.tscn" id="4_td70e"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="4_w5wgh"]
 [ext_resource type="PackedScene" uid="uid://b8sok264erfoc" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/xylophone/musical_rock.tscn" id="5_udrph"]
 [ext_resource type="AudioStream" uid="uid://cg57q82pb243w" path="res://assets/third_party/xylophone-sampler-pack/xylophone-c3.ogg" id="6_111wc"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="6_el8ux"]
-[ext_resource type="SpriteFrames" uid="uid://b41l3fs3yj2fc" path="res://scenes/quests/story_quests/template/3_music_puzzle/object.tres" id="6_h3jv3"]
 [ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="6_u8qfb"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="7_dj471"]
 [ext_resource type="AudioStream" uid="uid://b83x8h0ob5mpq" path="res://assets/third_party/xylophone-sampler-pack/xylophone-d3.ogg" id="7_h3jv3"]
@@ -45,7 +43,6 @@ y_sort_enabled = true
 
 [node name="Player" parent="OnTheGround" instance=ExtResource("1_0gc84")]
 position = Vector2(383, 371)
-sprite_frames = ExtResource("2_eeb0f")
 
 [node name="MusicPuzzle" type="Node2D" parent="OnTheGround" node_paths=PackedStringArray("steps")]
 y_sort_enabled = true
@@ -60,37 +57,31 @@ position = Vector2(356, 453)
 
 [node name="Blue" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0, 0.4, 0.6, 1)
-sprite_frames = ExtResource("6_h3jv3")
 audio_stream = ExtResource("6_111wc")
 
 [node name="Pink" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(80, -8)
-sprite_frames = ExtResource("6_h3jv3")
 audio_stream = ExtResource("7_h3jv3")
 
 [node name="Yellow" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(160, -16)
-sprite_frames = ExtResource("6_h3jv3")
 audio_stream = ExtResource("8_l74h8")
 
 [node name="Green" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0.188235, 0.717647, 0, 1)
 position = Vector2(240, -24)
-sprite_frames = ExtResource("6_h3jv3")
 audio_stream = ExtResource("9_bmpi1")
 
 [node name="Purple" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(320, -32)
-sprite_frames = ExtResource("6_h3jv3")
 audio_stream = ExtResource("10_wywhp")
 
 [node name="Red" parent="OnTheGround/MusicPuzzle/Rocks" instance=ExtResource("5_udrph")]
 modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(400, -40)
-sprite_frames = ExtResource("6_h3jv3")
 audio_stream = ExtResource("11_s88gu")
 
 [node name="Signs" type="Node2D" parent="OnTheGround/MusicPuzzle"]
@@ -109,13 +100,11 @@ sprite_frames = ExtResource("13_h3jv3")
 script = ExtResource("13_111wc")
 sequence = [NodePath("../../Rocks/Yellow"), NodePath("../../Rocks/Green"), NodePath("../../Rocks/Blue")]
 hint_sign = NodePath("../../Signs/BonfireSign1")
-metadata/_custom_type_script = "uid://ccc78coj2b1li"
 
 [node name="SequencePuzzleStep2" type="Node2D" parent="OnTheGround/MusicPuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
 script = ExtResource("13_111wc")
 sequence = [NodePath("../../Rocks/Blue"), NodePath("../../Rocks/Green"), NodePath("../../Rocks/Yellow"), NodePath("../../Rocks/Green")]
 hint_sign = NodePath("../../Signs/BonfireSign2")
-metadata/_custom_type_script = "uid://ccc78coj2b1li"
 
 [node name="CollectibleItem" parent="OnTheGround" instance=ExtResource("6_el8ux")]
 position = Vector2(861, 282)

--- a/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/story_quests/template/3_music_puzzle/music_puzzle.tscn
@@ -117,7 +117,7 @@ dialogue_title = &"well_done"
 [node name="Sign" parent="OnTheGround" instance=ExtResource("7_dj471")]
 position = Vector2(184, 434)
 direction = 1
-text = "First melody: play all notes from left to right."
+text = "First melody: yellow, green, blue."
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="."]
 

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=46 format=4 uid="uid://cufkthb25mpxy"]
+[gd_scene load_steps=47 format=4 uid="uid://cufkthb25mpxy"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_4evgk"]
 [ext_resource type="Script" uid="uid://8div00rgvsds" path="res://scenes/world_map/components/frays_end.gd" id="1_4gse6"]
@@ -9,6 +9,7 @@
 [ext_resource type="PackedScene" uid="uid://lfvn4u30s4yf" path="res://scenes/game_elements/props/buildings/house/house_1.tscn" id="5_5jg1p"]
 [ext_resource type="Texture2D" uid="uid://dsh7g1nlaitvv" path="res://scenes/game_elements/props/buildings/house/components/House_Patch_Blue_02.png" id="5_uhynt"]
 [ext_resource type="Texture2D" uid="uid://d2kjk3oiu5o6o" path="res://scenes/game_elements/props/buildings/house/components/House_Wool_Blue_02.png" id="5_uojly"]
+[ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_blue.tres" id="6_06x6x"]
 [ext_resource type="Texture2D" uid="uid://c8xgl7dcju5h7" path="res://scenes/game_elements/props/buildings/house/components/House_Patch_Blue_03.png" id="6_ojp30"]
 [ext_resource type="Texture2D" uid="uid://cvm2x4fhekowd" path="res://scenes/game_elements/props/buildings/house/components/House_Wool_Blue_03.png" id="6_uhynt"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="7_7v00g"]
@@ -120,6 +121,8 @@ tile_set = ExtResource("1_4evgk")
 
 [node name="Player" parent="." instance=ExtResource("3_tp7qs")]
 position = Vector2(985, 871)
+player_name = "StoryWeaver"
+sprite_frames = ExtResource("6_06x6x")
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 zoom = Vector2(2, 2)


### PR DESCRIPTION
Fix https://github.com/endlessm/threadbare/issues/585

@wjt @jbourqueendless I wonder if we want this. The template settings (assets, etc) are the default even for Lore. And Lore "dresses" eg. the player to be the StoryWeaver.

[Grabación de pantalla desde 2025-05-14 11-25-13.webm](https://github.com/user-attachments/assets/21ded949-ddef-4bdc-a6f5-e02d69eb9f72)

I have only changed a few things to demo the concept (player name, player SpriteFrames, throwing enemy SpriteFrames). And applied them to only one Lore scene, while clearing one template scene. If we decide to do this, we better do it soon as it is a change that will affect all the project!