### PR TITLE
gitignore: Ignore *.tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ __MACOSX
 # Archive formats
 *.zip
 *.rar
+
+# Temporary files, created in particular by Godot on Windows if you modify and
+# save a scene in the editor while it is in use by the running game.
+*.tmp


### PR DESCRIPTION
This is suggested by a comment on
https://docs.godotengine.org/en/4.4/tutorials/best_practices/version_control_systems.html and it matches what I have seen in various pull requests from Windows users: if you edit and save a scene in the editor while the game is running and using that scene, the changed version is saved to a file ending `.tmp` alongside the original file, because on Windows you cannot modify a file that is open in another process.