### PR TITLE
Project: Add color codes to filesystem folders

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -51,6 +51,14 @@ window/stretch/mode="viewport"
 
 enabled=PackedStringArray("res://addons/dialogue_manager/plugin.cfg", "res://addons/git_lfs_checker/plugin.cfg", "res://addons/sprite_frames_exported_textures/plugin.cfg")
 
+[file_customization]
+
+folder_colors={
+"res://scenes/quests/lore_quests/": "purple",
+"res://scenes/quests/story_quests/": "green",
+"res://scenes/quests/story_quests/template/": "yellow"
+}
+
 [global_group]
 
 spawn_point=""


### PR DESCRIPTION
Set colors to the scenes/quests subfolders:

- Lore Quests are purple
- Story Quests are green
- Template for Story Quests is yellow

![Captura desde 2025-06-25 09-01-27](https://github.com/user-attachments/assets/dd140a81-2429-4f05-8fc1-a5ce9c510e1e)
