### PR TITLE
Add optional animation for quest to storybook

### DIFF
--- a/scenes/menus/storybook/components/animated_texture_rect.gd
+++ b/scenes/menus/storybook/components/animated_texture_rect.gd
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name AnimatedTextureRect
+extends TextureRect
+## A [TextureRect] which shows a single animation from a [SpriteFrames].
+##
+## This is useful because the only built-in way to display an animation in a
+## TextureRect is to use an [AnimatedTexture], which is documented to be
+## deprecated and broken; and because we use this to display an animation from
+## an in-game sprite, so an appropriate SpriteFrames will already exist.
+
+## A sprite frame library containing the animation. If unset, no texture is shown.
+@export var sprite_frames: SpriteFrames = preload(
+	"res://scenes/quests/story_quests/template/template_player_components/template_player.tres"
+):
+	set(new_value):
+		sprite_frames = new_value
+		notify_property_list_changed()
+		_update_animation()
+
+## The animation from [member sprite_frames] to display. If this animation is
+## not defined in [member sprite_frames], no texture is shown.
+@export var animation_name: StringName = &"idle":
+	set(new_value):
+		animation_name = new_value
+		_update_animation()
+
+var _frame: int = 0
+var _time_to_next_frame: float = 0.0
+
+
+func _validate_property(property: Dictionary) -> void:
+	match property["name"]:
+		"animation_name":
+			if sprite_frames:
+				property.hint = PROPERTY_HINT_ENUM
+				property.hint_string = ",".join(sprite_frames.get_animation_names())
+			else:
+				property.usage |= PROPERTY_USAGE_READ_ONLY
+
+
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings: PackedStringArray
+
+	if sprite_frames and sprite_frames.get_animation_names().find(animation_name) == -1:
+		warnings.append("Sprite Frames does not define '%s' animation" % animation_name)
+
+	return warnings
+
+
+func _ready() -> void:
+	_update_animation()
+
+
+func _update_animation() -> void:
+	update_configuration_warnings()
+
+	if not sprite_frames or not sprite_frames.has_animation(animation_name):
+		texture = null
+		_frame = -1
+		return
+
+	_frame = 0
+	_update_texture()
+
+
+func _update_texture() -> void:
+	if _frame >= sprite_frames.get_frame_count(animation_name):
+		if sprite_frames.get_animation_loop(animation_name):
+			_frame = 0
+		else:
+			_frame = -1
+			return
+
+	texture = sprite_frames.get_frame_texture(animation_name, _frame)
+	_time_to_next_frame = (
+		sprite_frames.get_frame_duration(animation_name, _frame)
+		/ sprite_frames.get_animation_speed(animation_name)
+	)
+
+
+func _process(delta: float) -> void:
+	if Engine.is_editor_hint() or _frame < 0:
+		return
+
+	# It is unlikely but possible that an animation frame's duration may be so
+	# short that it should be skipped entirely.
+	while delta >= _time_to_next_frame:
+		delta -= _time_to_next_frame
+		_frame += 1
+		_update_texture()
+
+	_time_to_next_frame -= delta

--- a/scenes/menus/storybook/components/animated_texture_rect.gd.uid
+++ b/scenes/menus/storybook/components/animated_texture_rect.gd.uid
@@ -1,0 +1,1 @@
+uid://dfx8s2ybd11mt

--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -5,9 +5,7 @@ extends Resource
 ## Information that defines a playable quest
 
 ## The quest's title. This should be short, like the title of a novel.
-@export var title: String:
-	set(new_value):
-		title = new_value.strip_edges()
+@export var title: String
 
 ## A short description of the quest. This should be a single paragraph of around 2–3 sentences.
 @export_multiline var description: String

--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
+@tool
 class_name Quest
 extends Resource
 ## Information that defines a playable quest
@@ -19,6 +20,28 @@ extends Resource
 
 ## The path to the first scene of the quest.
 @export_file("*.tscn") var first_scene: String
+
+@export_group("Animation")
+
+## An optional sprite frame library to show in the storybook page for this quest.
+## This could be the main character, an NPC, or an important item in the quest.
+@export var sprite_frames: SpriteFrames:
+	set(new_value):
+		sprite_frames = new_value
+		notify_property_list_changed()
+
+## The animation in [member sprite_frames] to display. This should typically be a looping animation.
+@export var animation_name: StringName = &""
+
+
+func _validate_property(property: Dictionary) -> void:
+	match property["name"]:
+		"animation_name":
+			if sprite_frames:
+				property.hint = PROPERTY_HINT_ENUM
+				property.hint_string = ",".join(sprite_frames.get_animation_names())
+			else:
+				property.usage |= PROPERTY_USAGE_READ_ONLY
 
 
 func _to_string() -> String:

--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -19,12 +19,8 @@ extends Resource
 ## Leave blank if not needed.
 @export var affiliation: String
 
-@export_group("Advanced")
-
 ## The path to the first scene of the quest.
-## The path can be absolute (beginning with [code]res://[/code])
-## or relative to the folder where this quest resource is saved.
-@export_file("*.tscn") var first_scene: String = "0_intro_template/intro_template.tscn"
+@export_file("*.tscn") var first_scene: String
 
 
 func _to_string() -> String:
@@ -37,11 +33,3 @@ func get_title() -> String:
 		return title
 
 	return resource_path.get_base_dir().get_file()
-
-
-## Resolves [member first_scene] relative to the directory this Quest is stored in, if necessary.
-func get_first_scene_path() -> String:
-	if first_scene.is_absolute_path():
-		return first_scene
-
-	return resource_path.get_base_dir().path_join(first_scene)

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -97,7 +97,7 @@ func _on_button_focused(button: Button, quest: Quest) -> void:
 
 	match quest.authors.size():
 		0:
-			authors.text = "An anonymous story"
+			authors.text = ""
 		1:
 			authors.text = "A story by " + quest.authors[0]
 		_:

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -78,7 +78,7 @@ func _on_button_focused(button: Button, quest: Quest) -> void:
 		authors.text = "A story by the Threadbare Authors"
 		return
 
-	title.text = quest.title
+	title.text = quest.title.strip_edges()
 
 	if quest.description:
 		description.text = quest.description

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -9,6 +9,12 @@ signal play(quest: Quest)
 ## Template quest, which is expected to be blank and so is treated specially.
 const STORY_QUEST_TEMPLATE := preload("uid://ddxn14xw66ud8")
 
+## Sprite frames for the template quest
+const TEMPLATE_PLAYER_FRAMES: SpriteFrames = preload("uid://vwf8e1v8brdp")
+
+## Animation for the template quest
+const TEMPLATE_ANIMATION_NAME: StringName = &"idle"
+
 const QUEST_RESOURCE_NAME := "quest.tres"
 
 ## Directory to scan for quests. This directory should have 1 or more subdirectories, each of which
@@ -21,6 +27,7 @@ var _selected_quest: Quest
 @onready var title: Label = %Title
 @onready var description: Label = %Description
 @onready var authors: Label = %Authors
+@onready var animation: AnimatedTextureRect = %Animation
 @onready var play_button: Button = %PlayButton
 
 
@@ -76,6 +83,9 @@ func _on_button_focused(button: Button, quest: Quest) -> void:
 		title.text = "StoryQuest Template"
 		description.text = "This is the template for your own StoryQuests."
 		authors.text = "A story by the Threadbare Authors"
+		animation.sprite_frames = TEMPLATE_PLAYER_FRAMES
+		animation.animation_name = TEMPLATE_ANIMATION_NAME
+
 		return
 
 	title.text = quest.title.strip_edges()

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -1,7 +1,14 @@
-[gd_scene load_steps=3 format=3 uid="uid://bhm7fdjvppt8b"]
+[gd_scene load_steps=7 format=3 uid="uid://bhm7fdjvppt8b"]
 
 [ext_resource type="Script" uid="uid://5bt5um5g1g3p" path="res://scenes/menus/storybook/components/storybook.gd" id="1_gw8hn"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/dialogue/components/theme.tres" id="1_rdgd0"]
+[ext_resource type="Texture2D" uid="uid://c34pfs7jyf2qp" path="res://scenes/game_elements/props/checkpoint/components/Blue/Knitwitch_Idle.png" id="3_ju58s"]
+[ext_resource type="Script" uid="uid://dfx8s2ybd11mt" path="res://scenes/menus/storybook/components/animated_texture_rect.gd" id="3_n2i2u"]
+[ext_resource type="SpriteFrames" uid="uid://3elulifvmamm" path="res://scenes/game_elements/props/checkpoint/components/knitwitch_frames_blue.tres" id="5_ab72c"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1tfpy"]
+atlas = ExtResource("3_ju58s")
+region = Rect2(0, 0, 192, 192)
 
 [node name="Storybook" type="Control"]
 layout_mode = 3
@@ -66,6 +73,14 @@ layout_mode = 2
 size_flags_vertical = 1
 text = "by Jane Bloggs, Erika Mustermann and Jóna Jónsdóttir"
 autowrap_mode = 2
+
+[node name="Animation" type="TextureRect" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+texture = SubResource("AtlasTexture_1tfpy")
+script = ExtResource("3_n2i2u")
+sprite_frames = ExtResource("5_ab72c")
 
 [node name="Spacer" type="Control" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
 layout_mode = 2

--- a/scenes/quests/story_quests/template/quest.tres
+++ b/scenes/quests/story_quests/template/quest.tres
@@ -9,4 +9,5 @@ description = ""
 authors = Array[String]([])
 affiliation = ""
 first_scene = "uid://c1gdct760l86h"
+animation_name = &""
 metadata/_custom_type_script = "uid://dts1hwdy3phin"

--- a/scenes/quests/story_quests/template/quest.tres
+++ b/scenes/quests/story_quests/template/quest.tres
@@ -8,5 +8,5 @@ title = ""
 description = ""
 authors = Array[String]([])
 affiliation = ""
-first_scene = "0_intro_template/intro_template.tscn"
+first_scene = "uid://c1gdct760l86h"
 metadata/_custom_type_script = "uid://dts1hwdy3phin"


### PR DESCRIPTION
For the purposes of the storybook, a quest is defined by a Quest resource with various fields that populate the storybook page.

To add some visual variety to an otherwise text-heavy page, and potentially hint that the protagonist in a StoryQuest will not be StoryWeaver, allow a quest to specify a SpriteFrames, and an animation from that SpriteFrames, which will be shown on the storybook page if present.

To do this, I had to implement a custom TextureRect that can play an animation from a SpriteFrames. This was a surprising gap in Godot's Controls to me but there are many open bugs related to this.

I also cleaned up some bits and bobs in the quest resource class and storybook scene.

Fixes #557 

https://endlessm.github.io/threadbare/branches/endlessm/quest-animation-in-storybook/#menus/storybook/storybook