### PR TITLE
Guard: Use correct class for Player

### DIFF
--- a/scenes/game_elements/characters/enemies/guard/components/guard.gd
+++ b/scenes/game_elements/characters/enemies/guard/components/guard.gd
@@ -5,7 +5,7 @@ class_name Guard extends CharacterBody2D
 ## Enemy type that patrols along a path and raises an alert if the player is detected.
 
 ## Emitted when the player is detected.
-signal player_detected(player: Node2D)
+signal player_detected(player: Player)
 
 enum State {
 	## Going along the path.
@@ -89,7 +89,7 @@ var state: State = State.PATROLLING:
 	set = _change_state
 
 # The player that's being detected.
-var _player: Node2D
+var _player: Player
 
 ## Area that represents the sight of the guard. If a player is in this area
 ## and there are no walls in between detected by [member sight_ray_cast], it
@@ -504,22 +504,28 @@ func _set_alert_other_sound_stream(new_value: AudioStream) -> void:
 
 
 func _on_instant_detection_area_body_entered(body: Node2D) -> void:
+	if not body is Player:
+		return
 	state = State.ALERTED
-	player_detected.emit(body)
+	player_detected.emit(body as Player)
 
 
 func _on_detection_area_body_entered(body: Node2D) -> void:
-	_player = body
+	if not body is Player:
+		return
+	_player = body as Player
 	if _is_sight_to_point_blocked(body.global_position):
 		return
 	if player_instantly_detected_on_sight:
 		state = State.ALERTED
-		player_detected.emit(body)
+		player_detected.emit(_player)
 	else:
 		state = State.DETECTING
 
 
 func _on_detection_area_body_exited(body: Node2D) -> void:
+	if not body is Player:
+		return
 	_player = null
 	last_seen_position = body.global_position
 	if state == State.DETECTING:

--- a/scenes/game_logic/stealth_game_logic.gd
+++ b/scenes/game_logic/stealth_game_logic.gd
@@ -16,7 +16,7 @@ func _ready() -> void:
 		guard.player_detected.connect(self._on_player_detected)
 
 
-func _on_player_detected(player: Node2D) -> void:
+func _on_player_detected(player: Player) -> void:
 	player.mode = Player.Mode.DEFEATED
 	await get_tree().create_timer(2.0).timeout
 	SceneSwitcher.reload_with_transition(Transition.Effect.FADE, Transition.Effect.FADE)


### PR DESCRIPTION
The collision methods like body entered return a Node2D. But we must check that the player is the one being returned because the stealth game logic treats the node as a player, changing the mode to Player.Mode.DEFEATED when detected by the guards.