### PR TITLE
Throwing enemy: Document current limitation in throwing_period

### DIFF
--- a/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
+++ b/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
@@ -23,6 +23,7 @@ const WALK_TARGET_SKIP_ANGLE: float = PI / 4.
 const WALK_TARGET_SKIP_RANGE: float = 0.25
 
 ## The period of time between throwing projectiles.
+## Note: Currently this is limited by the length of the AnimationPlayer animation "attack".
 @export_range(0.1, 10., 0.1, "or_greater", "suffix:s") var throwing_period: float = 5.0
 
 ## Use this to have 2 enemies throwing projectiles alternatively and at the same pace


### PR DESCRIPTION
The limit is currently one second because in 3d3ef9be when switching to AnimationPlayer the animation was set to that length. It should be 0.8 seconds because that's the sum of the attack anticipation and attack animations. And probably the reason why the anticipation looks odd.