### PR TITLE
Play from Fray's End when running from the Editor

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Threadbare"
-run/main_scene="uid://huuo8mnwsphv"
+run/main_scene="uid://blduub8yuhb2h"
 config/features=PackedStringArray("4.4", "GL Compatibility")
 config/icon="uid://bc70phmq55dkf"
 

--- a/scenes/loader.tscn
+++ b/scenes/loader.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=2 format=3 uid="uid://blduub8yuhb2h"]
+
+[sub_resource type="GDScript" id="GDScript_uc6ls"]
+script/source = "extends Node
+
+const SPLASH = preload(\"uid://huuo8mnwsphv\")
+const FRAYS_END = preload(\"uid://cufkthb25mpxy\")
+
+func _ready() -> void:
+	var initial_scene := FRAYS_END if OS.has_feature(\"editor\") else SPLASH
+	get_tree().call_deferred(\"change_scene_to_packed\", initial_scene)
+"
+
+[node name="Loader" type="Node"]
+script = SubResource("GDScript_uc6ls")


### PR DESCRIPTION
Change the project main scene to be a new loader scene. The only thing that this scene does is to switch to the Splash scene if the game is not running in the editor, and to Fray's End if the game is running in the editor.

Fray's End is the actual main scene of the game. For development, it is better to skip the splash and intro and land directly in Fray's End.

Playing from the Splash scene is still possible by opening that scene in the Editor and clicking the "Run Current Scene" button.