### PR TITLE
Add initial PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -4,7 +4,7 @@ name: Bug
 description: An unexpected problem or behavior
 labels: bug
 type: Bug
-ody:
+body:
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+name: Bug
+description: An unexpected problem or behavior
+labels: bug
+type: Bug
+ody:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file an issue! **Please provide as much
+        detail as you can** so we can properly confirm, triage, and fix your bug.
+
+  - type: textarea
+    id: about
+    attributes:
+      label: Description
+      description: |
+        Describe the bug you're seeing. Provide detail such as **where in the 
+        game** you experienced it and **what you were doing** in the game when
+        it happened. If you can make it happen reliably, **share the steps to 
+        reproduce it**. If possible, please attach screenshots or a short video 
+        clip of the bug.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      description: Make sure you've completed each step and reviewed the [code of conduct](https://github.com/Endless-Access-Community/.github/blob/main/CODE_OF_CONDUCT.md) before submitting
+      options:
+        - label: I've reviewed and agree to follow the code of conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -16,10 +16,10 @@ ody:
     attributes:
       label: Description
       description: |
-        Describe the bug you're seeing. Provide detail such as **where in the 
+        Describe the bug you're seeing. Provide detail such as **where in the
         game** you experienced it and **what you were doing** in the game when
-        it happened. If you can make it happen reliably, **share the steps to 
-        reproduce it**. If possible, please attach screenshots or a short video 
+        it happened. If you can make it happen reliably, **share the steps to
+        reproduce it**. If possible, please attach screenshots or a short video
         clip of the bug.
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+contact_links:
+  - name: Join the Discord
+    url: https://discord.gg/mNtzvvaFXF
+    about: Chat with the team in real-time

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,14 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 contact_links:
+  - name: Playtest feedback
+    about: Tell us about your experience playing Threadbare
+    url: https://github.com/endlessm/threadbare/discussions/categories/playtest-feedback
+
+  - name: Ask a question
+    about: See previously-asked questions and ask your own
+    url: https://github.com/endlessm/threadbare/discussions/categories/q-a
+
   - name: Join the Discord
-    url: https://discord.gg/mNtzvvaFXF
     about: Chat with the team in real-time
+    url: https://discord.gg/mNtzvvaFXF

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!-- Thank you for opening a pull request!
+
+Please double-check that you've opened it against the correct fork and branch; for example, changes proposed to a work-in-progress StoryQuest within a team should target the base branch of the team's forked repository.
+
+See the [base repository and branch] link below for more information. 
+
+Please describe your pull request changes below this line: -->
+
+
+
+
+
+<!-- Replace the [ ] with [x] to check the following check boxes: -->
+
+- [ ] I've reviewed and agree to follow the [code of conduct]
+- [ ] I've double-checked the [base repository and branch]
+
+
+<!-- Please do not edit this line or anything after it. -->
+
+[code of conduct]: https://github.com/Endless-Access-Community/.github/blob/main/CODE_OF_CONDUCT.md
+
+[base repository and branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request#changing-the-branch-range-and-destination-repository

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Please double-check that you've opened it against the correct fork and branch; for example, changes proposed to a work-in-progress StoryQuest within a team should target the base branch of the team's forked repository.
 
-See the [base repository and branch] link below for more information. 
+See the [base repository and branch] link below for more information.
 
 Please describe your pull request changes below this line: -->
 
@@ -21,3 +21,8 @@ Please describe your pull request changes below this line: -->
 [code of conduct]: https://github.com/Endless-Access-Community/.github/blob/main/CODE_OF_CONDUCT.md
 
 [base repository and branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request#changing-the-branch-range-and-destination-repository
+
+<!--
+SPDX-FileCopyrightText: The Threadbare Authors
+SPDX-License-Identifier: MPL-2.0
+-->


### PR DESCRIPTION
Adds a `bug` issue template as well as links to the playtesting feedback discussions, Q&A discussions, and Discord.

Adds a PR template to encourage double-checking the base repo/branch.

Fixes #765