### PR TITLE
Elder: Offer the player a storybook

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -4,11 +4,10 @@
 class_name Elder
 extends Talker
 
-## The quest that this NPC offers to the player when they interact with them.
-@export var quest: Quest:
-	set(new_value):
-		quest = new_value
-		update_configuration_warnings()
+const STORYBOOK_SCENE := preload("uid://bhm7fdjvppt8b")
+
+## Directory of quests that this NPC offers to the player during interactions.
+@export_dir var quest_directory: String
 
 ## A reference to the loom, so that this Elder can determine whether you have
 ## the items you need to operate it.
@@ -22,22 +21,30 @@ extends Talker
 @export var idle_sound_stream: AudioStream = preload("uid://dxbxx6x5h7d8p"):
 	set = _set_idle_sound_stream
 
-## Whether to enter [member quest] when the current dialogue ends
-var _enter_quest_on_dialogue_ended: bool = false
+## The quest chosen by the player from the storybook
+var chosen_quest: Quest
+
+var _dialogue_balloon: CanvasLayer
+var _storybook: Storybook
 
 @onready var _book_sound: AudioStreamPlayer2D = %BookSound
+@onready var _storybook_layer: CanvasLayer = %StorybookLayer
 
 
 func _ready() -> void:
 	super._ready()
 	animated_sprite_2d.connect("frame_changed", _on_frame_changed)
 
+	if quest_directory:
+		_storybook = STORYBOOK_SCENE.instantiate()
+		_storybook.quest_directory = quest_directory
+
 
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array[String] = []
 
-	if not quest:
-		warnings.append("Quest property should be set")
+	if not quest_directory:
+		warnings.append("Quest Directory property should be set")
 
 	if not eternal_loom:
 		warnings.append("Eternal Loom property must be set")
@@ -51,25 +58,35 @@ func _on_interaction_started(player: Player, _from_right: bool) -> void:
 	var title: String = ""
 	if eternal_loom and eternal_loom.is_item_offering_possible():
 		title = "go_to_loom"
-	DialogueManager.show_dialogue_balloon(dialogue, title, [self, player])
+	_dialogue_balloon = DialogueManager.show_dialogue_balloon(dialogue, title, [self, player])
 
 
-## At the end of the current interaction, enter [member quest]. This is intended to be called
-## from dialogue.
-func enter_quest() -> void:
-	_enter_quest_on_dialogue_ended = true
+## Show a storybook to the player, and wait for them to select a story or close the book.
+func show_storybook() -> void:
+	if not _storybook:
+		return
+
+	# GDM will hide the balloon after a short pause if the awaitable hasn't resolved, but we want it
+	# to be replaced with the storybook immediately.
+	if _dialogue_balloon:
+		_dialogue_balloon.balloon.hide()
+
+	_storybook_layer.add_child(_storybook)
+	_storybook.reset_focus()
+	chosen_quest = await _storybook.selected
+	_storybook_layer.remove_child(_storybook)
 
 
 func _on_dialogue_ended(dialogue_resource: DialogueResource) -> void:
 	super(dialogue_resource)
 
-	if _enter_quest_on_dialogue_ended:
+	if chosen_quest:
 		%InteractArea.disabled = true
 		GameState.start_quest()
 		SceneSwitcher.change_to_file_with_transition(
-			quest.first_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+			chosen_quest.first_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE
 		)
-		_enter_quest_on_dialogue_ended = false
+		chosen_quest = null
 
 
 func _on_frame_changed() -> void:

--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -4,10 +4,10 @@
 class_name Elder
 extends Talker
 
-## The first scene of a quest that this NPC offers to the player when they interact with them.
-@export var quest_scene: PackedScene:
+## The quest that this NPC offers to the player when they interact with them.
+@export var quest: Quest:
 	set(new_value):
-		quest_scene = new_value
+		quest = new_value
 		update_configuration_warnings()
 
 ## A reference to the loom, so that this Elder can determine whether you have
@@ -22,7 +22,7 @@ extends Talker
 @export var idle_sound_stream: AudioStream = preload("uid://dxbxx6x5h7d8p"):
 	set = _set_idle_sound_stream
 
-## Whether to enter [member quest_scene] when the current dialogue ends
+## Whether to enter [member quest] when the current dialogue ends
 var _enter_quest_on_dialogue_ended: bool = false
 
 @onready var _book_sound: AudioStreamPlayer2D = %BookSound
@@ -36,8 +36,8 @@ func _ready() -> void:
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array[String] = []
 
-	if not quest_scene:
-		warnings.append("Quest Scene property should be set")
+	if not quest:
+		warnings.append("Quest property should be set")
 
 	if not eternal_loom:
 		warnings.append("Eternal Loom property must be set")
@@ -54,7 +54,7 @@ func _on_interaction_started(player: Player, _from_right: bool) -> void:
 	DialogueManager.show_dialogue_balloon(dialogue, title, [self, player])
 
 
-## At the end of the current interaction, enter [member quest_scene]. This is intended to be called
+## At the end of the current interaction, enter [member quest]. This is intended to be called
 ## from dialogue.
 func enter_quest() -> void:
 	_enter_quest_on_dialogue_ended = true
@@ -66,8 +66,8 @@ func _on_dialogue_ended(dialogue_resource: DialogueResource) -> void:
 	if _enter_quest_on_dialogue_ended:
 		%InteractArea.disabled = true
 		GameState.start_quest()
-		SceneSwitcher.change_to_packed_with_transition(
-			quest_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+		SceneSwitcher.change_to_file_with_transition(
+			quest.first_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE
 		)
 		_enter_quest_on_dialogue_ended = false
 

--- a/scenes/game_elements/characters/npcs/elder/components/lore_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/elder/components/lore_quest_starter.dialogue
@@ -3,15 +3,13 @@
 ~ start
 LoreQuest Elder: [[Hi|Hello|Greetings]], StoryWeaver. We've been waiting for you. Our world is unraveling!
 LoreQuest Elder: We need you to recover the Sacred Elements: the threads of Memory, Imagination, and Spirit! Will you help us?
-- No.
-	StoryWeaver: I don't know where I am, and I don't know what you are asking me to do.
+do show_storybook()
+if chosen_quest == null:
 	% LoreQuest Elder: Please stay. Our world will perish without your help!
 	% LoreQuest Elder: I hope to see you again. We really need you!
 	% LoreQuest Elder: The people of Threadbare are counting on you. I hope you change your mind!
-- Yes.
-	StoryWeaver: OK...I'm not sure how, but I'll do my best!
+else:
 	LoreQuest Elder: We believe in you, StoryWeaver.
-	do enter_quest()
 => END
 ~ go_to_loom
 LoreQuest Elder: Go on, StoryWeaver: take the threads to the Eternal Loom.

--- a/scenes/game_elements/characters/npcs/elder/components/story_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/elder/components/story_quest_starter.dialogue
@@ -3,15 +3,13 @@
 ~ start
 StoryQuest Elder: [[Hi|Hello|Greetings]], StoryWeaver. We've been waiting for you. Our world is unraveling!
 StoryQuest Elder: We need you to recover the Sacred Elements: the threads of Memory, Imagination, and Spirit! Will you help us?
-- No.
-	StoryWeaver: I don't know where I am, and I don't know what you are asking me to do.
+do show_storybook()
+if chosen_quest == null:
 	% StoryQuest Elder: Please stay. Our world will perish without your help!
 	% StoryQuest Elder: I hope to see you again. We really need you!
 	% StoryQuest Elder: The people of Threadbare are counting on you. I hope you change your mind!
-- Yes.
-	StoryWeaver: OK...I'm not sure how, but I'll do my best!
+else:
 	StoryQuest Elder: We believe in you, StoryWeaver. Become the hero, and see where the path leads.
-	do enter_quest()
 => END
 ~ go_to_loom
 StoryQuest Elder: Go on, StoryWeaver: take the threads to the Eternal Loom.

--- a/scenes/game_elements/characters/npcs/elder/elder.tscn
+++ b/scenes/game_elements/characters/npcs/elder/elder.tscn
@@ -54,3 +54,6 @@ pitch_scale = 2.0
 max_distance = 1500.0
 attenuation = 3.0
 bus = &"SFX"
+
+[node name="StorybookLayer" type="CanvasLayer" parent="."]
+unique_name_in_owner = true

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -37,8 +37,8 @@ func _enumerate_quests() -> Array[Quest]:
 
 	for dir in ResourceLoader.list_directory(quest_directory):
 		var quest_path := quest_directory.path_join(dir).path_join(QUEST_RESOURCE_NAME)
-		if ResourceLoader.exists(quest_path, "Quest"):
-			var quest: Quest = ResourceLoader.load(quest_path, "Quest")
+		if ResourceLoader.exists(quest_path):
+			var quest: Quest = ResourceLoader.load(quest_path)
 			if quest == STORY_QUEST_TEMPLATE:
 				has_template = true
 			else:

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -100,11 +100,7 @@ func _on_button_focused(button: Button, quest: Quest) -> void:
 		return
 
 	title.text = quest.title.strip_edges()
-
-	if quest.description:
-		description.text = quest.description
-	else:
-		description.text = "It is a mystery"
+	description.text = quest.description.strip_edges()
 
 	match quest.authors.size():
 		0:

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -20,53 +20,60 @@ grow_vertical = 2
 theme = ExtResource("1_rdgd0")
 script = ExtResource("1_gw8hn")
 
-[node name="PanelContainer" type="PanelContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/margin_left = 128
+theme_override_constants/margin_top = 128
+theme_override_constants/margin_right = 128
+theme_override_constants/margin_bottom = 128
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer"]
 layout_mode = 2
 
-[node name="LeftPage" type="MarginContainer" parent="PanelContainer/HBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/PanelContainer"]
+layout_mode = 2
+
+[node name="LeftPage" type="MarginContainer" parent="MarginContainer/PanelContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="QuestList" type="VBoxContainer" parent="PanelContainer/HBoxContainer/LeftPage"]
+[node name="QuestList" type="VBoxContainer" parent="MarginContainer/PanelContainer/HBoxContainer/LeftPage"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="VSeparator" type="VSeparator" parent="PanelContainer/HBoxContainer"]
+[node name="VSeparator" type="VSeparator" parent="MarginContainer/PanelContainer/HBoxContainer"]
 layout_mode = 2
 
-[node name="RightPage" type="MarginContainer" parent="PanelContainer/HBoxContainer"]
+[node name="RightPage" type="MarginContainer" parent="MarginContainer/PanelContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/HBoxContainer/RightPage"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage"]
 layout_mode = 2
 
-[node name="TitleBox" type="PanelContainer" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+[node name="TitleBox" type="PanelContainer" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 0
 theme_type_variation = &"PlayerRibbon"
 
-[node name="Title" type="Label" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer/TitleBox"]
+[node name="Title" type="Label" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer/TitleBox"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Title of the Quest"
 
-[node name="Description" type="Label" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+[node name="Description" type="Label" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 2
 text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pulvinar, erat non consectetur cursus, erat erat lobortis massa, quis mattis purus dolor ac lorem. In hac habitasse platea dictumst. Suspendisse vulputate felis purus, ac scelerisque mauris tristique sit amet. Lorem ipsum dolor sit amet, consectetur adipiscing elit."
 autowrap_mode = 2
 
-[node name="Authors" type="Label" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+[node name="Authors" type="Label" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 2
@@ -74,7 +81,7 @@ size_flags_vertical = 1
 text = "by Jane Bloggs, Erika Mustermann and Jóna Jónsdóttir"
 autowrap_mode = 2
 
-[node name="Animation" type="TextureRect" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+[node name="Animation" type="TextureRect" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -82,11 +89,11 @@ texture = SubResource("AtlasTexture_1tfpy")
 script = ExtResource("3_n2i2u")
 sprite_frames = ExtResource("5_ab72c")
 
-[node name="Spacer" type="Control" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+[node name="Spacer" type="Control" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="PlayButton" type="Button" parent="PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
+[node name="PlayButton" type="Button" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -95,4 +102,4 @@ focus_neighbor_bottom = NodePath(".")
 theme_type_variation = &"FlatButton"
 text = "Play"
 
-[connection signal="pressed" from="PanelContainer/HBoxContainer/RightPage/VBoxContainer/PlayButton" to="." method="_on_play_button_pressed"]
+[connection signal="pressed" from="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer/PlayButton" to="." method="_on_play_button_pressed"]

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -42,9 +42,21 @@ layout_mode = 2
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="QuestList" type="VBoxContainer" parent="MarginContainer/PanelContainer/HBoxContainer/LeftPage"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/HBoxContainer/LeftPage"]
+layout_mode = 2
+
+[node name="QuestList" type="VBoxContainer" parent="MarginContainer/PanelContainer/HBoxContainer/LeftPage/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_vertical = 3
+
+[node name="BackButton" type="Button" parent="MarginContainer/PanelContainer/HBoxContainer/LeftPage/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_next = NodePath("../../../RightPage/VBoxContainer/PlayButton")
+theme_type_variation = &"FlatButton"
+text = "< back"
+flat = true
 
 [node name="VSeparator" type="VSeparator" parent="MarginContainer/PanelContainer/HBoxContainer"]
 layout_mode = 2
@@ -99,7 +111,9 @@ layout_mode = 2
 size_flags_horizontal = 4
 focus_neighbor_top = NodePath(".")
 focus_neighbor_bottom = NodePath(".")
+focus_previous = NodePath("../../../LeftPage/VBoxContainer/BackButton")
 theme_type_variation = &"FlatButton"
 text = "Play"
 
+[connection signal="pressed" from="MarginContainer/PanelContainer/HBoxContainer/LeftPage/VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]
 [connection signal="pressed" from="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer/PlayButton" to="." method="_on_play_button_pressed"]

--- a/scenes/quests/lore_quests/quest_001/quest.tres
+++ b/scenes/quests/lore_quests/quest_001/quest.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="Quest" load_steps=3 format=3 uid="uid://doovydomib7rj"]
+
+[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_3ntet"]
+[ext_resource type="SpriteFrames" uid="uid://clx8sssi4tw8q" path="res://scenes/game_elements/characters/shared_components/sprite_frames/musician.tres" id="2_xjg3h"]
+
+[resource]
+script = ExtResource("1_3ntet")
+title = "The Musician's Quest"
+description = "StoryWeaver meets a musician and a series of terrifying creatures."
+authors = Array[String]([])
+affiliation = ""
+first_scene = "uid://7hoy2p14t6kc"
+sprite_frames = ExtResource("2_xjg3h")
+animation_name = &"idle"
+metadata/_custom_type_script = "uid://dts1hwdy3phin"

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -13,13 +13,11 @@
 [ext_resource type="Texture2D" uid="uid://c8xgl7dcju5h7" path="res://scenes/game_elements/props/buildings/house/components/House_Patch_Blue_03.png" id="6_ojp30"]
 [ext_resource type="Texture2D" uid="uid://cvm2x4fhekowd" path="res://scenes/game_elements/props/buildings/house/components/House_Wool_Blue_03.png" id="6_uhynt"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="7_7v00g"]
-[ext_resource type="PackedScene" uid="uid://7hoy2p14t6kc" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn" id="11_0a1i7"]
 [ext_resource type="PackedScene" uid="uid://bbsc3wssndtfe" path="res://scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.tscn" id="11_jqkod"]
 [ext_resource type="PackedScene" uid="uid://ipvcfv2g0oi1" path="res://scenes/game_elements/characters/npcs/talker/talker.tscn" id="11_mr2ek"]
 [ext_resource type="PackedScene" uid="uid://ccp4ayow34e7g" path="res://scenes/game_elements/props/decoration/books/books.tscn" id="12_06x6x"]
 [ext_resource type="Resource" uid="uid://c1baepfbbcd4s" path="res://scenes/game_elements/characters/npcs/elder/components/lore_quest_starter.dialogue" id="12_yntpr"]
 [ext_resource type="Texture2D" uid="uid://cyvi71ryavsld" path="res://scenes/game_elements/props/decoration/books/components/Books_2.png" id="13_xt3dw"]
-[ext_resource type="PackedScene" uid="uid://c1gdct760l86h" path="res://scenes/quests/story_quests/template/0_template_intro/template_intro.tscn" id="14_xa7wa"]
 [ext_resource type="SpriteFrames" uid="uid://cqe47tmqq3mu4" path="res://scenes/game_elements/characters/shared_components/sprite_frames/elder2.tres" id="15_iwt5r"]
 [ext_resource type="PackedScene" uid="uid://bp20cjimwi8l0" path="res://scenes/game_elements/props/buildings/house/house_2.tscn" id="15_uhynt"]
 [ext_resource type="PackedScene" uid="uid://712saqgof3kf" path="res://scenes/game_elements/props/eternal_loom/eternal_loom.tscn" id="16_ojp30"]
@@ -31,8 +29,10 @@
 [ext_resource type="PackedScene" uid="uid://6tkhqe1nvwop" path="res://scenes/game_elements/characters/npcs/npc_prop/fray_idle.tscn" id="20_xa7wa"]
 [ext_resource type="PackedScene" uid="uid://bytkm0r5fe5xb" path="res://scenes/game_elements/characters/npcs/elder/elder.tscn" id="20_xt3dw"]
 [ext_resource type="Script" uid="uid://d4bfnn5upde7h" path="res://scenes/game_elements/props/hint/input_key/input_key.gd" id="21_i7vhm"]
+[ext_resource type="Resource" uid="uid://doovydomib7rj" path="res://scenes/quests/lore_quests/quest_001/quest.tres" id="22_06x6x"]
 [ext_resource type="SpriteFrames" uid="uid://cpm5o35ede3qs" path="res://scenes/game_elements/characters/npcs/npc_prop/sprite_frames/fray_idle_purple.tres" id="22_e453w"]
 [ext_resource type="Texture2D" uid="uid://p8kty3uxifxu" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Space_Key_Dark.png" id="24_h30yx"]
+[ext_resource type="Resource" uid="uid://ddxn14xw66ud8" path="res://scenes/quests/story_quests/template/quest.tres" id="24_xt3dw"]
 [ext_resource type="PackedScene" uid="uid://hafqgtdg2nvp" path="res://scenes/game_elements/props/hint/hint.tscn" id="26_w8iew"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="27_aj6tp"]
 [ext_resource type="Texture2D" uid="uid://cc5wontx8obvi" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Arrow_Right_Key_Dark.png" id="27_w8iew"]
@@ -269,14 +269,14 @@ sprite_frames = ExtResource("22_e453w")
 
 [node name="LoreQuestElder" parent="NPCs" node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_xt3dw")]
 position = Vector2(690, 600)
-quest_scene = ExtResource("11_0a1i7")
+quest = ExtResource("22_06x6x")
 eternal_loom = NodePath("../../EternalLoom")
 npc_name = "LoreQuest Elder"
 dialogue = ExtResource("12_yntpr")
 
 [node name="StoryQuestElder" parent="NPCs" node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_xt3dw")]
 position = Vector2(1310, 598)
-quest_scene = ExtResource("14_xa7wa")
+quest = ExtResource("24_xt3dw")
 eternal_loom = NodePath("../../EternalLoom")
 npc_name = "StoryQuest Elder"
 sprite_frames = ExtResource("15_iwt5r")

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=47 format=4 uid="uid://cufkthb25mpxy"]
+[gd_scene load_steps=45 format=4 uid="uid://cufkthb25mpxy"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_4evgk"]
 [ext_resource type="Script" uid="uid://8div00rgvsds" path="res://scenes/world_map/components/frays_end.gd" id="1_4gse6"]
@@ -29,10 +29,8 @@
 [ext_resource type="PackedScene" uid="uid://6tkhqe1nvwop" path="res://scenes/game_elements/characters/npcs/npc_prop/fray_idle.tscn" id="20_xa7wa"]
 [ext_resource type="PackedScene" uid="uid://bytkm0r5fe5xb" path="res://scenes/game_elements/characters/npcs/elder/elder.tscn" id="20_xt3dw"]
 [ext_resource type="Script" uid="uid://d4bfnn5upde7h" path="res://scenes/game_elements/props/hint/input_key/input_key.gd" id="21_i7vhm"]
-[ext_resource type="Resource" uid="uid://doovydomib7rj" path="res://scenes/quests/lore_quests/quest_001/quest.tres" id="22_06x6x"]
 [ext_resource type="SpriteFrames" uid="uid://cpm5o35ede3qs" path="res://scenes/game_elements/characters/npcs/npc_prop/sprite_frames/fray_idle_purple.tres" id="22_e453w"]
 [ext_resource type="Texture2D" uid="uid://p8kty3uxifxu" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Space_Key_Dark.png" id="24_h30yx"]
-[ext_resource type="Resource" uid="uid://ddxn14xw66ud8" path="res://scenes/quests/story_quests/template/quest.tres" id="24_xt3dw"]
 [ext_resource type="PackedScene" uid="uid://hafqgtdg2nvp" path="res://scenes/game_elements/props/hint/hint.tscn" id="26_w8iew"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="27_aj6tp"]
 [ext_resource type="Texture2D" uid="uid://cc5wontx8obvi" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Arrow_Right_Key_Dark.png" id="27_w8iew"]
@@ -269,14 +267,14 @@ sprite_frames = ExtResource("22_e453w")
 
 [node name="LoreQuestElder" parent="NPCs" node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_xt3dw")]
 position = Vector2(690, 600)
-quest = ExtResource("22_06x6x")
+quest_directory = "res://scenes/quests/lore_quests/"
 eternal_loom = NodePath("../../EternalLoom")
 npc_name = "LoreQuest Elder"
 dialogue = ExtResource("12_yntpr")
 
 [node name="StoryQuestElder" parent="NPCs" node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_xt3dw")]
 position = Vector2(1310, 598)
-quest = ExtResource("24_xt3dw")
+quest_directory = "res://scenes/quests/story_quests/"
 eternal_loom = NodePath("../../EternalLoom")
 npc_name = "StoryQuest Elder"
 sprite_frames = ExtResource("15_iwt5r")


### PR DESCRIPTION
Previously, each elder could trigger exactly one quest. Soon we will have more than one StoryQuest, and in due course more than one LoreQuest, so we need a way to access those.

Wire up the existing Storybook scene to the elder. Trigger its display from dialogue, hiding the dialogue balloon while the storybook is on-screen. This replaces the previous yes/no choice in each dialogue (and may address #575).

Fixes #164

----

![image](https://github.com/user-attachments/assets/1782bb02-f609-48f7-904b-1ad166330ac7)
![image](https://github.com/user-attachments/assets/95682d24-731b-4706-8ee6-2daba4135413)

Test it at:

https://endlessm.github.io/threadbare/branches/endlessm/add-storybook-to-storyquest-elder/#uid://cufkthb25mpxy