### PR TITLE
Change "kick" to "tap" in sequence puzzles

### DIFF
--- a/scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn
+++ b/scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn
@@ -29,7 +29,7 @@ collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_55nmp")
 interact_label_position = Vector2(0, 30)
-action = "Kick"
+action = "Tap"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]
 position = Vector2(3, -11)

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue
@@ -15,7 +15,7 @@ StoryWeaver: What happened here?
 Musician: Songs stopped being sung. And when a song is forgotten... the world forgets itself.
 if puzzle.get_progress() >= 1:
 	Musician: Oh! Have you been playing with the stones over there?
-	StoryWeaver: I kicked them and something strange happened...
+	StoryWeaver: I tapped them and something strange happened...
 	Musician: They can be used to create music...
 else:
 	Musician: See those stones over there? They can be used to create music...
@@ -23,7 +23,7 @@ Musician: The songs can make wonderful things happen... make items or creatures 
 Musician: Those altars? They hold the memory of each song in the ashes of their fires.
 Musician: Now, if I remember correctly, there's a song that used to open the portal to the Ink Well, where songwriters found the ink to write all the songs of the world.
 Musician: Let's see if I can remember how it works...
-Musician: Try kicking the first, and second stones, then check the first altar above. If you see flames, we're on to the right melody.
+Musician: Try tapping the first, and second stones, then check the first altar above. If you see flames, we're on to the right melody.
 => END
 
 ~ hello_again
@@ -47,12 +47,12 @@ Musician: Hello again, StoryWeaver. Would you like a hint?
 ~ hint_melody_0
 match get_hint_level()
 	when 0
-		Musician: Hmmm... Try kicking the first, second, and third stones in that order.
+		Musician: Hmmm... Try tapping the first, second, and third stones in that order.
 	when 1
 		Musician: Even I'm forgetting in this torn world, let's see...
-		Musician: OK, I remember kicking the first, second, third, and fifth stones.
+		Musician: OK, I remember tapping the first, second, third, and fifth stones.
 	else
-		Musician: I remember kicking the first, second, third, and fifth stones.
+		Musician: I remember tapping the first, second, third, and fifth stones.
 => END
 
 ~ hint_melody_1

--- a/scenes/quests/story_quests/template/3_template_sequence_puzzle/template_sequence_puzzle.dialogue
+++ b/scenes/quests/story_quests/template/3_template_sequence_puzzle/template_sequence_puzzle.dialogue
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-This scene includes objects that the player must kick in a particular sequence, and signs with clues on them.
+This scene includes objects that the player must tap in a particular sequence, and signs with clues on them.
 Select a "SequencePuzzleStep" node and change the array in the "Sequence" field.
-The first melody is set to yellow, green, blue. This means that you should kick those objects in that order.
+The first melody is set to yellow, green, blue. This means that you should tap those objects in that order.
 Can you guess the second sequence without looking at the Inspector?
 => END
 ~ well_done


### PR DESCRIPTION
This is a change from @hydrolet in https://github.com/StellaQuest/threadbare/pull/31. It's OK to kick a rock, but not a tortoise. By using a more neutral term for the default interact verb, we reduce the number of cases where someone will have to figure out how to override it.

I updated the dialogue accordingly. Unfortunately "kick" is in the API and we can't change that.