### PR TITLE
Use consistent color for InteractArea CollisionShape2Ds

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/elder.tscn
+++ b/scenes/game_elements/characters/npcs/elder/elder.tscn
@@ -42,7 +42,7 @@ script = ExtResource("4_81yrg")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]
 position = Vector2(7.5, -40)
 shape = SubResource("RectangleShape2D_3eksq")
-debug_color = Color(0.591123, 0.547358, 0, 0.42)
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
 [node name="Sounds" type="Node2D" parent="."]
 

--- a/scenes/game_elements/characters/npcs/talker/talker.tscn
+++ b/scenes/game_elements/characters/npcs/talker/talker.tscn
@@ -36,4 +36,4 @@ interact_label_position = Vector2(0, -100)
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
-debug_color = Color(0.591123, 0.547358, 0, 0.42)
+debug_color = Color(0.600391, 0.54335, 0, 0.42)

--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -471,6 +471,7 @@ character = NodePath("../..")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PlayerInteraction/InteractZone"]
 position = Vector2(47, -30)
 shape = SubResource("RectangleShape2D_blfj0")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
 [node name="InteractMarker" type="Marker2D" parent="PlayerInteraction"]
 unique_name_in_owner = true

--- a/scenes/game_elements/props/checkpoint/checkpoint.tscn
+++ b/scenes/game_elements/props/checkpoint/checkpoint.tscn
@@ -33,4 +33,4 @@ action = "Admire"
 [node name="CollisionShape" type="CollisionShape2D" parent="InteractArea"]
 position = Vector2(1, -4)
 shape = SubResource("CircleShape2D_3xcwf")
-debug_color = Color(0, 0.606449, 0.661205, 0.42)
+debug_color = Color(0.600391, 0.54335, 0, 0.42)

--- a/scenes/game_elements/props/collectible_item/collectible_item.tscn
+++ b/scenes/game_elements/props/collectible_item/collectible_item.tscn
@@ -284,6 +284,7 @@ action = "Collect"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]
 shape = SubResource("CircleShape2D_ghwae")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/scenes/game_elements/props/eternal_loom/eternal_loom.tscn
+++ b/scenes/game_elements/props/eternal_loom/eternal_loom.tscn
@@ -552,6 +552,7 @@ action = "Use Eternal Loom"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]
 position = Vector2(0, 120)
 shape = SubResource("RectangleShape2D_uhynt")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
 [node name="LoomOfferingAnimation" type="Node2D" parent="."]
 z_index = 1

--- a/scenes/game_elements/props/lever/lever.tscn
+++ b/scenes/game_elements/props/lever/lever.tscn
@@ -28,7 +28,7 @@ action = "Toggle"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]
 shape = SubResource("CircleShape2D_ri4rx")
-debug_color = Color(0.591123, 0.547358, 0, 0.42)
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
 position = Vector2(1, -98)

--- a/scenes/game_elements/props/sequence_puzzle_hint_sign/sequence_puzzle_hint_sign.tscn
+++ b/scenes/game_elements/props/sequence_puzzle_hint_sign/sequence_puzzle_hint_sign.tscn
@@ -41,6 +41,7 @@ action = "Examine"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]
 position = Vector2(2, 0)
 shape = SubResource("CircleShape2D_gye5d")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
 [node name="Sounds" type="Node2D" parent="."]
 


### PR DESCRIPTION
Previously, these were a mix of yellowish colors, cyan for checkpoints, and the default color.

Consistently use the same shade of yellow for all interact areas, as well as the player's interact zone. This makes it a bit easier to distinguish the interaction area from the collision area that prevents walking through objects.