### PR TITLE
CollectibleItem: Fix collision & stacking

### DIFF
--- a/scenes/game_elements/props/collectible_item/collectible_item.tscn
+++ b/scenes/game_elements/props/collectible_item/collectible_item.tscn
@@ -271,6 +271,10 @@ _data = {
 &"reveal": SubResource("Animation_qy0vu")
 }
 
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_hhgm5"]
+radius = 9.0
+height = 28.0
+
 [node name="CollectibleItem" type="Node2D"]
 script = ExtResource("1_7ff3m")
 
@@ -300,3 +304,12 @@ bus = &"SFX"
 unique_name_in_owner = true
 stream = ExtResource("5_oh62b")
 bus = &"SFX"
+
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
+position = Vector2(1, 14)
+rotation = 1.5708
+shape = SubResource("CapsuleShape2D_hhgm5")
+debug_color = Color(0.976711, 0, 0.409753, 0.42)

--- a/scenes/game_elements/props/collectible_item/collectible_item.tscn
+++ b/scenes/game_elements/props/collectible_item/collectible_item.tscn
@@ -272,7 +272,6 @@ _data = {
 }
 
 [node name="CollectibleItem" type="Node2D"]
-z_index = 1
 script = ExtResource("1_7ff3m")
 
 [node name="InteractArea" parent="." instance=ExtResource("6_j0enh")]


### PR DESCRIPTION
I noticed this while experimenting on #887 – currently CollectibleItems float above the player and you can walk through them. I think this looks bad.

[Screencast from 2025-07-03 20-13-16.webm](https://github.com/user-attachments/assets/61ecfd6f-92e6-4079-824c-7c0477108e24)

Fixed in https://endlessm.github.io/threadbare/branches/endlessm/collectible-item-collision-z_index/#quests/lore_quests/quest_001/1_music_puzzle/music_puzzle