### PR TITLE
Talker: Don't change look_at_side after unrelated dialogue

### DIFF
--- a/scenes/game_elements/characters/npcs/talker/components/talker.gd
+++ b/scenes/game_elements/characters/npcs/talker/components/talker.gd
@@ -19,7 +19,6 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 	interact_area.interaction_started.connect(_on_interaction_started)
-	DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
 	if npc_name:
 		interact_area.action = "Talk to %s" % npc_name
 
@@ -28,6 +27,7 @@ func _on_interaction_started(player: Player, from_right: bool) -> void:
 	_previous_look_at_side = look_at_side
 	if look_at_side != Enums.LookAtSide.UNSPECIFIED:
 		look_at_side = Enums.LookAtSide.RIGHT if from_right else Enums.LookAtSide.LEFT
+	DialogueManager.dialogue_ended.connect(_on_dialogue_ended, CONNECT_ONE_SHOT)
 	DialogueManager.show_dialogue_balloon(dialogue, "", [self, player])
 
 


### PR DESCRIPTION
npc.gd has a look_at_side property which may be LEFT, RIGHT, or UNSPECIFIED. If look_at_side is LEFT, the sprite is flipped horizontally. (This assumes a convention that assets that have a directionality face right – we should document this!) UNSPECIFIED indicates that the npc faces forwards.

talker.gd extends npc.gd. When the player interacts with something, a flag is passed indicating whether the player is to the right of the InteractArea. In the case where the talker has look_at_side not equal to UNSPECIFIED, look_at_side is changed to have the NPC turn towards the player during the interaction. The previous value is stored; at the end of the dialogue, the old value is restored.

However, previously talker.gd would continously listen to the DialogueManager.dialogue_ended signal, not only when the player is interacting with this NPC and triggering this dialogue. This means that after any dialogue (triggered for any reason, in particular including a Cinematic), all talkers would have their look_at_side set to the default value of the _previous_look_at_side property. This property is only initialised in the _on_interaction_started() handler, so in the case where the player has not interacted with the talker, the value will be UNSPECIFIED.

The result is as follows: if you had a talker in a scene, with its look_at_side set to LEFT, and the scene also had a cinematic, then at the end of the cinematic the talker would flip horizontally for no apparent reason.

Fix this by only connecting to dialogue_ended at the start of the interaction, with CONNECT_ONE_SHOT.