### PR TITLE
Teleporter: Detect instances of spawn_point.tscn

### DIFF
--- a/scenes/game_elements/props/teleporter/teleporter/components/teleporter.gd
+++ b/scenes/game_elements/props/teleporter/teleporter/components/teleporter.gd
@@ -6,12 +6,27 @@ extends Area2D
 
 const SPAWN_POINT_GROUP_NAME: String = "spawn_point"
 
+## Scene to switch to when the player enters this teleport. If empty, the player
+## will teleport within the current scene, to the position specified by [member
+## spawn_point_path].
 @export_file("*.tscn") var next_scene: String:
 	set(new_value):
 		next_scene = new_value
 		_update_available_spawn_points()
 		notify_property_list_changed()
 
+## Which SpawnPoint in [member next_scene] the player character should start at;
+## or blank/NONE to start at the default position in the scene.
+@export var spawn_point_path: NodePath:
+	set(new_val):
+		if new_val == ^"NONE":
+			spawn_point_path = ^""
+		else:
+			spawn_point_path = new_val
+
+@export_group("Transition")
+
+## Whether to use a visual transition effect when the player enters the teleporter.
 @export var use_transition: bool = true:
 	set(new_val):
 		use_transition = new_val
@@ -22,15 +37,6 @@ const SPAWN_POINT_GROUP_NAME: String = "spawn_point"
 
 ## Transition to use when the player leaves this teleport.
 @export var exit_transition: Transition.Effect = Transition.Effect.RIGHT_TO_LEFT_WIPE
-
-## Which SpawnPoint in [member next_scene] the player character should start at;
-## or blank/NONE to start at the default position in the scene.
-@export var spawn_point_path: NodePath:
-	set(new_val):
-		if new_val == ^"NONE":
-			spawn_point_path = ^""
-		else:
-			spawn_point_path = new_val
 
 var _available_spawn_points: Array[NodePath] = []
 


### PR DESCRIPTION
Teleporter has (among other properties) a `next_scene` property, which is the resource path of the scene to switch to when the player enters the teleporter, and a `spawn_point_path` property, which is the `NodePath` within `next_scene` of a `SpawnPoint` (a custom subclass of `Marker2D`). The tricky thing here is that normally an `@export`ed `NodePath` refers to paths within the current scene, but here it refers to a path in a different scene.

To make this property easier to use in the editor, there is custom code which introspects the target of the `next_scene` property, listing all spawn points within, and then exposes the `spawn_point_path` property as an enum listing all those paths, plus a NONE entry to not use a spawn point.

Spawn points in the remote scene are found by their group. `spawn_point.gd` is also a `@tool` script and adds itself to the `spawn_point` group.

However, as well as `spawn_point.gd` we also have a `spawn_point.tscn` scene (which just contains a Marker2D with `spawn_point.gd` attached). When inspecting a `next_scene` with an instance of `spawn_point.tscn`, then the entry in the `SceneState` for `next_scene` does not list the spawn point as being in the spawn_points group. For example, in `frays_end.tscn` we have:

    [node name="SpawnPointAfterIntro" parent="." instance=ExtResource("37_thm8h")]
    position = Vector2(62, 1747)

As a result, if you have a teleporter in another scene that targets `frays_end.tscn`, `SpawnPointAfterIntro` does not appear in the drop-down list.

To fix this, when enumerating nodes in the `SceneState`, check if each one is an instanced scene; if so, get the SceneState for that scene, and also consider the groups for its root node.

Fixes https://github.com/endlessm/threadbare/issues/791