### PR TITLE
Eternal Loom: Use world sprites for collectibles

### DIFF
--- a/scenes/game_elements/props/eternal_loom/eternal_loom.tscn
+++ b/scenes/game_elements/props/eternal_loom/eternal_loom.tscn
@@ -3,9 +3,9 @@
 [ext_resource type="Script" uid="uid://dj5shb75ckk2a" path="res://scenes/game_elements/props/eternal_loom/components/eternal_loom.gd" id="1_0f752"]
 [ext_resource type="Texture2D" uid="uid://cj62bpasgf643" path="res://scenes/game_elements/props/eternal_loom/components/eternal_loom_blue.png" id="2_dj2yp"]
 [ext_resource type="PackedScene" uid="uid://dutgnbiy7xalb" path="res://scenes/game_elements/props/interact_area/interact_area.tscn" id="3_kyhkd"]
-[ext_resource type="Texture2D" uid="uid://brspc1u02oawt" path="res://assets/first_party/collectibles/memory.png" id="4_ytadt"]
-[ext_resource type="Texture2D" uid="uid://wyiamtqmp4gk" path="res://assets/first_party/collectibles/imagination.png" id="5_x4prg"]
-[ext_resource type="Texture2D" uid="uid://c4fefrg0tfkpl" path="res://assets/first_party/collectibles/spirit.png" id="6_j8bpo"]
+[ext_resource type="Texture2D" uid="uid://5wscjc8yqqts" path="res://assets/first_party/collectibles/world_memory.png" id="4_12bvc"]
+[ext_resource type="Texture2D" uid="uid://6bf8rum68wq3" path="res://assets/first_party/collectibles/world_imagination.png" id="5_eq7jh"]
+[ext_resource type="Texture2D" uid="uid://cepg1o3ihp055" path="res://assets/first_party/collectibles/world_spirit.png" id="6_hfqem"]
 [ext_resource type="AudioStream" uid="uid://bg8u4en3hlo6w" path="res://assets/third_party/sounds/eternal_loom/EternalLoomShort.ogg" id="7_12bvc"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_dj2yp"]
@@ -568,19 +568,19 @@ libraries = {
 visible = false
 texture_filter = 1
 position = Vector2(1, -34)
-texture = ExtResource("4_ytadt")
+texture = ExtResource("4_12bvc")
 
 [node name="Imagination" type="Sprite2D" parent="LoomOfferingAnimation"]
 visible = false
 texture_filter = 1
 position = Vector2(50, 33)
-texture = ExtResource("5_x4prg")
+texture = ExtResource("5_eq7jh")
 
 [node name="Spirit" type="Sprite2D" parent="LoomOfferingAnimation"]
 visible = false
 texture_filter = 1
 position = Vector2(-48, 33)
-texture = ExtResource("6_j8bpo")
+texture = ExtResource("6_hfqem")
 
 [node name="LoomOfferingSound" type="AudioStreamPlayer2D" parent="LoomOfferingAnimation"]
 stream = ExtResource("7_12bvc")


### PR DESCRIPTION
The animation for returning the collected Memory, Imagination and Spirit to the Eternal Loom was using the sprites for the HUD. Use the sprites for the world instead.

Fix https://github.com/endlessm/threadbare/issues/586