### PR TITLE
ci: Only run release CI when release is published

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
   pull_request:
   release:
+    types:
+      - published
   push:
     branches:
       - '*'


### PR DESCRIPTION
Previously, the export workflow was run for any `release` event. But there are several types of `release` events, so previously this workflow would be triggered multiple times when making a release. This is wasted effort because the same artifact can't be attached to the release twice.

Instead, only run the job for the `published` type of `release` event.

Fixes https://github.com/endlessm/threadbare/issues/704

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release