### PR TITLE
tree: Don't randomise scale when editing tree scene itself

### DIFF
--- a/scenes/game_elements/props/tree/components/tree.gd
+++ b/scenes/game_elements/props/tree/components/tree.gd
@@ -22,6 +22,10 @@ func _set_sprite_frames(new_sprite_frames: SpriteFrames) -> void:
 
 
 func _ready() -> void:
+	if Engine.is_editor_hint() and get_tree().edited_scene_root == self:
+		# Don't randomise scale when editing tree scene itself
+		scale = Vector2.ONE
+
 	_set_sprite_frames(sprite_frames)
 	var frames_length: int = animated_sprite_2d.sprite_frames.get_frame_count(
 		animated_sprite_2d.animation


### PR DESCRIPTION
When a tree is instantiated, its scale is randomised. The objective here is to introduce some variation in a forest, without requiring significant manual effort; while still allowing the level designer to choose their own scale if they really want to.

The exact way this works always surprises me when I think about it. When you place a tree into a scene:

1. In `_notification(NOTIFICATION_SCENE_INSTANTIATED)`, the tree sets its own `scale` property to a random value. Call this value `S`. At this point the tree instance is not in the tree and is not ready.

2. Now the tree is added to the scene and becomes ready. Later on you save the enclosing scene; in that scene file, the tree instance has its `scale` property set to `S`.

Next time you load that scene (at runtime or in the editor):

1. The tree receives `NOTIFICATION_SCENE_INSTANTIATED` and sets its `scale` property to a **new** random value. Let's call it `T`.

2. Now the properties that were saved in the scene are reapplied to the tree, so its `scale` property is set back to `S`.

The quirk here is that if you actually want a tree to have scale (1, 1) in your scene, it is not enough to reset the scale property in the inspector because it will be re-randomised next time the scene loads. Instead you need to pin the property, so that its value is saved even though it matches the default. (Unfortunately there is no PROPERTY_USAGE flag that could be added to the scale property to make this the default.)

Anyway, previously whenever you open tree.tscn in the editor, the scale property would be randomised; and when you run the game (saving all scenes) the random value would be persisted to tree.tscn. This is not desired, but is easy to do by mistake.

Special-case the case where the tree itself is being edited, and reset the scale property in that case. This cannot be done in `_notification(NOTIFICATION_SCENE_INSTANTIATED)` because that fires before the scene becomes the edited scene.

Fixes https://github.com/endlessm/threadbare/issues/809