### PR TITLE
REUSE: Fix duplicate annotation for aseprite files in scenes/

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -20,7 +20,6 @@ path = [
     "scenes/*.tscn",
     "scenes/**/*.tscn",
     "scenes/**/*.tres",
-    "scenes/**/*.aseprite",
     # .import files are largely machine-generated but developers can tweak their contents
     "**/*.import",
 ]


### PR DESCRIPTION
Previously, there were two rules for the pattern scenes/**/*.aseprite, one applying MPL-2.0 and the other applying CC-BY-SA-4.0.

The latter is correct. The former rule is in a block that is meant to cover machine-edited Godot resource files.