### PR TITLE
hiding_mushroom: Simplify behaviour

### DIFF
--- a/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd
+++ b/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd
@@ -3,21 +3,6 @@
 @tool
 extends Node2D
 
-@export var is_hidden: bool = true:
-	set(val):
-		var was_hidden: bool = is_hidden
-		is_hidden = val
-		if not is_node_ready():
-			return
-		if is_hidden != was_hidden:
-			_update_hidden_state()
-			notify_property_list_changed()
-
-@export var stay_hidden_or_revealed: bool = false
-
-var _reveal_when_player_nearby: bool = false
-var _hide_when_player_nearby: bool = false
-
 @onready var animated_sprite_2d: AnimatedSprite2D = %AnimatedSprite2D
 
 
@@ -36,40 +21,11 @@ func _reveal() -> void:
 		animated_sprite_2d.play(&"idle")
 
 
-func _update_hidden_state() -> void:
-	if is_hidden:
-		_hide()
-	else:
-		_reveal()
-
-
-func _get_property_list() -> Array[Dictionary]:
-	return [
-		{
-			"name": "_reveal_when_player_nearby" if is_hidden else "_hide_when_player_nearby",
-			"type": TYPE_BOOL,
-			"usage": PROPERTY_USAGE_DEFAULT,
-		}
-	]
-
-
-func _reveal_or_hide(is_player_nearby: bool) -> void:
-	if _reveal_when_player_nearby:
-		is_hidden = not is_player_nearby
-	elif _hide_when_player_nearby:
-		is_hidden = is_player_nearby
-
-
-func _ready() -> void:
-	if is_hidden:
-		animated_sprite_2d.visible = false
-
-
 func _on_player_detector_body_entered(body: Node2D) -> void:
 	if body.is_in_group(&"player"):
-		_reveal_or_hide(true)
+		_hide()
 
 
 func _on_player_detector_body_exited(body: Node2D) -> void:
-	if body.is_in_group(&"player") and not stay_hidden_or_revealed:
-		_reveal_or_hide(false)
+	if body.is_in_group(&"player"):
+		_reveal()

--- a/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.tscn
+++ b/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.tscn
@@ -126,13 +126,12 @@ radius = 128.0
 
 [node name="HidingMushroom" type="Node2D"]
 script = ExtResource("1_v208a")
-_reveal_when_player_nearby = true
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
-visible = false
 sprite_frames = SubResource("SpriteFrames_vnqon")
-animation = &"hide"
+animation = &"idle"
+frame_progress = 0.232213
 
 [node name="PlayerDetector" type="Area2D" parent="."]
 unique_name_in_owner = true

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -170,23 +170,15 @@ texture = ExtResource("40_06x6x")
 
 [node name="HidingMushroom" parent="Props" instance=ExtResource("11_jqkod")]
 position = Vector2(906, 1516)
-is_hidden = false
-_hide_when_player_nearby = true
 
 [node name="HidingMushroom2" parent="Props" instance=ExtResource("11_jqkod")]
 position = Vector2(1061, 1643)
-is_hidden = false
-_hide_when_player_nearby = true
 
 [node name="HidingMushroom3" parent="Props" instance=ExtResource("11_jqkod")]
 position = Vector2(929, 1235)
-is_hidden = false
-_hide_when_player_nearby = true
 
 [node name="HidingMushroom4" parent="Props" instance=ExtResource("11_jqkod")]
 position = Vector2(1049, 1193)
-is_hidden = false
-_hide_when_player_nearby = true
 
 [node name="Books" parent="Props" instance=ExtResource("12_06x6x")]
 position = Vector2(616, 611)


### PR DESCRIPTION
Previously, the behaviour of the mushroom was configurable: it could be configured to start hidden, or start visible; and it could be configured to stay hidden/revealed once its state changes. I found the logic confusing, particularly the dynamic redefinition of the "stay hidden/revealed" property based on the value of is_hidden. And the behaviour of the four instances in Fray's End was incorrect: they are supposed to start revealed, and hide when the player gets near.

Remove all configuration from the mushroom. Make it always follow the behaviour of being visible unless the player is nearby.

Fixes https://github.com/endlessm/threadbare/issues/580