### PR TITLE
SceneSwitcher: Unconditionally set current_spawn_point

### DIFF
--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -105,5 +105,4 @@ func change_to_file(scene_path: String, spawn_point: NodePath = ^"") -> void:
 func change_to_packed(scene: PackedScene, spawn_point: NodePath = ^"") -> void:
 	if get_tree().change_scene_to_packed(scene) == OK:
 		_set_hash(scene.resource_path)
-		if spawn_point != ^"":
-			GameState.current_spawn_point = spawn_point
+		GameState.current_spawn_point = spawn_point


### PR DESCRIPTION
Previously, when switching scenes, current_spawn_point would only be set if a non-empty spawn_point parameter was passed to change_to_*(). There is only one case in the project today which passes a non-empty path here: the transition from the intro to Fray's End. (All other uses of cinematic.gd leave spawn_point_path unset; as do all uses of teleporter.gd.) The only other place where GameState.current_spawn_point is updated is by checkpoints in stealth challenges.

spawn_point_path only has a well-defined meaning together with a particular scene, so if we are switching scene we should clear it. In particular, this fixes a bug where if you play the StoryQuest template stealth quest (which has a node named Checkpoints/Checkpoint), and then go on to play the LoreQuest stealth quest (which also has a node named Checkpoints/Checkpoint), you incorrectly spawn at the first checkpoint of the latter rather than at the start.

Unconditionally set current_spawn_point when changing scenes, even if it is empty.

Fixes https://github.com/endlessm/threadbare/issues/555