### PR TITLE
Add Talk Behavior node

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: MPL-2.0
 @tool
 class_name Elder
-extends Talker
+extends NPC
 
 const STORYBOOK_SCENE := preload("uid://bhm7fdjvppt8b")
+
+@export var dialogue: DialogueResource = preload("uid://cc3paugq4mma4")
 
 ## Directory of quests that this NPC offers to the player during interactions.
 @export_dir var quest_directory: String
@@ -27,12 +29,19 @@ var chosen_quest: Quest
 var _dialogue_balloon: CanvasLayer
 var _storybook: Storybook
 
+@onready var interact_area: InteractArea = %InteractArea
+@onready var talk_behavior: TalkBehavior = %TalkBehavior
 @onready var _book_sound: AudioStreamPlayer2D = %BookSound
 @onready var _storybook_layer: CanvasLayer = %StorybookLayer
 
 
 func _ready() -> void:
 	super._ready()
+	if Engine.is_editor_hint():
+		return
+	talk_behavior.dialogue = dialogue
+	talk_behavior.before_dialogue = _before_dialogue
+	interact_area.interaction_ended.connect(_on_interaction_ended)
 	animated_sprite_2d.connect("frame_changed", _on_frame_changed)
 
 	if quest_directory:
@@ -52,16 +61,6 @@ func _get_configuration_warnings() -> PackedStringArray:
 	return warnings
 
 
-# Override this talker method so we can vary the dialogue title based on
-# whether the loom offering is possible.
-func _on_interaction_started(player: Player, _from_right: bool) -> void:
-	var title: String = ""
-	if eternal_loom and eternal_loom.is_item_offering_possible():
-		title = "go_to_loom"
-	DialogueManager.dialogue_ended.connect(_on_dialogue_ended, CONNECT_ONE_SHOT)
-	_dialogue_balloon = DialogueManager.show_dialogue_balloon(dialogue, title, [self, player])
-
-
 ## Show a storybook to the player, and wait for them to select a story or close the book.
 func show_storybook() -> void:
 	if not _storybook:
@@ -78,11 +77,14 @@ func show_storybook() -> void:
 	_storybook_layer.remove_child(_storybook)
 
 
-func _on_dialogue_ended(dialogue_resource: DialogueResource) -> void:
-	super(dialogue_resource)
+func _before_dialogue() -> void:
+	if eternal_loom and eternal_loom.is_item_offering_possible():
+		talk_behavior.title = "go_to_loom"
 
+
+func _on_interaction_ended() -> void:
 	if chosen_quest:
-		%InteractArea.disabled = true
+		interact_area.disabled = true
 		GameState.start_quest(chosen_quest)
 		SceneSwitcher.change_to_file_with_transition(
 			chosen_quest.first_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE

--- a/scenes/game_elements/characters/npcs/elder/elder.tscn
+++ b/scenes/game_elements/characters/npcs/elder/elder.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=8 format=3 uid="uid://bytkm0r5fe5xb"]
+[gd_scene load_steps=9 format=3 uid="uid://bytkm0r5fe5xb"]
 
 [ext_resource type="Script" uid="uid://dedhjloxblho6" path="res://scenes/game_elements/characters/npcs/elder/components/elder.gd" id="1_jlpjw"]
 [ext_resource type="Resource" uid="uid://ykdgo73x62wa" path="res://scenes/game_elements/characters/npcs/elder/components/story_quest_starter.dialogue" id="2_kqtes"]
 [ext_resource type="SpriteFrames" uid="uid://bpfnbr7ig4s5g" path="res://scenes/game_elements/characters/shared_components/sprite_frames/elder.tres" id="3_ak236"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/components/interact_area.gd" id="4_81yrg"]
+[ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="5_ak236"]
 [ext_resource type="AudioStream" uid="uid://dxbxx6x5h7d8p" path="res://assets/third_party/sounds/characters/npcs/elder/BookPage.ogg" id="5_kqtes"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_3vyb7"]
@@ -43,6 +44,13 @@ script = ExtResource("4_81yrg")
 position = Vector2(7.5, -40)
 shape = SubResource("RectangleShape2D_3eksq")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="TalkBehavior" type="Node" parent="." node_paths=PackedStringArray("interact_area")]
+unique_name_in_owner = true
+script = ExtResource("5_ak236")
+dialogue = ExtResource("2_kqtes")
+interact_area = NodePath("../InteractArea")
+metadata/_custom_type_script = "uid://edcifob4jc4s"
 
 [node name="Sounds" type="Node2D" parent="."]
 

--- a/scenes/game_elements/characters/npcs/elder/elder.tscn
+++ b/scenes/game_elements/characters/npcs/elder/elder.tscn
@@ -39,6 +39,7 @@ unique_name_in_owner = true
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("4_81yrg")
+metadata/_custom_type_script = "uid://du8wfijr35r35"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea"]
 position = Vector2(7.5, -40)

--- a/scenes/game_elements/characters/npcs/shared_components/npc.gd
+++ b/scenes/game_elements/characters/npcs/shared_components/npc.gd
@@ -6,6 +6,8 @@ extends CharacterBody2D
 
 const DEFAULT_SPRITE_FRAME: SpriteFrames = preload("uid://cpm5o35ede3qs")
 
+@export var npc_name: String
+
 @export var look_at_side: Enums.LookAtSide = Enums.LookAtSide.LEFT:
 	set = _set_look_at_side
 

--- a/scenes/game_elements/characters/npcs/talker/components/talker.gd
+++ b/scenes/game_elements/characters/npcs/talker/components/talker.gd
@@ -6,7 +6,6 @@ extends NPC
 
 const DEFAULT_DIALOGUE: DialogueResource = preload("uid://cc3paugq4mma4")
 
-@export var npc_name: String
 @export var dialogue: DialogueResource = DEFAULT_DIALOGUE
 
 var _previous_look_at_side: Enums.LookAtSide = Enums.LookAtSide.UNSPECIFIED
@@ -19,8 +18,6 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 	interact_area.interaction_started.connect(_on_interaction_started)
-	if npc_name:
-		interact_area.action = "Talk to %s" % npc_name
 
 
 func _on_interaction_started(player: Player, from_right: bool) -> void:

--- a/scenes/game_elements/characters/npcs/talker/components/talker.gd
+++ b/scenes/game_elements/characters/npcs/talker/components/talker.gd
@@ -4,30 +4,28 @@
 class_name Talker
 extends NPC
 
-const DEFAULT_DIALOGUE: DialogueResource = preload("uid://cc3paugq4mma4")
-
-@export var dialogue: DialogueResource = DEFAULT_DIALOGUE
+@export var dialogue: DialogueResource = preload("uid://cc3paugq4mma4")
 
 var _previous_look_at_side: Enums.LookAtSide = Enums.LookAtSide.UNSPECIFIED
 
 @onready var interact_area: InteractArea = %InteractArea
+@onready var talk_behavior: Node = %TalkBehavior
 
 
 func _ready() -> void:
 	super._ready()
 	if Engine.is_editor_hint():
 		return
+	talk_behavior.dialogue = dialogue
 	interact_area.interaction_started.connect(_on_interaction_started)
+	interact_area.interaction_ended.connect(_on_interaction_ended)
 
 
-func _on_interaction_started(player: Player, from_right: bool) -> void:
+func _on_interaction_started(_player: Player, from_right: bool) -> void:
 	_previous_look_at_side = look_at_side
 	if look_at_side != Enums.LookAtSide.UNSPECIFIED:
 		look_at_side = Enums.LookAtSide.RIGHT if from_right else Enums.LookAtSide.LEFT
-	DialogueManager.dialogue_ended.connect(_on_dialogue_ended, CONNECT_ONE_SHOT)
-	DialogueManager.show_dialogue_balloon(dialogue, "", [self, player])
 
 
-func _on_dialogue_ended(_dialogue_resource: DialogueResource) -> void:
+func _on_interaction_ended() -> void:
 	look_at_side = _previous_look_at_side
-	interact_area.interaction_ended.emit()

--- a/scenes/game_elements/characters/npcs/talker/components/talker.gd
+++ b/scenes/game_elements/characters/npcs/talker/components/talker.gd
@@ -3,6 +3,7 @@
 @tool
 class_name Talker
 extends NPC
+## @deprecated: Instead of instantiating this class, use a [TalkBehavior] node instead.
 
 @export var dialogue: DialogueResource = preload("uid://cc3paugq4mma4")
 

--- a/scenes/game_elements/characters/npcs/talker/talker.tscn
+++ b/scenes/game_elements/characters/npcs/talker/talker.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=6 format=3 uid="uid://ipvcfv2g0oi1"]
+[gd_scene load_steps=7 format=3 uid="uid://ipvcfv2g0oi1"]
 
 [ext_resource type="Script" uid="uid://mbfqmrnr6h06" path="res://scenes/game_elements/characters/npcs/talker/components/talker.gd" id="1_yqle0"]
 [ext_resource type="SpriteFrames" uid="uid://cpm5o35ede3qs" path="res://scenes/game_elements/characters/npcs/npc_prop/sprite_frames/fray_idle_purple.tres" id="2_o8ron"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/components/interact_area.gd" id="3_c0xhn"]
+[ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="4_t2xbo"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_3vyb7"]
 height = 42.0
@@ -37,3 +38,9 @@ interact_label_position = Vector2(0, -100)
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="TalkBehavior" type="Node" parent="." node_paths=PackedStringArray("interact_area")]
+unique_name_in_owner = true
+script = ExtResource("4_t2xbo")
+interact_area = NodePath("../InteractArea")
+metadata/_custom_type_script = "uid://edcifob4jc4s"

--- a/scenes/game_elements/props/checkpoint/checkpoint.tscn
+++ b/scenes/game_elements/props/checkpoint/checkpoint.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=6 format=3 uid="uid://dua6mynlw2ptw"]
+[gd_scene load_steps=7 format=3 uid="uid://dua6mynlw2ptw"]
 
 [ext_resource type="Script" uid="uid://bk5ri1yoakaqp" path="res://scenes/game_elements/props/checkpoint/components/checkpoint.gd" id="1_kkoqv"]
 [ext_resource type="Script" uid="uid://0enyu5v4ra34" path="res://scenes/game_elements/props/spawn_point/components/spawn_point.gd" id="2_s5d1s"]
 [ext_resource type="SpriteFrames" uid="uid://dmg1egdoye3ns" path="res://scenes/game_elements/props/checkpoint/components/knitwitch_frames_purple.tres" id="4_3xcwf"]
 [ext_resource type="PackedScene" uid="uid://dutgnbiy7xalb" path="res://scenes/game_elements/props/interact_area/interact_area.tscn" id="4_cukws"]
+[ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="5_3xcwf"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_3xcwf"]
 radius = 48.0
@@ -34,3 +35,9 @@ action = "Admire"
 position = Vector2(1, -4)
 shape = SubResource("CircleShape2D_3xcwf")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="TalkBehavior" type="Node" parent="." node_paths=PackedStringArray("interact_area")]
+unique_name_in_owner = true
+script = ExtResource("5_3xcwf")
+interact_area = NodePath("../InteractArea")
+metadata/_custom_type_script = "uid://edcifob4jc4s"

--- a/scenes/game_elements/props/checkpoint/components/checkpoint.gd
+++ b/scenes/game_elements/props/checkpoint/components/checkpoint.gd
@@ -36,6 +36,7 @@ const REQUIRED_ANIMATIONS := [&"idle", &"appear"]
 @onready var sprite: AnimatedSprite2D = %Sprite
 
 @onready var interact_area: InteractArea = %InteractArea
+@onready var talk_behavior: TalkBehavior = %TalkBehavior
 
 
 func _set_sprite_frames(new_sprite_frames: SpriteFrames) -> void:
@@ -62,9 +63,11 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
+	talk_behavior.dialogue = dialogue
 	sprite.visible = false
 	body_entered.connect(func(_body: Node2D) -> void: self.activate())
 	interact_area.interaction_started.connect(_on_interaction_started)
+	interact_area.interaction_ended.connect(_on_interaction_ended)
 
 
 ## Makes this the active checkpoint.
@@ -80,11 +83,9 @@ func activate() -> void:
 	sprite.play(&"idle")
 
 
-func _on_interaction_started(player: Player, from_right: bool) -> void:
+func _on_interaction_started(_player: Player, from_right: bool) -> void:
 	sprite.flip_h = from_right
 
-	DialogueManager.show_dialogue_balloon(dialogue, "", [self, player])
-	await DialogueManager.dialogue_ended
 
+func _on_interaction_ended() -> void:
 	sprite.flip_h = false
-	interact_area.interaction_ended.emit()

--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
@@ -13,12 +13,17 @@ const SOKOBANS := [
 	"uid://b64uft76tbblp",
 ]
 
+var _have_threads := is_item_offering_possible()
+
 @onready var interact_area: InteractArea = %InteractArea
+@onready var talk_behavior: TalkBehavior = %TalkBehavior
 @onready var loom_offering_animation_player: AnimationPlayer = %LoomOfferingAnimationPlayer
 
 
 func _ready() -> void:
-	interact_area.interaction_started.connect(self._on_interacted)
+	talk_behavior.dialogue = ETERNAL_LOOM_INTERACTION
+	talk_behavior.title = "have_threads" if _have_threads else "no_threads"
+	interact_area.interaction_ended.connect(self._on_interaction_ended)
 
 	if GameState.incorporating_threads:
 		if Transitions.is_running():
@@ -31,16 +36,8 @@ func _ready() -> void:
 		GameState.set_incorporating_threads(false)
 
 
-func _on_interacted(player: Player, _from_right: bool) -> void:
-	var have_threads := is_item_offering_possible()
-
-	var title := "have_threads" if have_threads else "no_threads"
-	DialogueManager.show_dialogue_balloon(ETERNAL_LOOM_INTERACTION, title, [self, player])
-	await DialogueManager.dialogue_ended
-
-	interact_area.end_interaction()
-
-	if have_threads:
+func _on_interaction_ended() -> void:
+	if _have_threads:
 		# Hide interact label during scene transition
 		interact_area.disabled = true
 

--- a/scenes/game_elements/props/eternal_loom/eternal_loom.tscn
+++ b/scenes/game_elements/props/eternal_loom/eternal_loom.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=29 format=3 uid="uid://712saqgof3kf"]
+[gd_scene load_steps=30 format=3 uid="uid://712saqgof3kf"]
 
 [ext_resource type="Script" uid="uid://dj5shb75ckk2a" path="res://scenes/game_elements/props/eternal_loom/components/eternal_loom.gd" id="1_0f752"]
 [ext_resource type="Texture2D" uid="uid://cj62bpasgf643" path="res://scenes/game_elements/props/eternal_loom/components/eternal_loom_blue.png" id="2_dj2yp"]
 [ext_resource type="PackedScene" uid="uid://dutgnbiy7xalb" path="res://scenes/game_elements/props/interact_area/interact_area.tscn" id="3_kyhkd"]
 [ext_resource type="Texture2D" uid="uid://5wscjc8yqqts" path="res://assets/first_party/collectibles/world_memory.png" id="4_12bvc"]
+[ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="4_eq7jh"]
 [ext_resource type="Texture2D" uid="uid://6bf8rum68wq3" path="res://assets/first_party/collectibles/world_imagination.png" id="5_eq7jh"]
 [ext_resource type="Texture2D" uid="uid://cepg1o3ihp055" path="res://assets/first_party/collectibles/world_spirit.png" id="6_hfqem"]
 [ext_resource type="AudioStream" uid="uid://bg8u4en3hlo6w" path="res://assets/third_party/sounds/eternal_loom/EternalLoomShort.ogg" id="7_12bvc"]
@@ -553,6 +554,12 @@ action = "Use Eternal Loom"
 position = Vector2(0, 120)
 shape = SubResource("RectangleShape2D_uhynt")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="TalkBehavior" type="Node" parent="." node_paths=PackedStringArray("interact_area")]
+unique_name_in_owner = true
+script = ExtResource("4_eq7jh")
+interact_area = NodePath("../InteractArea")
+metadata/_custom_type_script = "uid://edcifob4jc4s"
 
 [node name="LoomOfferingAnimation" type="Node2D" parent="."]
 z_index = 1

--- a/scenes/game_logic/talk_behavior.gd
+++ b/scenes/game_logic/talk_behavior.gd
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name TalkBehavior
+extends Node
+## Display a dialogue when interacted.
+##
+## It displays the [member dialogue] passing the parent node and the player as the extra game
+## state.
+## If [member title] is set, it will display the dialogue at that title.[br][br]
+## When the dialogue ends, it finishes the interaction by calling [method
+## InteractArea.end_interaction].
+## If the parent is an NPC, it sets the [member InteractArea.action] to "Talk to NAME",
+## where NAME is the [member NPC.npc_name].[br][br]
+## Optionally, an awaitable function can be passed to [member before_dialogue] if
+## something needs to happen before the [member dialogue] is displayed. This can be used,
+## for example, to dynamically set the [member title] of the dialogue considering the
+## game state at the moment the interaction happens.
+
+@export var dialogue: DialogueResource = preload("uid://cc3paugq4mma4")
+@export var title: String = ""
+@export var before_dialogue: Callable
+@export var interact_area: InteractArea:
+	set = _set_interact_area
+
+
+func _set_interact_area(new_interact_area: InteractArea) -> void:
+	interact_area = new_interact_area
+	update_configuration_warnings()
+
+
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings: PackedStringArray
+	if not interact_area:
+		warnings.append("Interact Area property must be set.")
+	return warnings
+
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		return
+	interact_area.interaction_started.connect(_on_interaction_started)
+
+	if get_parent() is NPC:
+		var npc = get_parent() as NPC
+		if npc.npc_name:
+			interact_area.action = "Talk to %s" % npc.npc_name
+
+
+func _on_interaction_started(player: Player, _from_right: bool) -> void:
+	if before_dialogue:
+		await before_dialogue.call()
+	DialogueManager.show_dialogue_balloon(dialogue, title, [get_parent(), player])
+	await DialogueManager.dialogue_ended
+	interact_area.end_interaction()

--- a/scenes/game_logic/talk_behavior.gd.uid
+++ b/scenes/game_logic/talk_behavior.gd.uid
@@ -1,0 +1,1 @@
+uid://edcifob4jc4s

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -298,10 +298,10 @@ sprite_frames = ExtResource("22_e453w")
 
 [node name="LoreQuestElder" parent="NPCs" node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_xt3dw")]
 position = Vector2(690, 600)
+dialogue = ExtResource("12_yntpr")
 quest_directory = "res://scenes/quests/lore_quests/"
 eternal_loom = NodePath("../../EternalLoom")
 npc_name = "LoreQuest Elder"
-dialogue = ExtResource("12_yntpr")
 
 [node name="StoryQuestElder" parent="NPCs" node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_xt3dw")]
 position = Vector2(1310, 598)


### PR DESCRIPTION
This node wraps few logic, but it is a reusable component that lets developers easily trigger dialogues when the player interacts with an area, with only setup and no scripting. Hopefully it will help learners create their own talkers.

Fixes https://github.com/endlessm/threadbare/issues/950