### PR TITLE
Pause overlay: Add button to go back to title screen

### DIFF
--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 extends CanvasLayer
 
+const TITLE_SCENE: PackedScene = preload("uid://stdqc6ttomff")
+
 @onready var pause_menu: Control = %PauseMenu
 @onready var resume_button: Button = %ResumeButton
 @onready var options: Control = %Options
@@ -38,3 +40,10 @@ func _on_options_back() -> void:
 
 func _on_resume_button_pressed() -> void:
 	toggle_pause()
+
+
+func _on_title_screen_button_pressed() -> void:
+	toggle_pause()
+	SceneSwitcher.change_to_packed_with_transition(
+		TITLE_SCENE, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+	)

--- a/scenes/globals/pause/pause_overlay.tscn
+++ b/scenes/globals/pause/pause_overlay.tscn
@@ -58,13 +58,6 @@ theme_type_variation = &"PlayerRibbon"
 layout_mode = 2
 text = "Game Paused"
 
-[node name="OptionsButton" type="Button" parent="TabContainer/PauseMenu/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-theme_type_variation = &"FlatButton"
-text = "Options"
-
 [node name="ResumeButton" type="Button" parent="TabContainer/PauseMenu/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -72,12 +65,27 @@ size_flags_horizontal = 4
 theme_type_variation = &"FlatButton"
 text = "Resume"
 
+[node name="OptionsButton" type="Button" parent="TabContainer/PauseMenu/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Options"
+
+[node name="TitleScreenButton" type="Button" parent="TabContainer/PauseMenu/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Exit to Title"
+
 [node name="Options" parent="TabContainer" instance=ExtResource("3_sd5t1")]
 unique_name_in_owner = true
 process_mode = 2
 visible = false
 layout_mode = 2
 
-[connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/OptionsButton" to="." method="_on_options_button_pressed"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/ResumeButton" to="." method="_on_resume_button_pressed"]
+[connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/OptionsButton" to="." method="_on_options_button_pressed"]
+[connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/TitleScreenButton" to="." method="_on_title_screen_button_pressed"]
 [connection signal="back" from="TabContainer/Options" to="." method="_on_options_back"]


### PR DESCRIPTION
And move the Resume button to the top, as it is the default focused option.

Currently this is a way to abandon and lose all your progress, because nothing is persisted. But is also a way to restart the experience if you get stuck in the Sokobans, for example.

In the future, the progress should be persisted, and the title screen should be able to offer a Resume + Restart options instead of Start, if there is progress.

Fixes https://github.com/endlessm/threadbare/issues/432