### PR TITLE
Track *.ogv files in Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@
 *.wav filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
 *.zip filter=lfs diff=lfs merge=lfs -text
+*.ogv filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
These are video files in an Ogg container.

There are currently no such videos in the tree, but we have just
received a pull request adding one. Video files should certainly be
tracked in Git LFS.
