### PR TITLE
Player: Do not warn if attack_02 animation is missing

### DIFF
--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -21,7 +21,6 @@ const REQUIRED_ANIMATION_FRAMES: Dictionary[StringName, int] = {
 	&"idle": 10,
 	&"walk": 6,
 	&"attack_01": 4,
-	&"attack_02": 4,
 	&"defeated": 11,
 }
 const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("uid://vwf8e1v8brdp")


### PR DESCRIPTION
This animation is still not used in the game.

Also, currently the template doesn't have such animation. To avoid confusions among learners, it has been removed in b26c1a7c. So that means that the template would display a warning to learners if we don't remove this requirement.

I have cherry picked this from https://github.com/endlessm/threadbare/pull/661 because I noticed while working on Stella that the warning is still there.