### PR TITLE
InteractArea: Warn if it doesn't belong to its collision layer

### DIFF
--- a/scenes/game_elements/props/interact_area/components/interact_area.gd
+++ b/scenes/game_elements/props/interact_area/components/interact_area.gd
@@ -36,6 +36,21 @@ func get_global_interact_label_position() -> Vector2:
 	return to_global(interact_label_position)
 
 
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings: PackedStringArray
+	if not disabled and not get_collision_layer_value(INTERACTABLE_LAYER):
+		warnings.append(
+			"Consider enabling collision with the interactable layer: %d." % INTERACTABLE_LAYER
+		)
+	return warnings
+
+
+func _set(property: StringName, _value: Variant) -> bool:
+	if property == "collision_layer":
+		update_configuration_warnings()
+	return false
+
+
 func _draw() -> void:
 	if not Engine.is_editor_hint():
 		return


### PR DESCRIPTION
The InteractArea instantiated scene or node is supposed to be in a particular collision layer. So add a warning if not. Override the _set() virtual method to update the warnings when the collision layers change.