### PR TITLE
Fullscreen option

### DIFF
--- a/scenes/globals/settings/settings.gd
+++ b/scenes/globals/settings/settings.gd
@@ -10,6 +10,9 @@ const DEFAULT_VOLUMES: Dictionary[String, float] = {
 	"Music": -15.0,
 }
 
+const VIDEO_SECTION := "Video"
+const VIDEO_WINDOW_MODE_KEY := "Window Mode"
+
 var _settings := ConfigFile.new()
 
 
@@ -19,6 +22,7 @@ func _ready() -> void:
 		push_error("Failed to load %s: %s" % [SETTINGS_PATH, err])
 
 	_restore_volumes()
+	_restore_video_settings()
 
 
 func _restore_volumes() -> void:
@@ -28,6 +32,21 @@ func _restore_volumes() -> void:
 			VOLUME_SECTION, bus, DEFAULT_VOLUMES.get(bus, 0.0)
 		)
 		_set_volume(bus_idx, volume_db)
+
+
+func _restore_video_settings() -> void:
+	var default_window_mode: int = ProjectSettings.get_setting("display/window/size/mode")
+	var window_mode: int = (
+		_settings
+		. get_value(
+			VIDEO_SECTION,
+			VIDEO_WINDOW_MODE_KEY,
+			default_window_mode,
+		)
+	)
+	if window_mode == DisplayServer.window_get_mode():
+		return
+	DisplayServer.window_set_mode(window_mode)
 
 
 func get_volume(bus: String) -> float:
@@ -41,6 +60,23 @@ func set_volume(bus: String, volume_db: float) -> void:
 	_set_volume(bus_idx, volume_db)
 
 	_settings.set_value(VOLUME_SECTION, bus, volume_db)
+	_save()
+
+
+func is_fullscreen() -> bool:
+	return DisplayServer.window_get_mode() == DisplayServer.WINDOW_MODE_FULLSCREEN
+
+
+func toggle_fullscreen(toggled_on: bool) -> void:
+	var default_window_mode: int = ProjectSettings.get_setting("display/window/size/mode")
+	set_window_mode(DisplayServer.WINDOW_MODE_FULLSCREEN if toggled_on else default_window_mode)
+
+
+func set_window_mode(window_mode: int) -> void:
+	if window_mode == DisplayServer.window_get_mode():
+		return
+	DisplayServer.window_set_mode(window_mode)
+	_settings.set_value(VIDEO_SECTION, VIDEO_WINDOW_MODE_KEY, window_mode)
 	_save()
 
 

--- a/scenes/menus/options/components/video_settings.gd
+++ b/scenes/menus/options/components/video_settings.gd
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends VBoxContainer
+
+@onready var check_button: CheckButton = %CheckButton
+
+
+func _ready() -> void:
+	check_button.set_pressed_no_signal(Settings.is_fullscreen())
+
+
+func _on_check_button_toggled(toggled_on: bool) -> void:
+	Settings.toggle_fullscreen(toggled_on)

--- a/scenes/menus/options/components/video_settings.gd.uid
+++ b/scenes/menus/options/components/video_settings.gd.uid
@@ -1,0 +1,1 @@
+uid://c63sfg6wgj2uy

--- a/scenes/menus/options/components/video_settings.tscn
+++ b/scenes/menus/options/components/video_settings.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=3 format=3 uid="uid://tahf2q1d3e74"]
+
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/dialogue/components/theme.tres" id="1_qb52c"]
+[ext_resource type="Script" uid="uid://c63sfg6wgj2uy" path="res://scenes/menus/options/components/video_settings.gd" id="2_qb52c"]
+
+[node name="VideoSettings" type="VBoxContainer"]
+offset_left = 96.0
+offset_top = 64.0
+offset_right = 544.0
+offset_bottom = 254.0
+theme = ExtResource("1_qb52c")
+script = ExtResource("2_qb52c")
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_type_variation = &"PlayerRibbon"
+
+[node name="Label" type="Label" parent="PanelContainer"]
+layout_mode = 2
+text = "Video Settings"
+
+[node name="GridContainer" type="GridContainer" parent="."]
+layout_mode = 2
+columns = 2
+
+[node name="MusicLabel" type="Label" parent="GridContainer"]
+layout_mode = 2
+text = "Fullscreen"
+horizontal_alignment = 2
+
+[node name="CheckButton" type="CheckButton" parent="GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[connection signal="toggled" from="GridContainer/CheckButton" to="." method="_on_check_button_toggled"]

--- a/scenes/menus/options/options.tscn
+++ b/scenes/menus/options/options.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://dkeb0yjgcfi86"]
+[gd_scene load_steps=5 format=3 uid="uid://dkeb0yjgcfi86"]
 
 [ext_resource type="PackedScene" uid="uid://de6s2quemrmkf" path="res://scenes/menus/options/components/sound_settings.tscn" id="1_7hrlm"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/dialogue/components/theme.tres" id="1_ptihp"]
 [ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="2_cw13b"]
+[ext_resource type="PackedScene" uid="uid://tahf2q1d3e74" path="res://scenes/menus/options/components/video_settings.tscn" id="4_cw13b"]
 
 [node name="Options" type="CenterContainer"]
 anchors_preset = 15
@@ -22,6 +23,9 @@ layout_mode = 2
 layout_mode = 2
 
 [node name="SoundSettingsPanel" parent="PanelContainer/VBoxContainer" instance=ExtResource("1_7hrlm")]
+layout_mode = 2
+
+[node name="VideoSettings" parent="PanelContainer/VBoxContainer" instance=ExtResource("4_cw13b")]
 layout_mode = 2
 
 [node name="BackButton" type="Button" parent="PanelContainer/VBoxContainer"]

--- a/scenes/ui_elements/dialogue/components/theme.tres
+++ b/scenes/ui_elements/dialogue/components/theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=22 format=3 uid="uid://cvitou84ni7qe"]
+[gd_resource type="Theme" load_steps=25 format=3 uid="uid://cvitou84ni7qe"]
 
 [ext_resource type="Texture2D" uid="uid://dv7kcbngjjwq7" path="res://assets/third_party/tiny-swords/UI/Buttons/Button_Blue_3Slides.png" id="1_0xtm5"]
 [ext_resource type="Texture2D" uid="uid://bxk0fu4vv6wt2" path="res://assets/third_party/tiny-swords/UI/Buttons/Button_Hover_3Slides.png" id="1_1romn"]
@@ -45,6 +45,15 @@ texture_margin_right = 32.0
 texture_margin_bottom = 28.0
 axis_stretch_horizontal = 2
 axis_stretch_vertical = 2
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lerkg"]
+bg_color = Color(1, 1, 1, 0.152941)
+expand_margin_left = 16.0
+expand_margin_right = 16.0
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_7k42u"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_lerkg"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_lerkg"]
 texture = ExtResource("5_7k42u")
@@ -139,6 +148,10 @@ Button/styles/focus = SubResource("StyleBoxTexture_si72l")
 Button/styles/hover = SubResource("StyleBoxTexture_rcupm")
 Button/styles/normal = SubResource("StyleBoxTexture_rcupm")
 Button/styles/pressed = SubResource("StyleBoxTexture_w6oc6")
+CheckButton/styles/focus = SubResource("StyleBoxFlat_lerkg")
+CheckButton/styles/hover = SubResource("StyleBoxFlat_lerkg")
+CheckButton/styles/normal = SubResource("StyleBoxEmpty_7k42u")
+CheckButton/styles/pressed = SubResource("StyleBoxEmpty_lerkg")
 FlatButton/colors/font_hover_color = Color(1, 1, 1, 1)
 FlatButton/styles/focus = SubResource("StyleBoxTexture_lerkg")
 FlatButton/styles/hover = SubResource("StyleBoxTexture_q6hjb")


### PR DESCRIPTION
This adds a fullscreen ON/OFF checkbox to the Options menu, that nobody asked but I wanted to implement for a while:

![Captura desde 2025-06-04 13-51-22](https://github.com/user-attachments/assets/d23ecd1d-e986-4444-b08b-182937c8a855)

Like the volume settings, the change is persisted.

Note: I did not want to deal with the theme for now, there is https://github.com/endlessm/threadbare/issues/381 for that.

Note 2: Ideally all settings should be in a single GridContainer, so the labels and controls are aligned. I tried but I wasn't able to make the "Sound Settings" and "Video Settings" labels occupy 2 columns of the grid.