### PR TITLE
HTML export: Add social card metadata

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -28,7 +28,20 @@ vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
 html/export_icon=true
 html/custom_html_shell=""
-html/head_include=""
+html/head_include="<meta property=\"og:title\" content=\"Threadbare\" />
+<meta property=\"og:type\" content=\"website\" />
+<meta property=\"og:description\" content=\"Rebuild an unraveling world\" />
+<meta property=\"og:image\" content=\"https://repository-images.githubusercontent.com/941971441/4633bb09-4b7e-477c-a83b-369b29f23c39\" />
+<meta property=\"og:image:type\" content=\"image/png\" />
+<meta property=\"og:image:width\" content=\"1280\" />
+<meta property=\"og:image:height\" content=\"640\" />
+<meta property=\"og:image:alt\" content=\"A cartoon character carrying a sewing needle & button and wearing a thimble for a hat looks towards an elderly cartoon man with a long white beard, wooden staff, and book.\" />
+
+
+<meta property=\"twitter:card\" content=\"summary_large_image\" />
+<meta property=\"twitter:title\" content=\"Threadbare\" />
+<meta property=\"twitter:description\" content=\"Rebuild an unraveling world\" />
+<meta property=\"twitter:image\" content=\"https://repository-images.githubusercontent.com/941971441/4633bb09-4b7e-477c-a83b-369b29f23c39\" />"
 html/canvas_resize_policy=2
 html/focus_canvas_on_start=true
 html/experimental_virtual_keyboard=false


### PR DESCRIPTION
The image URL corresponds to the repository image for https://github.com/endlessm/threadbare. It will need to be manually updated when that image changes (perhaps by storing the image in the repo and adding a CI check that the export file is updated if the image has changed since the referenced commit) but this will do for now.

Fixes https://github.com/endlessm/threadbare/issues/944