### PR TITLE
Refactor storybook.gd somewhat

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -9,7 +9,10 @@ extends Control
 signal selected(quest: Quest)
 
 ## Template quest, which is expected to be blank and so is treated specially.
-const STORY_QUEST_TEMPLATE := preload("uid://ddxn14xw66ud8")
+const STORY_QUEST_TEMPLATE: Quest = preload("uid://ddxn14xw66ud8")
+
+## Replacement metadata for the template's blank metadata
+const TEMPLATE_QUEST_METADATA: Quest = preload("uid://dwl8letaanhhi")
 
 ## Sprite frames for the template quest
 const TEMPLATE_PLAYER_FRAMES: SpriteFrames = preload("uid://vwf8e1v8brdp")
@@ -48,7 +51,7 @@ func _enumerate_quests() -> Array[Quest]:
 				quests.append(quest)
 
 	if has_template:
-		quests.append(STORY_QUEST_TEMPLATE)
+		quests.append(TEMPLATE_QUEST_METADATA)
 
 	return quests
 
@@ -89,15 +92,6 @@ func _on_button_focused(button: Button, quest: Quest) -> void:
 	play_button.focus_next = button.get_path()
 	play_button.focus_neighbor_left = button.get_path()
 	_selected_quest = quest
-
-	if quest == STORY_QUEST_TEMPLATE:
-		title.text = "StoryQuest Template"
-		description.text = "This is the template for your own StoryQuests."
-		authors.text = "A story by the Threadbare Authors"
-		animation.sprite_frames = TEMPLATE_PLAYER_FRAMES
-		animation.animation_name = TEMPLATE_ANIMATION_NAME
-
-		return
 
 	title.text = quest.title.strip_edges()
 	description.text = quest.description.strip_edges()

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -26,14 +26,8 @@ const QUEST_RESOURCE_NAME := "quest.tres"
 ## have a [code]quest.tres[/code] file within.
 @export_dir var quest_directory: String = "res://scenes/quests/story_quests"
 
-var _selected_quest: Quest
-
 @onready var quest_list: VBoxContainer = %QuestList
-@onready var title: Label = %Title
-@onready var description: Label = %Description
-@onready var authors: Label = %Authors
-@onready var animation: AnimatedTextureRect = %Animation
-@onready var play_button: Button = %PlayButton
+@onready var storybook_page: StorybookPage = %StorybookPage
 @onready var back_button: Button = %BackButton
 
 
@@ -66,7 +60,7 @@ func _ready() -> void:
 
 		button.focus_entered.connect(_on_button_focused.bind(button, quest))
 		button.focus_next = back_button.get_path()
-		button.focus_previous = play_button.get_path()
+		button.focus_previous = storybook_page.play_button.get_path()
 
 		if previous_button:
 			button.focus_neighbor_top = previous_button.get_path()
@@ -89,40 +83,13 @@ func _input(event: InputEvent) -> void:
 
 func _on_button_focused(button: Button, quest: Quest) -> void:
 	back_button.focus_previous = button.get_path()
-	play_button.focus_next = button.get_path()
-	play_button.focus_neighbor_left = button.get_path()
-	_selected_quest = quest
-
-	title.text = quest.title.strip_edges()
-	description.text = quest.description.strip_edges()
-
-	match quest.authors.size():
-		0:
-			authors.text = ""
-		1:
-			authors.text = "A story by " + quest.authors[0]
-		_:
-			authors.text = (
-				" "
-				. join(
-					[
-						"A story by",
-						", ".join(quest.authors.slice(0, -1)),
-						"and",
-						quest.authors[-1],
-					]
-				)
-			)
-
-	if quest.affiliation:
-		authors.text += " of " + quest.affiliation
-
-	animation.sprite_frames = quest.sprite_frames
-	animation.animation_name = quest.animation_name
+	storybook_page.play_button.focus_next = button.get_path()
+	storybook_page.play_button.focus_neighbor_left = button.get_path()
+	storybook_page.quest = quest
 
 
-func _on_play_button_pressed() -> void:
-	selected.emit(_selected_quest)
+func _on_storybook_page_selected(quest: Quest) -> void:
+	selected.emit(quest)
 
 
 func _on_back_button_pressed() -> void:

--- a/scenes/menus/storybook/components/storybook_page.gd
+++ b/scenes/menus/storybook/components/storybook_page.gd
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name StorybookPage
+extends MarginContainer
+## A control that displays a [Quest].
+
+## Emitted when the player chooses the quest shown on this page
+signal selected(quest: Quest)
+
+## The quest displayed on this page
+var quest: Quest = preload("uid://dwl8letaanhhi"):
+	set = _set_quest
+
+@onready var title: Label = %Title
+@onready var description: Label = %Description
+@onready var authors: Label = %Authors
+@onready var animation: AnimatedTextureRect = %Animation
+@onready var play_button: Button = %PlayButton
+
+
+func _set_quest(new_quest: Quest) -> void:
+	quest = new_quest
+
+	if not is_node_ready():
+		return
+
+	title.text = quest.title.strip_edges()
+	description.text = quest.description.strip_edges()
+
+	match quest.authors.size():
+		0:
+			authors.text = ""
+		1:
+			authors.text = "A story by " + quest.authors[0]
+		_:
+			authors.text = (
+				" "
+				. join(
+					[
+						"A story by",
+						", ".join(quest.authors.slice(0, -1)),
+						"and",
+						quest.authors[-1],
+					]
+				)
+			)
+
+	if quest.affiliation:
+		authors.text += " of " + quest.affiliation
+
+	animation.sprite_frames = quest.sprite_frames
+	animation.animation_name = quest.animation_name
+
+
+func _ready() -> void:
+	_set_quest(quest)
+
+
+func _on_play_button_pressed() -> void:
+	selected.emit(quest)

--- a/scenes/menus/storybook/components/storybook_page.gd.uid
+++ b/scenes/menus/storybook/components/storybook_page.gd.uid
@@ -1,0 +1,1 @@
+uid://csl2nw1r7fhpj

--- a/scenes/menus/storybook/components/storybook_page.tscn
+++ b/scenes/menus/storybook/components/storybook_page.tscn
@@ -1,0 +1,69 @@
+[gd_scene load_steps=7 format=3 uid="uid://cgtonist08yxn"]
+
+[ext_resource type="Script" uid="uid://csl2nw1r7fhpj" path="res://scenes/menus/storybook/components/storybook_page.gd" id="1_jl23h"]
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/dialogue/components/theme.tres" id="1_otsbv"]
+[ext_resource type="Texture2D" uid="uid://c34pfs7jyf2qp" path="res://scenes/game_elements/props/checkpoint/components/Blue/Knitwitch_Idle.png" id="2_otsbv"]
+[ext_resource type="Script" uid="uid://dfx8s2ybd11mt" path="res://scenes/menus/storybook/components/animated_texture_rect.gd" id="3_rxv6h"]
+[ext_resource type="SpriteFrames" uid="uid://3elulifvmamm" path="res://scenes/game_elements/props/checkpoint/components/knitwitch_frames_blue.tres" id="4_0inj8"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1tfpy"]
+atlas = ExtResource("2_otsbv")
+region = Rect2(0, 0, 192, 192)
+
+[node name="StorybookPage" type="MarginContainer"]
+custom_minimum_size = Vector2(640, 0)
+size_flags_horizontal = 3
+theme = ExtResource("1_otsbv")
+script = ExtResource("1_jl23h")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="TitleBox" type="PanelContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_type_variation = &"PlayerRibbon"
+
+[node name="Title" type="Label" parent="VBoxContainer/TitleBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Title of the Quest"
+
+[node name="Description" type="Label" parent="VBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 64)
+layout_mode = 2
+text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pulvinar, erat non consectetur cursus, erat erat lobortis massa, quis mattis purus dolor ac lorem. In hac habitasse platea dictumst. Suspendisse vulputate felis purus, ac scelerisque mauris tristique sit amet. Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+autowrap_mode = 2
+
+[node name="Authors" type="Label" parent="VBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(64, 64)
+layout_mode = 2
+size_flags_vertical = 1
+text = "by Jane Bloggs, Erika Mustermann and Jóna Jónsdóttir"
+autowrap_mode = 2
+
+[node name="Animation" type="TextureRect" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+texture = SubResource("AtlasTexture_1tfpy")
+script = ExtResource("3_rxv6h")
+sprite_frames = ExtResource("4_0inj8")
+
+[node name="Spacer" type="Control" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="PlayButton" type="Button" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+focus_neighbor_top = NodePath(".")
+focus_neighbor_bottom = NodePath(".")
+focus_previous = NodePath("../../../LeftPage/VBoxContainer/BackButton")
+theme_type_variation = &"FlatButton"
+text = "Play"
+
+[connection signal="pressed" from="VBoxContainer/PlayButton" to="." method="_on_play_button_pressed"]

--- a/scenes/menus/storybook/components/template_quest.tres
+++ b/scenes/menus/storybook/components/template_quest.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="Quest" load_steps=3 format=3 uid="uid://dwl8letaanhhi"]
+
+[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_4e4qu"]
+[ext_resource type="SpriteFrames" uid="uid://vwf8e1v8brdp" path="res://scenes/quests/story_quests/template/template_player_components/template_player.tres" id="2_hcwxq"]
+
+[resource]
+script = ExtResource("1_4e4qu")
+title = "StoryQuest Template"
+description = "This is a template which guides you through making your own StoryQuest."
+authors = Array[String]([])
+affiliation = ""
+first_scene = "uid://dwl8letaanhhi"
+sprite_frames = ExtResource("2_hcwxq")
+animation_name = &"idle"
+metadata/_custom_type_script = "uid://dts1hwdy3phin"

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -1,14 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://bhm7fdjvppt8b"]
+[gd_scene load_steps=4 format=3 uid="uid://bhm7fdjvppt8b"]
 
 [ext_resource type="Script" uid="uid://5bt5um5g1g3p" path="res://scenes/menus/storybook/components/storybook.gd" id="1_gw8hn"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/dialogue/components/theme.tres" id="1_rdgd0"]
-[ext_resource type="Texture2D" uid="uid://c34pfs7jyf2qp" path="res://scenes/game_elements/props/checkpoint/components/Blue/Knitwitch_Idle.png" id="3_ju58s"]
-[ext_resource type="Script" uid="uid://dfx8s2ybd11mt" path="res://scenes/menus/storybook/components/animated_texture_rect.gd" id="3_n2i2u"]
-[ext_resource type="SpriteFrames" uid="uid://3elulifvmamm" path="res://scenes/game_elements/props/checkpoint/components/knitwitch_frames_blue.tres" id="5_ab72c"]
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_1tfpy"]
-atlas = ExtResource("3_ju58s")
-region = Rect2(0, 0, 192, 192)
+[ext_resource type="PackedScene" uid="uid://cgtonist08yxn" path="res://scenes/menus/storybook/components/storybook_page.tscn" id="3_n2i2u"]
 
 [node name="Storybook" type="Control"]
 layout_mode = 3
@@ -53,7 +47,7 @@ size_flags_vertical = 3
 [node name="BackButton" type="Button" parent="MarginContainer/PanelContainer/HBoxContainer/LeftPage/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-focus_next = NodePath("../../../RightPage/VBoxContainer/PlayButton")
+focus_next = NodePath("../../../StorybookPage/VBoxContainer/PlayButton")
 theme_type_variation = &"FlatButton"
 text = "< back"
 flat = true
@@ -61,59 +55,9 @@ flat = true
 [node name="VSeparator" type="VSeparator" parent="MarginContainer/PanelContainer/HBoxContainer"]
 layout_mode = 2
 
-[node name="RightPage" type="MarginContainer" parent="MarginContainer/PanelContainer/HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage"]
-layout_mode = 2
-
-[node name="TitleBox" type="PanelContainer" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 0
-theme_type_variation = &"PlayerRibbon"
-
-[node name="Title" type="Label" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer/TitleBox"]
+[node name="StorybookPage" parent="MarginContainer/PanelContainer/HBoxContainer" instance=ExtResource("3_n2i2u")]
 unique_name_in_owner = true
 layout_mode = 2
-text = "Title of the Quest"
-
-[node name="Description" type="Label" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(64, 64)
-layout_mode = 2
-text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pulvinar, erat non consectetur cursus, erat erat lobortis massa, quis mattis purus dolor ac lorem. In hac habitasse platea dictumst. Suspendisse vulputate felis purus, ac scelerisque mauris tristique sit amet. Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-autowrap_mode = 2
-
-[node name="Authors" type="Label" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(64, 64)
-layout_mode = 2
-size_flags_vertical = 1
-text = "by Jane Bloggs, Erika Mustermann and Jóna Jónsdóttir"
-autowrap_mode = 2
-
-[node name="Animation" type="TextureRect" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-texture = SubResource("AtlasTexture_1tfpy")
-script = ExtResource("3_n2i2u")
-sprite_frames = ExtResource("5_ab72c")
-
-[node name="Spacer" type="Control" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 3
-
-[node name="PlayButton" type="Button" parent="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-focus_neighbor_top = NodePath(".")
-focus_neighbor_bottom = NodePath(".")
-focus_previous = NodePath("../../../LeftPage/VBoxContainer/BackButton")
-theme_type_variation = &"FlatButton"
-text = "Play"
 
 [connection signal="pressed" from="MarginContainer/PanelContainer/HBoxContainer/LeftPage/VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]
-[connection signal="pressed" from="MarginContainer/PanelContainer/HBoxContainer/RightPage/VBoxContainer/PlayButton" to="." method="_on_play_button_pressed"]
+[connection signal="selected" from="MarginContainer/PanelContainer/HBoxContainer/StorybookPage" to="." method="_on_storybook_page_selected"]


### PR DESCRIPTION
This splits some hardcoded override data for the template storyquest into a resource file, and factors out the section of the scene that displays a quest to a separate scene.

(I was experimenting with switching to a one-quest-per-page model.)