### PR TITLE
Update copyright owner to Endless Access LLC

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,6 @@
 #
 # SPDX-FileCopyrightText: NONE
 # SPDX-License-Identifier: CC0-1.0
-Endless OS Foundation LLC
+Endless Access LLC
 Omar Mendez
 Miguel Navarro


### PR DESCRIPTION
The legal entity formerly known as Endless OS Foundation LLC has been renamed to Endless Access LLC.