### PR TITLE
Title: Use loud version of main theme

### DIFF
--- a/scenes/menus/title/title_screen.tscn
+++ b/scenes/menus/title/title_screen.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://bvlx57seuur65" path="res://assets/first_party/intro/background.png" id="3_2ijyo"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="4_c6kyi"]
 [ext_resource type="PackedScene" uid="uid://wgmdsj1sbmja" path="res://scenes/menus/title/components/main_menu.tscn" id="5_0vy2n"]
-[ext_resource type="AudioStream" uid="uid://davnfkvtb3edk" path="res://assets/first_party/music/Threadbare_Main_Quiet.ogg" id="5_5uobg"]
+[ext_resource type="AudioStream" uid="uid://kc657macgib4" path="res://assets/first_party/music/Threadbare_Main_Loud.ogg" id="5_5uobg"]
 [ext_resource type="PackedScene" uid="uid://6s70kur03rjk" path="res://scenes/menus/title/components/credits.tscn" id="6_2ijyo"]
 [ext_resource type="PackedScene" uid="uid://dkeb0yjgcfi86" path="res://scenes/menus/options/options.tscn" id="8_5uobg"]
 


### PR DESCRIPTION
The quiet version we were using before is mastered at a substantially lower volume than the loud version, and (more to the point) the other pieces of in-game music. This meant that an appropriate volume for the main game is too quiet for the title screen; and that if you crank up the music volume on the title screen to compensate, you are blasted by the in-game music.