### PR TITLE
AreaFiller: Allow larger separation

### DIFF
--- a/scenes/game_elements/props/area_filler/area_filler.gd
+++ b/scenes/game_elements/props/area_filler/area_filler.gd
@@ -30,7 +30,7 @@ extends Node
 
 ## Minimum separation between placed scenes. The maximum separation is twice
 ## this value.
-@export_range(16.0, 128.0, 1.0) var minimum_separation: float = 64.0
+@export_range(16.0, 256.0, 1.0, "suffix:px", "or_more") var minimum_separation: float = 64.0
 
 @export_tool_button("Refill") var fill_button: Callable = fill
 


### PR DESCRIPTION
Previously the maximum separation was 128px. I found this to be not sparse enough to scatter trees across an otherwise open field.

Increase the upper bound on the exported range to 256px, and add the or_more annotation so that a larger value can be typed into the field.