### PR TITLE
Default dialogue: Remove reference to npc_name

### DIFF
--- a/scenes/game_elements/characters/npcs/talker/components/default.dialogue
+++ b/scenes/game_elements/characters/npcs/talker/components/default.dialogue
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-{{npc_name}}: [[Hi|Hello|Greetings]], {{player_name}}.
+[[Hi|Hello|Greetings]], {{player_name}}.
 => END


### PR DESCRIPTION
The new TalkBehavior node can be added anywhere, so the default dialogue shouldn't assume that the parent node is an NPC.