### PR TITLE
FixedSizeLabel: Resize container to label

### DIFF
--- a/scenes/game_elements/props/fixed_size_label/components/fixed_size_label.gd
+++ b/scenes/game_elements/props/fixed_size_label/components/fixed_size_label.gd
@@ -58,3 +58,10 @@ func _exit_tree() -> void:
 
 	if label_container:
 		label_container.queue_free()
+
+
+func _on_label_resized() -> void:
+	if not is_node_ready():
+		return
+	# TODO: Workaround for https://github.com/godotengine/godot/issues/100626
+	label_container.reset_size()

--- a/scenes/game_elements/props/fixed_size_label/fixed_size_label.tscn
+++ b/scenes/game_elements/props/fixed_size_label/fixed_size_label.tscn
@@ -14,13 +14,12 @@ label_text = "Talk"
 [node name="LabelContainer" type="PanelContainer" parent="."]
 unique_name_in_owner = true
 texture_filter = 2
-layout_mode = 2
-offset_left = -50.0
-offset_top = -32.5
-offset_right = 50.0
-offset_bottom = 32.5
-grow_horizontal = 2
-grow_vertical = 2
+custom_minimum_size = Vector2(68, 46)
+layout_mode = 0
+offset_left = -34.0
+offset_top = -23.0
+offset_right = 34.0
+offset_bottom = 23.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
 theme = ExtResource("1_ah0mj")
@@ -28,6 +27,8 @@ theme_type_variation = &"FixedSizeLabelContainer"
 
 [node name="MarginContainer" type="MarginContainer" parent="LabelContainer"]
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 10
@@ -36,8 +37,10 @@ theme_override_constants/margin_bottom = 5
 [node name="Label" type="Label" parent="LabelContainer/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_vertical = 1
+size_flags_horizontal = 4
 theme_type_variation = &"FixedSizeLabel"
 text = "Talk"
 horizontal_alignment = 1
 vertical_alignment = 1
+
+[connection signal="resized" from="LabelContainer/MarginContainer/Label" to="." method="_on_label_resized"]


### PR DESCRIPTION
This is a workaround for an upstream bug:
https://github.com/godotengine/godot/issues/100626

Connect the label size changed signal to a handler, that calls reset_size() in the PanelContainer

Also, change the minimum size of the PanelContainer to the current size, and shrink center both the MarginContainer and the Label nodes. The offsets in the diff have changed automatically because of this.

Fixes https://github.com/endlessm/threadbare/issues/608