### PR TITLE
Game elements: Revert because of accidental merge

### DIFF
--- a/scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn
+++ b/scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=12 format=3 uid="uid://b82nsrh332syj"]
 
 [ext_resource type="Script" uid="uid://dfj3625owet5p" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd" id="1_ffq0m"]
-[ext_resource type="SpriteFrames" uid="uid://deosvk5k4su5f" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy.tres" id="2_knmau"]
+[ext_resource type="SpriteFrames" uid="uid://deosvk5k4su5f" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_throwing_enemy.tres" id="2_cvpou"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_3vyb7"]
 height = 42.0
@@ -246,8 +246,9 @@ script = ExtResource("1_ffq0m")
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
 position = Vector2(0, -30)
-sprite_frames = ExtResource("2_knmau")
+sprite_frames = ExtResource("2_cvpou")
 animation = &"walk"
+autoplay = "idle"
 flip_h = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -269,7 +270,7 @@ collision_layer = 128
 collision_mask = 256
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HitBox"]
-position = Vector2(-1, -26)
+position = Vector2(0, -31.5)
 shape = SubResource("RectangleShape2D_ffq0m")
 debug_color = Color(0.990065, 0, 0.28292, 0.42)
 

--- a/scenes/game_elements/characters/npcs/npc_prop/fray_idle.tscn
+++ b/scenes/game_elements/characters/npcs/npc_prop/fray_idle.tscn
@@ -15,7 +15,6 @@ sprite_frames = ExtResource("2_j3sup")
 unique_name_in_owner = true
 position = Vector2(0, -30)
 sprite_frames = ExtResource("2_j3sup")
-animation = &"idle"
 frame_progress = 0.948213
 flip_h = true
 

--- a/scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn
+++ b/scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn
@@ -5,8 +5,7 @@
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/components/interact_area.gd" id="3_55nmp"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_kw7av"]
-radius = 5.99998
-height = 12.6667
+height = 32.0
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_kw7av"]
 size = Vector2(45, 45)
@@ -18,7 +17,6 @@ script = ExtResource("1_kw7av")
 unique_name_in_owner = true
 scale = Vector2(0.7, 0.7)
 sprite_frames = ExtResource("2_cltuv")
-animation = &"struck"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(3, 7)


### PR DESCRIPTION
The PR https://github.com/endlessm/threadbare/pull/705/ was merged accidentally. It has intentional changes in quests/story_quests/stella, but also unintentional changes in scenes/game_elements/ . So revert the unintentional changes.