### PR TITLE
Rename NPC to KnitWitch in template and edit narrative text in template scenes

### DIFF
--- a/scenes/quests/story_quests/template/0_template_intro/template_intro_components/template_intro.dialogue
+++ b/scenes/quests/story_quests/template/0_template_intro/template_intro_components/template_intro.dialogue
@@ -4,10 +4,11 @@
 ~ start
 do animation_player.play(&"walk_on")
 do animation_player.animation_finished
-Inside your StoryQuest intro folder, double click intro.dialogue to edit the text.
-Press Enter to add a new line. Each line becomes a new dialogue box in-game.
-Text can be placed during and after the walking animations. Try experimenting!
-do animation_player.play(&"walk_off")
-Select Cinematic node; drag your StoryQuest dialogue to the dialogue field in the Inspector.
+Welcome to the StoryQuest template, where you'll learn how to mod elements of each scene and create your own StoryQuest! Let's start with the intro.
+In the Godot FileSystem, find the intro folder and double-click on the intro dialogue file to edit the text.
+Press enter to add a new line. Each line becomes a new dialogue box in-game.
+Select Cinematic node; drag your StoryQuest dialogue to the "Dialogue" field in the Inspector.
 Set the next scene using the "Next Scene" field in the Inspector.
+do animation_player.play(&"walk_off")
+Explore other elements to mod, like the placeholder image, tile map, and animation options for this scene!
 => END

--- a/scenes/quests/story_quests/template/1_template_stealth/template_stealth_components/template_checkpoint.dialogue
+++ b/scenes/quests/story_quests/template/1_template_stealth/template_stealth_components/template_checkpoint.dialogue
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-NPC Name: This is a checkpoint that can be used to save player progress.
+KnitWitch: This is a checkpoint that can be used to save player progress.
 {{player_name}}: Thanks!
 => END

--- a/scenes/quests/story_quests/template/1_template_stealth/template_stealth_components/template_collected.dialogue
+++ b/scenes/quests/story_quests/template/1_template_stealth/template_stealth_components/template_collected.dialogue
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: MPL-2.0
 ~ start
 Select the CollectibleItem node and set "Next Scene" and "Item > Type" in the Inspector.
+You're doin' great!
 => END

--- a/scenes/quests/story_quests/template/1_template_stealth/template_stealth_components/template_stealth.dialogue
+++ b/scenes/quests/story_quests/template/1_template_stealth/template_stealth_components/template_stealth.dialogue
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-This simple stealth scene includes guards and a collectible. Use the nodes in the scene tree to build a stealth level.
-Click a node, like "Player" or "Enemy Guard" and modify their properties in the inspector, or add new nodes.
+This simple stealth scene includes guards and a collectible. Use the nodes in the Scene Tree to build a level.
+Notice the tile map is built with multiple layers. This makes it easier to make changes to the environment.
+Click a node, like "Player" or "Guard1" and modify their properties in the Inspector, or add new elements.
+Don't be afraid to think outside the box. (Oh, and remove or replace this text!)
 => END

--- a/scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_combat.dialogue
+++ b/scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_combat.dialogue
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
 ~ start
-Something in this scene will throw projectiles at you.
-Your goal is to hit them toward the targets.
-Try this example first, then explore the Scene Tree in the editor.
-You can add, change, or remove things to explore how that affects the gameplay.
+Something in this scene will throw projectiles at you. The goal is to redirect them toward the targets.
+Explore the Scene Tree to add, change, or remove elements.
 => END
 
 ~ well_done
-You can add text here after the player takes the collectible.
+You can add text here after the player takes the collectible. Be creative with this one!
 => END

--- a/scenes/quests/story_quests/template/3_template_sequence_puzzle/template_sequence_puzzle.dialogue
+++ b/scenes/quests/story_quests/template/3_template_sequence_puzzle/template_sequence_puzzle.dialogue
@@ -1,13 +1,12 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-This simple puzzle scene includes a series of musical objects the player must kick in a particular sequence.
-There are two signs which give clues for the two steps of the puzzle.
-To change the sequences, select each of the "SequencePuzzleStep" nodes and then change the "Sequence" array.
+This scene includes objects that the player must kick in a particular sequence, and signs with clues on them.
+Select a "SequencePuzzleStep" node and change the array in the "Sequence" field.
 The first melody is set to yellow, green, blue. This means that you should kick those objects in that order.
 Can you guess the second sequence without looking at the Inspector?
 => END
 ~ well_done
 Well done! You can add more steps to the puzzle. Just remember to add them to the "SequencePuzzle" node, and add a new hint sign for each one.
-We are going to transition to the last scene now...
+Using what you've learned so far, what kind of challenge can you create here? Have fun!
 => END

--- a/scenes/quests/story_quests/template/4_template_outro/template_outro_components/template_outro.dialogue
+++ b/scenes/quests/story_quests/template/4_template_outro/template_outro_components/template_outro.dialogue
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-Replace this text for the closing scene.
-Now we are going back to Fray's End so you can return these threads to the Eternal Loom...
+You've made it to the closing scene!
+This is where you will tie up the loose ends of your story.
+Let's go back to Fray's End so you can return these threads to the Eternal Loom...
 => END


### PR DESCRIPTION
Rename NPC to KnitWitch in template to match lore. Edit narrative text in template scenes to clarify tasks for learners.  