### PR TITLE
StoryWeaver: Use different animation for attack

### DIFF
--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -21,7 +21,6 @@ const REQUIRED_ANIMATION_FRAMES: Dictionary[StringName, int] = {
 	&"idle": 10,
 	&"walk": 6,
 	&"attack_01": 4,
-	&"attack_02": 4,
 	&"defeated": 11,
 }
 const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("uid://vwf8e1v8brdp")

--- a/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_blue.tres
+++ b/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_blue.tres
@@ -6,22 +6,6 @@
 [ext_resource type="Texture2D" uid="uid://ceiyxl0dy2cg1" path="res://scenes/game_elements/characters/player/components/storyweaver_blue_idle.png" id="3_lo7nh"]
 [ext_resource type="Texture2D" uid="uid://dmvl71i6783rk" path="res://scenes/game_elements/characters/player/components/storyweaver_blue_walk.png" id="4_3nn5s"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_007i1"]
-atlas = ExtResource("1_h7p10")
-region = Rect2(0, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6cv16"]
-atlas = ExtResource("1_h7p10")
-region = Rect2(192, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_j4nxn"]
-atlas = ExtResource("1_h7p10")
-region = Rect2(384, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_28m0y"]
-atlas = ExtResource("1_h7p10")
-region = Rect2(576, 0, 192, 192)
-
 [sub_resource type="AtlasTexture" id="AtlasTexture_bbmj2"]
 atlas = ExtResource("2_bgej0")
 region = Rect2(0, 0, 192, 192)
@@ -36,6 +20,22 @@ region = Rect2(384, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_5q8fn"]
 atlas = ExtResource("2_bgej0")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_007i1"]
+atlas = ExtResource("1_h7p10")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_6cv16"]
+atlas = ExtResource("1_h7p10")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_j4nxn"]
+atlas = ExtResource("1_h7p10")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_28m0y"]
+atlas = ExtResource("1_h7p10")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_5c6ie"]
@@ -150,23 +150,6 @@ region = Rect2(960, 0, 192, 192)
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_007i1")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_6cv16")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_j4nxn")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_28m0y")
-}],
-"loop": true,
-"name": &"attack_01",
-"speed": 10.0
-}, {
-"frames": [{
-"duration": 1.0,
 "texture": SubResource("AtlasTexture_bbmj2")
 }, {
 "duration": 1.0,
@@ -177,6 +160,23 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_5q8fn")
+}],
+"loop": true,
+"name": &"attack_01",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_007i1")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_6cv16")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_j4nxn")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_28m0y")
 }],
 "loop": true,
 "name": &"attack_02",

--- a/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_green.tres
+++ b/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_green.tres
@@ -6,22 +6,6 @@
 [ext_resource type="Texture2D" uid="uid://lu23w20tg0ja" path="res://scenes/game_elements/characters/player/components/storyweaver_green_idle.png" id="4_elx2a"]
 [ext_resource type="Texture2D" uid="uid://cyscpghhq5jf8" path="res://scenes/game_elements/characters/player/components/storyweaver_green_walk.png" id="5_elx2a"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_3cwop"]
-atlas = ExtResource("1_elx2a")
-region = Rect2(0, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_jx664"]
-atlas = ExtResource("1_elx2a")
-region = Rect2(192, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_gv5e3"]
-atlas = ExtResource("1_elx2a")
-region = Rect2(384, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_do88s"]
-atlas = ExtResource("1_elx2a")
-region = Rect2(576, 0, 192, 192)
-
 [sub_resource type="AtlasTexture" id="AtlasTexture_gh5jr"]
 atlas = ExtResource("2_elx2a")
 region = Rect2(0, 0, 192, 192)
@@ -36,6 +20,22 @@ region = Rect2(384, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_lov4t"]
 atlas = ExtResource("2_elx2a")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_3cwop"]
+atlas = ExtResource("1_elx2a")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_jx664"]
+atlas = ExtResource("1_elx2a")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_gv5e3"]
+atlas = ExtResource("1_elx2a")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_do88s"]
+atlas = ExtResource("1_elx2a")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_b618t"]
@@ -150,23 +150,6 @@ region = Rect2(960, 0, 192, 192)
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_3cwop")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_jx664")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_gv5e3")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_do88s")
-}],
-"loop": true,
-"name": &"attack_01",
-"speed": 10.0
-}, {
-"frames": [{
-"duration": 1.0,
 "texture": SubResource("AtlasTexture_gh5jr")
 }, {
 "duration": 1.0,
@@ -177,6 +160,23 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_lov4t")
+}],
+"loop": true,
+"name": &"attack_01",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_3cwop")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_jx664")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_gv5e3")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_do88s")
 }],
 "loop": true,
 "name": &"attack_02",

--- a/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_purple.tres
+++ b/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_purple.tres
@@ -6,22 +6,6 @@
 [ext_resource type="Texture2D" uid="uid://cqtkhe4dtcvp8" path="res://scenes/game_elements/characters/player/components/storyweaver_purple_idle.png" id="4_c5mw7"]
 [ext_resource type="Texture2D" uid="uid://dm8llgejx2n31" path="res://scenes/game_elements/characters/player/components/storyweaver_purple_walk.png" id="5_c5mw7"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_yi8hj"]
-atlas = ExtResource("1_c5mw7")
-region = Rect2(0, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_ynrol"]
-atlas = ExtResource("1_c5mw7")
-region = Rect2(192, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_ix87i"]
-atlas = ExtResource("1_c5mw7")
-region = Rect2(384, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_p0583"]
-atlas = ExtResource("1_c5mw7")
-region = Rect2(576, 0, 192, 192)
-
 [sub_resource type="AtlasTexture" id="AtlasTexture_0r6ir"]
 atlas = ExtResource("2_c5mw7")
 region = Rect2(0, 0, 192, 192)
@@ -36,6 +20,22 @@ region = Rect2(384, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_44ago"]
 atlas = ExtResource("2_c5mw7")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_yi8hj"]
+atlas = ExtResource("1_c5mw7")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ynrol"]
+atlas = ExtResource("1_c5mw7")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ix87i"]
+atlas = ExtResource("1_c5mw7")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_p0583"]
+atlas = ExtResource("1_c5mw7")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_ce6x2"]
@@ -150,23 +150,6 @@ region = Rect2(960, 0, 192, 192)
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_yi8hj")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_ynrol")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_ix87i")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_p0583")
-}],
-"loop": true,
-"name": &"attack_01",
-"speed": 10.0
-}, {
-"frames": [{
-"duration": 1.0,
 "texture": SubResource("AtlasTexture_0r6ir")
 }, {
 "duration": 1.0,
@@ -177,6 +160,23 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_44ago")
+}],
+"loop": true,
+"name": &"attack_01",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_yi8hj")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ynrol")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ix87i")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_p0583")
 }],
 "loop": true,
 "name": &"attack_02",

--- a/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_red.tres
+++ b/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_red.tres
@@ -6,22 +6,6 @@
 [ext_resource type="Texture2D" uid="uid://dcolxb7p4oyob" path="res://scenes/game_elements/characters/player/components/storyweaver_red_idle.png" id="4_3nggq"]
 [ext_resource type="Texture2D" uid="uid://b0rbcdewdt5sq" path="res://scenes/game_elements/characters/player/components/storyweaver_red_walk.png" id="5_6yxbf"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_8410a"]
-atlas = ExtResource("1_bn0m5")
-region = Rect2(0, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_xol17"]
-atlas = ExtResource("1_bn0m5")
-region = Rect2(192, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_iflks"]
-atlas = ExtResource("1_bn0m5")
-region = Rect2(384, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_71e06"]
-atlas = ExtResource("1_bn0m5")
-region = Rect2(576, 0, 192, 192)
-
 [sub_resource type="AtlasTexture" id="AtlasTexture_kpp0b"]
 atlas = ExtResource("2_4ljpj")
 region = Rect2(0, 0, 192, 192)
@@ -36,6 +20,22 @@ region = Rect2(384, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_kgewq"]
 atlas = ExtResource("2_4ljpj")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_8410a"]
+atlas = ExtResource("1_bn0m5")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_xol17"]
+atlas = ExtResource("1_bn0m5")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_iflks"]
+atlas = ExtResource("1_bn0m5")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_71e06"]
+atlas = ExtResource("1_bn0m5")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_g4r0o"]
@@ -150,23 +150,6 @@ region = Rect2(960, 0, 192, 192)
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_8410a")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_xol17")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_iflks")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_71e06")
-}],
-"loop": true,
-"name": &"attack_01",
-"speed": 10.0
-}, {
-"frames": [{
-"duration": 1.0,
 "texture": SubResource("AtlasTexture_kpp0b")
 }, {
 "duration": 1.0,
@@ -177,6 +160,23 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_kgewq")
+}],
+"loop": true,
+"name": &"attack_01",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_8410a")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_xol17")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_iflks")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_71e06")
 }],
 "loop": true,
 "name": &"attack_02",

--- a/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_yellow.tres
+++ b/scenes/game_elements/characters/shared_components/sprite_frames/storyweaver_yellow.tres
@@ -6,22 +6,6 @@
 [ext_resource type="Texture2D" uid="uid://bhnp4agy8kox2" path="res://scenes/game_elements/characters/player/components/storyweaver_yellow_idle.png" id="4_41ces"]
 [ext_resource type="Texture2D" uid="uid://bpfftom0yxqjk" path="res://scenes/game_elements/characters/player/components/storyweaver_yellow_walk.png" id="5_41ces"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_ivl47"]
-atlas = ExtResource("1_41ces")
-region = Rect2(0, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_7sx2o"]
-atlas = ExtResource("1_41ces")
-region = Rect2(192, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_hys0b"]
-atlas = ExtResource("1_41ces")
-region = Rect2(384, 0, 192, 192)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_fiqf7"]
-atlas = ExtResource("1_41ces")
-region = Rect2(576, 0, 192, 192)
-
 [sub_resource type="AtlasTexture" id="AtlasTexture_nb5pg"]
 atlas = ExtResource("2_41ces")
 region = Rect2(0, 0, 192, 192)
@@ -36,6 +20,22 @@ region = Rect2(384, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_eudai"]
 atlas = ExtResource("2_41ces")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ivl47"]
+atlas = ExtResource("1_41ces")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_7sx2o"]
+atlas = ExtResource("1_41ces")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_hys0b"]
+atlas = ExtResource("1_41ces")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_fiqf7"]
+atlas = ExtResource("1_41ces")
 region = Rect2(576, 0, 192, 192)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_fcn0h"]
@@ -150,23 +150,6 @@ region = Rect2(960, 0, 192, 192)
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_ivl47")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_7sx2o")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_hys0b")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_fiqf7")
-}],
-"loop": true,
-"name": &"attack_01",
-"speed": 10.0
-}, {
-"frames": [{
-"duration": 1.0,
 "texture": SubResource("AtlasTexture_nb5pg")
 }, {
 "duration": 1.0,
@@ -177,6 +160,23 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_eudai")
+}],
+"loop": true,
+"name": &"attack_01",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_ivl47")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_7sx2o")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_hys0b")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_fiqf7")
 }],
 "loop": true,
 "name": &"attack_02",


### PR DESCRIPTION
Use the animation named "Attack 02" in the Aseprite source file for the SpriteFrames animation "Attack 01".

Ideally we would change the AnimationPlayer in the Player scene to just use Attack 02. But we can't do that without also adding back "Attack 02" to the template for the player. That "Attack 02" animation was removed from the player template upon request, to avoid confusion in learners, as the animation wasn't used.

So, rename animation "Attack_01" to "Attack_unused" in StoryWeaver SpriteFrames in all color variations. And rename "Attack_02" to "Attack_01".

This is confusing, but may be the only thing we can do at this point.

Fixes https://github.com/endlessm/threadbare/issues/509