### PR TITLE
Elder: Fix end of dialogue

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -58,6 +58,7 @@ func _on_interaction_started(player: Player, _from_right: bool) -> void:
 	var title: String = ""
 	if eternal_loom and eternal_loom.is_item_offering_possible():
 		title = "go_to_loom"
+	DialogueManager.dialogue_ended.connect(_on_dialogue_ended, CONNECT_ONE_SHOT)
 	_dialogue_balloon = DialogueManager.show_dialogue_balloon(dialogue, title, [self, player])
 
 


### PR DESCRIPTION
In commit 1edfb44e78faab2a08621f467e9e442ccd2df978, I moved talker.gd's connection to DialogueManager.dialogue_ended to
_on_interaction_started(). What I missed is that elder.gd overrides this function without chaining up. So the elders' _on_dialogue_ended() is never called, making it impossible to enter a quest.

Copy the same new code into elder.gd.