### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,35 @@
+# CODEOWNERS
+#
+# Each line is a file pattern followed by one or more users or teams. Order is
+# important; the last matching pattern takes the most precedence. When someone
+# opens a pull request that only modifies files matching a pattern farther down,
+# only the last-matching owner(s) and not the global owner(s) will be requested 
+# for a review.
+#
+# Prefer listing teams instead of individual users whenever possible for easier
+# access management.
+#
+# This is a living document mapping expertise to the codebase; it can and should
+# be updated over time! See: https://opensauced.pizza/blog/shared-ownership-culture
+#
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: CC0-1.0
+
+# Global (will be requested for review if no more specific match)
+* @endlessm/games
+
+# Learning-related resources; anything that directly affects the learning
+# journey, especially related to documentation that the learning team would need
+# to update.
+pull_request_template.md         @endlessm/learning
+docs/pull_request_template.md    @endlessm/learning
+.github/pull_request_template.md @endlessm/learning
+.github/PULL_REQUEST_TEMPLATE/   @endlessm/learning
+
+# Community stuff; directly affects the community contributor experience and
+# related documentation
+README.md                 @endlessm/community
+.github/ISSUE_TEMPLATE/   @endlessm/community
+issue_template.md         @endlessm/community
+docs/issue_template.md    @endlessm/community
+.github/issue_template.md @endlessm/community

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # Each line is a file pattern followed by one or more users or teams. Order is
 # important; the last matching pattern takes the most precedence. When someone
 # opens a pull request that only modifies files matching a pattern farther down,
-# only the last-matching owner(s) and not the global owner(s) will be requested 
+# only the last-matching owner(s) and not the global owner(s) will be requested
 # for a review.
 #
 # Prefer listing teams instead of individual users whenever possible for easier


### PR DESCRIPTION
Related to #811; document areas of ownership/expertise to enable automatically requesting reviews from specific people/teams. This should be considered a living document that can and should be updated over time as the codebase, knowledge, etc. shifts.

See also: https://opensauced.pizza/blog/shared-ownership-culture

Note that forks will use the CODEOWNERS file from the base repo/branch of the PR (the branch that the PR will modify if merged); this means the upstream CODEOWNERS file unless we update our GitHub app to modify the file (not sure if that's even possible), or have instructors/mentors/maintainers update the file (which sounds annoying). However, in practice **CODEOWNERS only applies if the listed owners have write permissions for the base branch**—so it would not affect forks or cause extra review requests for listed owners.

See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-forks