### PR TITLE
CONTRIBUTING: Document how to cite AI-generated images

### DIFF
--- a/assets/first_party/logo/threadbare-logo.png.license
+++ b/assets/first_party/logo/threadbare-logo.png.license
@@ -1,4 +1,4 @@
 SPDX-FileCopyrightText: The Threadbare Authors
 SPDX-License-Identifier: CC-BY-SA-4.0
 
-This image was created using Midjourney.
+This image was created using Midjourney by Joana Filizola.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -130,3 +130,11 @@ happy to help.
 
 For significant contributions, add yourself (or the copyright owner of your
 work, if not you) to the [AUTHORS](../AUTHORS) file.
+
+Assets may not knowingly infringe somebody else's intellectual property. For
+example, a hand-drawn illustration of a Star Wars character cannot be accepted
+by the project, even if the illustration itself is your own original work. By
+contrast, fan art based on an original image where the original image is
+licensed under CC-BY-SA-4.0 or another suitable license is allowed by that
+license and so is acceptable, provided the copyright owner of the original work
+is also cited as a joint owner of the fan art.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -112,6 +112,33 @@ example, [CC0 1.0 Universal](../LICENSES/CC0-1.0) is okay, while
 International](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en) is
 not.
 
+It is common for collections of free game assets to have licensing terms which
+allow the assets to be used in free or commercial games, but do not allow
+redistribution of the assets themselves. Unfortunately, assets under such
+licenses cannot be used in Threadbare, because including the assets in the
+(public) Threadbare Git repository constitutes redistribution. Some examples of
+such unsuitable license terms:
+
+- The [Pixabay Content License](https://pixabay.com/service/license-summary/),
+  which states:
+
+  > You cannot sell or distribute Content (either in digital or physical form)
+  > on a Standalone basis. Standalone means where no creative effort has been
+  > applied to the Content and it remains in substantially the same form as it
+  > exists on our website.
+
+- The current license for [Tiny
+  Swords](https://pixelfrog-assets.itch.io/tiny-swords), which states:
+
+  > You can share these assets as part of tutorials or educational content, as
+  > long as you provide a link to Tiny Swords project page. However, you may not
+  > redistribute, resell, or repackage the assets, even if the files are
+  > modified.
+
+  (The version of Tiny Swords included in `assets/third_party/tiny-swords` in
+  this repository is an older version which was published under the
+  [CC0-1.0](../LICENSES/CC0-1.0.txt) license.)
+
 Source code and assets added to the project should have their copyright owner
 and license described in machine-readable form following the
 [REUSE](https://reuse.software/) specification. For source code, include a

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -165,3 +165,62 @@ contrast, fan art based on an original image where the original image is
 licensed under CC-BY-SA-4.0 or another suitable license is allowed by that
 license and so is acceptable, provided the copyright owner of the original work
 is also cited as a joint owner of the fan art.
+
+## AI-generated assets and code
+
+**We strongly prefer that assets in Threadbare are created by hand, without
+using generative AI.**
+
+While AI tools can be useful as part of a creative process, at Endless Access we
+aim to teach fundamental creative skills through game-making: animation, visual
+design, sound design, game design, etc. We believe that having a solid grounding
+in the underlying skills is necessary to create high-quality art, whatever tools
+are used by the artist.
+
+Handmade assets are also in keeping with the aesthetic of the Threadbare world
+(an environment patched together from fabric, using traditional techniques and
+tools) and our use of free and open source tools to create the game.
+
+All this being said, we do accept assets which have been created partly or
+wholly by AI, provided that:
+
+1. the AI tool used is cited in a corresponding `.license` file;
+
+2. the AI tool's terms of use allows the asset to be placed under a suitable
+   license for this project;
+
+3. the commit message or `.license` file describe who used the AI tool, whether
+   the asset is purely AI-generated or whether the creator modified it after
+   generation or provided another asset as input to the AI tool, and ideally the
+   model (if known) and prompt used.
+
+For example, the current
+[main menu logo](../assets/first_party/logo/threadbare-logo.png)
+was generated with Midjourney, with no modifications. It is accompanied by a
+[`.license` file](../assets/first_party/logo/threadbare-logo.png.license)
+which reads:
+
+```
+SPDX-FileCopyrightText: The Threadbare Authors
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+This image was created using Midjourney by Joana Filizola.
+```
+
+The [Midjourney Terms of Service][midjourney-tos] state that:
+
+> You own all Assets You create with the Services to the fullest extent possible
+> under applicable law.
+
+so we are able to place the resulting asset under
+[CC-BY-SA-4.0](../LICENSES/CC-BY-SA-4.0.txt), the preferred asset license for
+this project.
+
+In their article
+[*Understanding CC Licenses and Generative AI*][cc-ai],
+the Creative Commons team recommends that assets whose creation did not involve
+a significant degree of human creativity should be placed under
+[CC0-1.0](../LICENSES/CC0-1.0.txt).
+
+[midjourney-tos]: https://docs.midjourney.com/hc/en-us/articles/32083055291277-Terms-of-Service
+[cc-ai]: https://creativecommons.org/2023/08/18/understanding-cc-licenses-and-generative-ai/


### PR DESCRIPTION
This codifies what I added in commit
a4e08eb42cfb8dc7bebe66740574320e802eae58, along with a tweak to specify the human who used the AI tool in the `.license` file.