### PR TITLE
HintSign: Make demonstrating sequence optional

### DIFF
--- a/scenes/game_elements/props/sequence_puzzle_hint_sign/sequence_puzzle_hint_sign.tscn
+++ b/scenes/game_elements/props/sequence_puzzle_hint_sign/sequence_puzzle_hint_sign.tscn
@@ -36,7 +36,7 @@ unique_name_in_owner = true
 position = Vector2(-2, 1)
 collision_layer = 0
 disabled = true
-action = "Listen"
+action = "Examine"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]
 position = Vector2(2, 0)


### PR DESCRIPTION
Previously, interacting with a hint sign would always demonstrate the sequence. Now that it is possible to supply a `hint` animation to play on the sign itself (as is done in the template), some level designers may prefer to not demonstrate the sequence and make the puzzle more than a memory/imitation game.

For example, the template puzzle has two signs. Each sign shows a different series of symbols that have a natural correspondence to a coloured object (e.g. green = leaf). You could imagine changing this puzzle so that the player learns the correspondence from the first sign (which demonstrates the sequence of objects) and then has to interpret the symbols alone on the second sign. (They can replay the first sign if they have forgotten.)

I also adjusted the interact prompt on the sign.

Fixes #525
