### PR TITLE
Player: move walk sound to sfx bus

### DIFF
--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -546,3 +546,4 @@ unique_name_in_owner = true
 stream = ExtResource("11_blfj0")
 volume_db = -5.0
 pitch_scale = 7.0
+bus = &"SFX"


### PR DESCRIPTION
Previously, that audio stream player had its bus set to Master, meaning it could still be heard even if the SFX volume was turned down.

Fixes https://github.com/endlessm/threadbare/issues/709