### PR TITLE
Add character walk behaviors

### DIFF
--- a/scenes/game_elements/characters/components/gym_area_test.tscn
+++ b/scenes/game_elements/characters/components/gym_area_test.tscn
@@ -1,13 +1,78 @@
-[gd_scene load_steps=9 format=4 uid="uid://ikgvi75j5dls"]
+[gd_scene load_steps=29 format=4 uid="uid://ikgvi75j5dls"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_5xpm5"]
-[ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="2_5127f"]
 [ext_resource type="SpriteFrames" uid="uid://07di3updrwh0" path="res://scenes/game_elements/characters/components/sprite_frames/storyweaver_purple.tres" id="3_6axvd"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="3_7132a"]
 [ext_resource type="SpriteFrames" uid="uid://brspwu70qbdaf" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_blue.tres" id="4_5127f"]
 [ext_resource type="SpriteFrames" uid="uid://2ek86nvw6y28" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_yellow.tres" id="5_7132a"]
 [ext_resource type="PackedScene" uid="uid://bbsc3wssndtfe" path="res://scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.tscn" id="6_l45sp"]
 [ext_resource type="PackedScene" uid="uid://dv4f232y8w8dv" path="res://scenes/game_elements/props/decoration/water_rock/water_rock.tscn" id="7_1aydi"]
+[ext_resource type="SpriteFrames" uid="uid://b3r84ksew5djp" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_purple.tres" id="9_6nfeg"]
+[ext_resource type="Script" uid="uid://cx0sk4uhvnii0" path="res://scenes/game_logic/erratic_walk_behavior.gd" id="10_k43ew"]
+[ext_resource type="Script" uid="uid://q4jj6ou7yonf" path="res://scenes/game_logic/bounce_walk_behavior.gd" id="11_utmd2"]
+[ext_resource type="Script" uid="uid://cwoclmik3db2" path="res://scenes/game_logic/follow_walk_behavior.gd" id="12_w4jvh"]
+[ext_resource type="SpriteFrames" uid="uid://qwlhm21ndgn2" path="res://scenes/game_elements/characters/enemies/guard/components/storyvore_frames_orange.tres" id="12_wq1h3"]
+[ext_resource type="SpriteFrames" uid="uid://3ujiuhj7wpm2" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_red.tres" id="13_wq1h3"]
+[ext_resource type="Script" uid="uid://c8xbryhknipab" path="res://scenes/game_logic/input_walk_behavior.gd" id="15_k43ew"]
+[ext_resource type="Script" uid="uid://dy68p7gf07pi3" path="res://scenes/game_logic/character_sprite_behavior.gd" id="15_utmd2"]
+[ext_resource type="Texture2D" uid="uid://dxaq5piwxqnht" path="res://scenes/game_elements/characters/player/components/dust.png" id="16_w4jvh"]
+[ext_resource type="SpriteFrames" uid="uid://r3dn5pxqk1sv" path="res://scenes/game_elements/characters/enemies/guard/components/storyvore_frames_gray.tres" id="17_w4jvh"]
+[ext_resource type="Script" uid="uid://id28maao3vdy" path="res://scenes/game_logic/path_walk_behavior.gd" id="18_wq1h3"]
+
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_oojqe"]
+
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_3vyb7"]
+height = 42.0
+
+[sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_wq1h3"]
+blend_mode = 1
+particles_animation = true
+particles_anim_h_frames = 5
+particles_anim_v_frames = 1
+particles_anim_loop = false
+
+[sub_resource type="Curve" id="Curve_itker"]
+_data = [Vector2(0, 1), 0.0, 0.0, 0, 0, Vector2(1e-05, 1), 0.0, 0.0, 0, 0, Vector2(1, 0), -1.71104, 0.0, 0, 0]
+point_count = 3
+
+[sub_resource type="CurveTexture" id="CurveTexture_j0tly"]
+curve = SubResource("Curve_itker")
+
+[sub_resource type="CurveXYZTexture" id="CurveXYZTexture_3in67"]
+
+[sub_resource type="ParticleProcessMaterial" id="ParticleProcessMaterial_oojqe"]
+particle_flag_disable_z = true
+emission_shape = 1
+emission_sphere_radius = 25.0
+spread = 0.0
+initial_velocity_min = -40.0
+initial_velocity_max = -10.0
+directional_velocity_min = 1.0
+directional_velocity_max = 1.0
+directional_velocity_curve = SubResource("CurveXYZTexture_3in67")
+gravity = Vector3(0, 0, 0)
+scale_max = 1.5
+alpha_curve = SubResource("CurveTexture_j0tly")
+anim_speed_min = 1.0
+anim_speed_max = 1.0
+
+[sub_resource type="GDScript" id="GDScript_w4jvh"]
+script/source = "extends GPUParticles2D
+
+
+func _on_input_walk_behavior_running_changed(is_running: bool) -> void:
+	emitting = is_running
+"
+
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_itker"]
+radius = 13.0
+height = 66.0
+
+[sub_resource type="Curve2D" id="Curve2D_wq1h3"]
+_data = {
+"points": PackedVector2Array(-30.7395, -24.1992, 30.7395, 24.1992, 138, 42, -34.3214, -51.6631, 34.3214, 51.6631, 464, 60, -4.09808, -51.226, 4.09808, 51.226, 485, 563, 114.063, -1.36603, -114.063, 1.36603, 323, 682, 63.8618, -12.7724, -63.8618, 12.7724, -335, 678, 35.585, 52.1139, -35.585, -52.1139, -502, 645, 13.6603, 56.5038, -13.6603, -56.5038, -500, 93, -94.38, 15.523, 94.38, -15.523, -463, -136, -100.476, 1.69342, 100.476, -1.69342, -229, -129, -38.0165, -26.4463, 38.0165, 26.4463, 18, -121, -30.739, -24.199, 0, 0, 138, 42)
+}
+point_count = 11
 
 [node name="TestGymArea" type="Node2D"]
 
@@ -35,15 +100,6 @@ tile_set = ExtResource("1_5xpm5")
 
 [node name="OnTheGround" type="Node2D" parent="."]
 y_sort_enabled = true
-
-[node name="Player" parent="OnTheGround" instance=ExtResource("2_5127f")]
-position = Vector2(1312, 740)
-sprite_frames = ExtResource("3_6axvd")
-
-[node name="Camera2D" type="Camera2D" parent="OnTheGround/Player"]
-limit_left = -320
-limit_top = -640
-editor_draw_limits = true
 
 [node name="Decoration" type="Node2D" parent="OnTheGround"]
 y_sort_enabled = true
@@ -96,4 +152,157 @@ position = Vector2(1415, -187)
 [node name="WaterRock6" parent="OnTheGround/Decoration" instance=ExtResource("7_1aydi")]
 position = Vector2(1578, 1718)
 
+[node name="CharacterBody2D" type="CharacterBody2D" parent="OnTheGround"]
+position = Vector2(1594, 896)
+collision_layer = 2
+collision_mask = 531
+motion_mode = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/CharacterBody2D"]
+rotation = -1.57079
+shape = SubResource("CapsuleShape2D_oojqe")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="OnTheGround/CharacterBody2D"]
+position = Vector2(0, -37)
+sprite_frames = ExtResource("9_6nfeg")
+animation = &"idle"
+
+[node name="CharacterSpriteBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D/AnimatedSprite2D" node_paths=PackedStringArray("character")]
+script = ExtResource("15_utmd2")
+character = NodePath("../..")
+metadata/_custom_type_script = "uid://dy68p7gf07pi3"
+
+[node name="ErraticWalkBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D"]
+script = ExtResource("10_k43ew")
+travel_distance = 100.0
+metadata/_custom_type_script = "uid://cx0sk4uhvnii0"
+
+[node name="CharacterBody2D2" type="CharacterBody2D" parent="OnTheGround"]
+position = Vector2(921, 621)
+collision_layer = 2
+collision_mask = 531
+motion_mode = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/CharacterBody2D2"]
+rotation = -1.57079
+shape = SubResource("CapsuleShape2D_oojqe")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="OnTheGround/CharacterBody2D2"]
+position = Vector2(0, -37)
+sprite_frames = ExtResource("13_wq1h3")
+animation = &"idle"
+
+[node name="CharacterSpriteBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D2/AnimatedSprite2D" node_paths=PackedStringArray("character")]
+position = Vector2(0, 37)
+script = ExtResource("15_utmd2")
+character = NodePath("../..")
+metadata/_custom_type_script = "uid://dy68p7gf07pi3"
+
+[node name="FollowWalkBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D2" node_paths=PackedStringArray("target")]
+script = ExtResource("12_w4jvh")
+walk_speed = 170.0
+target = NodePath("../../CharacterBody2D")
+metadata/_custom_type_script = "uid://cwoclmik3db2"
+
+[node name="CharacterBody2D3" type="CharacterBody2D" parent="OnTheGround"]
+position = Vector2(1691, 621)
+collision_layer = 2
+collision_mask = 531
+motion_mode = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/CharacterBody2D3"]
+rotation = -1.57079
+shape = SubResource("CapsuleShape2D_oojqe")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="OnTheGround/CharacterBody2D3"]
+position = Vector2(0, -37)
+sprite_frames = ExtResource("12_wq1h3")
+animation = &"idle"
+
+[node name="CharacterSpriteBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D3/AnimatedSprite2D" node_paths=PackedStringArray("character")]
+script = ExtResource("15_utmd2")
+character = NodePath("../..")
+metadata/_custom_type_script = "uid://dy68p7gf07pi3"
+
+[node name="BounceWalkBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D3"]
+script = ExtResource("11_utmd2")
+walk_speed = 50.0
+metadata/_custom_type_script = "uid://q4jj6ou7yonf"
+
+[node name="CharacterBody2D4" type="CharacterBody2D" parent="OnTheGround" groups=["player"]]
+position = Vector2(1312, 760.076)
+collision_mask = 531
+motion_mode = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/CharacterBody2D4"]
+rotation = -1.57079
+shape = SubResource("CapsuleShape2D_3vyb7")
+
+[node name="GPUParticles2D" type="GPUParticles2D" parent="OnTheGround/CharacterBody2D4"]
+modulate = Color(1, 1, 1, 0.498039)
+material = SubResource("CanvasItemMaterial_wq1h3")
+position = Vector2(0, -6)
+emitting = false
+amount = 6
+texture = ExtResource("16_w4jvh")
+lifetime = 0.5
+randomness = 0.6
+fixed_fps = 10
+process_material = SubResource("ParticleProcessMaterial_oojqe")
+script = SubResource("GDScript_w4jvh")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="OnTheGround/CharacterBody2D4"]
+position = Vector2(0, -17)
+sprite_frames = ExtResource("3_6axvd")
+animation = &"idle"
+
+[node name="CharacterSpriteBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D4/AnimatedSprite2D" node_paths=PackedStringArray("character")]
+script = ExtResource("15_utmd2")
+character = NodePath("../..")
+metadata/_custom_type_script = "uid://dy68p7gf07pi3"
+
+[node name="InputWalkBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D4"]
+script = ExtResource("15_k43ew")
+metadata/_custom_type_script = "uid://c8xbryhknipab"
+
+[node name="Camera2D" type="Camera2D" parent="OnTheGround/CharacterBody2D4"]
+limit_left = -320
+limit_top = -640
+editor_draw_limits = true
+
+[node name="CharacterBody2D5" type="CharacterBody2D" parent="OnTheGround"]
+position = Vector2(977, 907)
+collision_layer = 2
+collision_mask = 531
+motion_mode = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/CharacterBody2D5"]
+rotation = -1.57079
+shape = SubResource("CapsuleShape2D_itker")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="OnTheGround/CharacterBody2D5"]
+position = Vector2(0, -27)
+sprite_frames = ExtResource("17_w4jvh")
+animation = &"idle"
+
+[node name="CharacterSpriteBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D5/AnimatedSprite2D" node_paths=PackedStringArray("character")]
+position = Vector2(0, 37)
+script = ExtResource("15_utmd2")
+character = NodePath("../..")
+metadata/_custom_type_script = "uid://dy68p7gf07pi3"
+
+[node name="PathWalkBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D5" node_paths=PackedStringArray("walking_path")]
+script = ExtResource("18_wq1h3")
+walk_speed = 90.0
+stuck_speed = 20.0
+walking_path = NodePath("../../Path2D")
+metadata/_custom_type_script = "uid://id28maao3vdy"
+
+[node name="Path2D" type="Path2D" parent="OnTheGround"]
+position = Vector2(839, 865)
+curve = SubResource("Curve2D_wq1h3")
+
 [node name="ScreenOverlay" type="CanvasLayer" parent="."]
+
+[connection signal="running_changed" from="OnTheGround/CharacterBody2D4/InputWalkBehavior" to="OnTheGround/CharacterBody2D4/GPUParticles2D" method="_on_input_walk_behavior_running_changed"]
+[connection signal="running_changed" from="OnTheGround/CharacterBody2D4/InputWalkBehavior" to="OnTheGround/CharacterBody2D4/AnimatedSprite2D/CharacterSpriteBehavior" method="on_running_changed"]

--- a/scenes/game_logic/bounce_walk_behavior.gd
+++ b/scenes/game_logic/bounce_walk_behavior.gd
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name BounceWalkBehavior
+extends Node2D
+## @experimental
+##
+## Make the character move and bounce on walls.
+
+## Emitted when [member direction] is updated.
+signal direction_changed
+
+## The character walking speed.
+@export_range(10, 1000, 10, "or_greater", "suffix:m/s") var walk_speed: float = 300.0
+
+## The speed to consider that the character is stuck.
+## If less than [member walk_speed], the character may slide on walls instead of bouncing.
+@export_range(0, 1000, 10, "or_greater", "suffix:m/s") var stuck_speed: float = 300.0
+
+## If set, ignore the [member initial_angle] and pick a random one instead.
+@export var pick_random_initial_angle: bool = false:
+	set(value):
+		pick_random_initial_angle = value
+		notify_property_list_changed()
+
+## Angle of the initial direction.
+@export_range(0, 360, 1, "radians_as_degrees") var initial_angle: float = PI / 4.0
+
+## The current direction as a unit Vector2.
+var direction: Vector2
+
+## The controlled character.
+@onready var character: CharacterBody2D = get_parent()
+
+
+func _validate_property(property: Dictionary) -> void:
+	if property.name == "initial_angle" and pick_random_initial_angle:
+		property.usage |= PROPERTY_USAGE_READ_ONLY
+
+
+func _update_direction() -> void:
+	if not direction:
+		direction = Vector2.from_angle(
+			randf_range(0, TAU) if pick_random_initial_angle else initial_angle
+		)
+		direction_changed.emit()
+	elif character.is_on_wall():
+		direction = direction.bounce(character.get_wall_normal())
+		direction_changed.emit()
+
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		set_physics_process(false)
+		return
+
+	_update_direction()
+
+
+func _physics_process(_delta: float) -> void:
+	if not direction:
+		_update_direction()
+
+	character.velocity = direction * walk_speed
+	var collided := character.move_and_slide()
+
+	if collided and character.is_on_wall():
+		if character.get_real_velocity().length_squared() <= stuck_speed * stuck_speed:
+			_update_direction()

--- a/scenes/game_logic/bounce_walk_behavior.gd.uid
+++ b/scenes/game_logic/bounce_walk_behavior.gd.uid
@@ -1,0 +1,1 @@
+uid://q4jj6ou7yonf

--- a/scenes/game_logic/character_sprite_behavior.gd
+++ b/scenes/game_logic/character_sprite_behavior.gd
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name CharacterSpriteBehavior
+extends Node2D
+## Flip horizontally and/or play animations in [member sprite] according
+## to the velocity of [member character].
+
+## The [member CharacterBody2D.velocity] is used to change the [member sprite].
+@export var character: CharacterBody2D
+
+## Whether to play the sprite animations or not. If not, the only thing that will happen is that
+## the sprite will be flipped horizontally according to the velocity of [member character].
+## Use this when using more advanced animation through an AnimationPlayer node.
+@export var play_animations: bool = true
+
+var _is_character_running: bool = false
+
+## The controlled sprite.
+@onready var sprite: AnimatedSprite2D = get_parent()
+
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		set_process(false)
+		return
+
+
+func _process(delta: float) -> void:
+	if not character:
+		return
+
+	if play_animations:
+		_process_animations(delta)
+
+	if not is_zero_approx(character.velocity.x):
+		sprite.flip_h = character.velocity.x < 0
+
+
+func _process_animations(_delta: float) -> void:
+	if character.velocity.is_zero_approx():
+		sprite.speed_scale = 1.0
+		sprite.play(&"idle")
+	else:
+		if _is_character_running:
+			if sprite.sprite_frames.has_animation(&"run"):
+				sprite.speed_scale = 1.0
+				sprite.play(&"run")
+			else:
+				sprite.speed_scale = 2.0
+				sprite.play(&"walk")
+		else:
+			sprite.speed_scale = 1.0
+			sprite.play(&"walk")
+
+
+func _notification(what: int) -> void:
+	match what:
+		NOTIFICATION_EDITOR_PRE_SAVE:
+			# Since this is a tool script that plays the animations in the
+			# editor, reset the frame progress before saving the scene.
+			sprite.frame_progress = 0
+
+
+## Force the sprite to flip to a [enum Enums.LookAtSide] direction.
+func look_at_side(side: Enums.LookAtSide) -> void:
+	if side == 0:
+		return
+	sprite.flip_h = side < 0
+
+
+## You can connect this callback to a [member InputWalkBehavior.running_changed] signal.
+func on_running_changed(is_running: bool) -> void:
+	_is_character_running = is_running

--- a/scenes/game_logic/character_sprite_behavior.gd.uid
+++ b/scenes/game_logic/character_sprite_behavior.gd.uid
@@ -1,0 +1,1 @@
+uid://dy68p7gf07pi3

--- a/scenes/game_logic/erratic_walk_behavior.gd
+++ b/scenes/game_logic/erratic_walk_behavior.gd
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name ErraticWalkBehavior
+extends Node2D
+## @experimental
+##
+## Make the character walk around erratically.
+
+## Emitted when [member character] got stuck while walking.
+signal got_stuck
+
+## Emitted when [member direction] is updated.
+signal direction_changed
+
+## The character walking speed.
+@export_range(10, 1000, 10, "or_greater", "suffix:m/s") var walk_speed: float = 300.0
+
+## The speed to consider that the character is stuck.
+## If less than [member walk_speed], the character may slide on walls instead of emitting
+## the [signal got_stuck] signal.
+## If closer to zero, the character may not ever emit the [signal got_stuck] signal.
+@export_range(0, 1000, 10, "or_greater", "suffix:m/s") var stuck_speed: float = 300.0
+
+## The turn direction will be randomly picked between this and [member turn_angle_right].
+@export_range(0, 180, 1, "radians_as_degrees") var turn_angle_left: float = PI / 2.0
+
+## The turn direction will be randomly picked between [member turn_angle_left] and this.
+@export_range(0, 180, 1, "radians_as_degrees") var turn_angle_right: float = PI / 2.0
+
+## The distance to travel between turns.
+## If zero, the character will turn around all the time.
+@export_range(0, 800, 1, "or_greater", "suffix:m") var travel_distance: float = 400.0
+
+## How smooth or sharp is the change of direction.
+## Close to zero: smooth.
+## Close to one: sharp (immediate).
+@export_range(0.1, 1.0, 0.1, "suffix:m") var direction_weight: float = 0.2
+
+## The current walking direction.
+var direction: Vector2
+
+## The current distance travelled since last turn.
+var distance: float = 0
+
+## The controlled character.
+@onready var character: CharacterBody2D = get_parent()
+
+
+func _update_direction() -> void:
+	if not direction:
+		direction = Vector2.from_angle(randf_range(0, TAU))
+	else:
+		direction = direction.rotated(randf_range(-turn_angle_left, turn_angle_right))
+	direction_changed.emit()
+
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		set_physics_process(false)
+		return
+
+
+func _physics_process(delta: float) -> void:
+	if not direction:
+		_update_direction()
+
+	character.velocity = character.velocity.lerp(direction * walk_speed, direction_weight)
+	var collided := character.move_and_slide()
+	if collided and character.is_on_wall():
+		if character.get_real_velocity().length_squared() <= stuck_speed * stuck_speed:
+			got_stuck.emit()
+			_update_direction()
+			distance = 0.0
+	else:
+		distance += walk_speed * delta
+		if distance > travel_distance:
+			_update_direction()
+			distance = 0.0

--- a/scenes/game_logic/erratic_walk_behavior.gd.uid
+++ b/scenes/game_logic/erratic_walk_behavior.gd.uid
@@ -1,0 +1,1 @@
+uid://cx0sk4uhvnii0

--- a/scenes/game_logic/follow_walk_behavior.gd
+++ b/scenes/game_logic/follow_walk_behavior.gd
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name FollowWalkBehavior
+extends Node2D
+## @experimental
+##
+## Make the character follow a target.
+
+## Emitted when [member target] becomes reached or not.
+signal target_reached_changed(is_reached: bool)
+
+## The character walking speed.
+@export_range(10, 1000, 10, "or_greater", "suffix:m/s") var walk_speed: float = 300.0
+
+## The speed to consider that the character is stuck.
+## If less than [member walk_speed], the character may slide on walls instead of emitting
+## the [signal got_stuck] signal.
+## If closer to zero, the character may not ever emit the [signal got_stuck] signal.
+@export_range(0, 1000, 10, "or_greater", "suffix:m/s") var stuck_speed: float = 300.0
+
+## The target to follow.
+@export var target: Node2D:
+	set = _set_target
+
+## How smooth or sharp is the change of direction.
+## Close to zero: smooth.
+## Close to one: sharp (immediate).
+@export_range(0.1, 1.0, 0.1, "suffix:m") var direction_weight: float = 0.2
+
+## The distance to travel between retargetting.
+## If zero, it will constantly retarget.
+@export_range(0, 100, 1, "or_greater", "suffix:m") var travel_distance: float = 50.0
+
+## How close should the character be from the target to emit the [signal target_reached_changed]
+## signal.
+## Note that this distance should be big enough to consider the collision shapes of both
+## the target and this character, if they are set to collide, otherwise the
+## [signal target_reached_changed] signal may not be ever emitted.
+@export_range(0, 400, 1, "or_greater", "suffix:m") var target_reached_distance: float = 200.0
+
+## The current direction as a unit Vector2.
+var direction: Vector2
+
+## The current distance travelled since last direction update.
+var distance: float = 0
+
+## True if the character has reached the target.
+var is_target_reached: bool:
+	set = _set_is_target_reached
+
+## The controlled character.
+@onready var character: CharacterBody2D = get_parent()
+
+
+func _set_target(new_target: Node2D) -> void:
+	target = new_target
+	update_configuration_warnings()
+
+
+func _set_is_target_reached(new_is_target_reached: bool) -> void:
+	if is_target_reached == new_is_target_reached:
+		return
+	is_target_reached = new_is_target_reached
+	target_reached_changed.emit(is_target_reached)
+
+
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings: PackedStringArray
+	if not target:
+		warnings.append("Target property must be set.")
+	return warnings
+
+
+func _update_direction() -> void:
+	direction = character.global_position.direction_to(target.global_position)
+
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		set_physics_process(false)
+		return
+
+	_update_direction()
+
+
+func _physics_process(delta: float) -> void:
+	if not direction:
+		_update_direction()
+
+	character.velocity = character.velocity.lerp(direction * walk_speed, direction_weight)
+	var collided := character.move_and_slide()
+
+	if collided and character.is_on_wall():
+		if character.get_real_velocity().length_squared() <= stuck_speed * stuck_speed:
+			_update_direction()
+	else:
+		distance += walk_speed * delta
+		if distance > travel_distance:
+			_update_direction()
+			distance = 0.0
+
+	is_target_reached = (
+		(character.global_position - target.global_position).length_squared()
+		<= target_reached_distance * target_reached_distance
+	)

--- a/scenes/game_logic/follow_walk_behavior.gd.uid
+++ b/scenes/game_logic/follow_walk_behavior.gd.uid
@@ -1,0 +1,1 @@
+uid://cwoclmik3db2

--- a/scenes/game_logic/input_walk_behavior.gd
+++ b/scenes/game_logic/input_walk_behavior.gd
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name InputWalkBehavior
+extends Node2D
+## @experimental
+##
+## Control the character with input actions to walk and run.
+
+## Emitted when the character starts or stops running.
+signal running_changed(is_running: bool)
+
+## The character walking speed.
+@export_range(10, 1000, 10, "or_greater", "suffix:m/s") var walk_speed: float = 300.0
+
+## The character running speed.
+@export_range(10, 1000, 10, "or_greater", "suffix:m/s") var run_speed: float = 500.0
+
+## How fast does the player transition from walking/running to stopped.
+## A low value will make the character look as slipping on ice.
+## A high value will stop the character immediately.
+@export_range(10, 4000, 10, "or_greater", "suffix:m/s²") var stopping_step: float = 1500.0
+
+## How fast does the player transition from stopped to walking/running.
+@export_range(10, 4000, 10, "or_greater", "suffix:m/s²") var moving_step: float = 4000.0
+
+## The target walking/running velocity according to the input actions.
+var input_vector: Vector2
+
+## True if the character is running according to the input actions.
+var is_running: bool:
+	set = _set_is_running
+
+## The controlled character.
+@onready var character: CharacterBody2D = get_parent()
+
+
+func _set_is_running(new_is_running: bool) -> void:
+	if is_running == new_is_running:
+		return
+	is_running = new_is_running
+	running_changed.emit(is_running)
+
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		set_physics_process(false)
+		return
+
+
+func _unhandled_input(_event: InputEvent) -> void:
+	var axis := Input.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down")
+	var speed: float = run_speed if Input.is_action_pressed(&"running") else walk_speed
+	input_vector = axis * speed
+
+
+func _physics_process(delta: float) -> void:
+	var step: float = stopping_step if input_vector.is_zero_approx() else moving_step
+	character.velocity = character.velocity.move_toward(input_vector, step * delta)
+	character.move_and_slide()
+
+	# When using an analogue joystick, this can be false even if the player is
+	# holding the "run" button, because the joystick may be inclined only slightly.
+	is_running = input_vector.length_squared() > (walk_speed * walk_speed) + 1.0

--- a/scenes/game_logic/input_walk_behavior.gd.uid
+++ b/scenes/game_logic/input_walk_behavior.gd.uid
@@ -1,0 +1,1 @@
+uid://c8xbryhknipab

--- a/scenes/game_logic/path_walk_behavior.gd
+++ b/scenes/game_logic/path_walk_behavior.gd
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name PathWalkBehavior
+extends Node2D
+## @experimental
+##
+## Make the character walk along a path.
+##
+## If the path is closed the character walks in circles. If not, they walk back and forth turning
+## around in endings.
+##
+## If the character gets stuck while walking the path, they turn around.
+
+## Emitted when [member character] reaches the ending of the path.
+signal ending_reached
+
+## Emitted when [member character] got stuck while walking the path.
+signal got_stuck
+
+## Emitted when turning around.
+signal direction_changed
+
+## Emitted when a "pointy" part of the path is reached.
+## This could be used to wait standing for a bit in these points.
+## If the path is not closed, both endings are considered pointy so this signal will also
+## emit in them.
+signal pointy_path_reached
+
+## The character walking speed.
+@export_range(10, 1000, 10, "or_greater", "suffix:m/s") var walk_speed: float = 300.0
+
+## The speed to consider that the character is stuck.
+## If less than [member walk_speed], the character may slide on walls instead of emitting
+## the [signal got_stuck] signal.
+## If closer to zero, the character may not ever emit the [signal got_stuck] signal.
+@export_range(0, 1000, 10, "or_greater", "suffix:m/s") var stuck_speed: float = 300.0
+
+## The walking path.
+@export var walking_path: Path2D:
+	set = _set_walking_path
+
+## If set, the character will turn around when reaching the path ending or when stuck.
+@export var turn_around: bool = true
+
+## Make the "is path continuous" calculation more or less sensitive.
+@export_range(0, 1, 0.01, "or_greater", "suffix:m") var path_continuous_tolerance: float = 0.01
+
+## Make the "is path pointy" calculation more or less sensitive.
+@export_range(0, 100, 1, "or_greater", "suffix:m") var path_pointy_tolerance: float = 20
+
+## Position of the first point relative to the path position.
+var initial_position: Vector2
+
+## This is 1 when walking in the path direction, and -1 when walking in the opposite direction.
+var direction: int = 1:
+	set = _set_direction
+
+# Offset of each point that the character will wait standing.
+var _standing_offsets: Array[float]
+
+## The controlled character.
+@onready var character: CharacterBody2D = get_parent()
+
+
+func _set_walking_path(new_walking_path: Path2D) -> void:
+	walking_path = new_walking_path
+	update_configuration_warnings()
+	if not is_node_ready():
+		return
+	if walking_path:
+		# Set initial position and put character in path:
+		initial_position = walking_path.position + walking_path.curve.get_point_position(0)
+		character.position = initial_position
+		_setup_standing_offsets()
+
+
+func _set_direction(new_direction: int) -> void:
+	direction = signi(new_direction)
+	if not is_node_ready():
+		return
+	direction_changed.emit()
+
+
+func _get_configuration_warnings() -> PackedStringArray:
+	if not walking_path:
+		return ["Walking Path property must be set."]
+	return []
+
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		set_physics_process(false)
+		return
+
+	_set_walking_path(walking_path)
+
+
+func _physics_process(delta: float) -> void:
+	var closest_offset := walking_path.curve.get_closest_offset(
+		character.position - initial_position + walking_path.curve.get_point_position(0)
+	)
+	var new_offset := closest_offset + walk_speed * delta * direction
+
+	for idx in range(_standing_offsets.size()):
+		var point_offset := _standing_offsets[idx]
+		if direction == 1:
+			if (
+				point_offset > closest_offset
+				and (point_offset < new_offset or is_equal_approx(point_offset, new_offset))
+			):
+				pointy_path_reached.emit()
+			elif new_offset > walking_path.curve.get_baked_length():
+				pointy_path_reached.emit()
+		elif direction == -1:
+			if (
+				point_offset < closest_offset
+				and (point_offset > new_offset or is_equal_approx(point_offset, new_offset))
+			):
+				pointy_path_reached.emit()
+
+	if not _is_path_closed():
+		# Turn around in endings:
+		if new_offset > walking_path.curve.get_baked_length() or new_offset < 0.0:
+			ending_reached.emit()
+			if turn_around:
+				direction *= -1
+
+	var target_position := (
+		initial_position
+		+ walking_path.curve.sample_baked(new_offset)
+		- walking_path.curve.get_point_position(0)
+	)
+
+	character.velocity = character.position.direction_to(target_position) * walk_speed
+
+	var collided := character.move_and_slide()
+	if collided and character.is_on_wall():
+		if character.get_real_velocity().length_squared() <= stuck_speed * stuck_speed:
+			got_stuck.emit()
+			if turn_around:
+				direction *= -1
+
+
+func _setup_standing_offsets() -> void:
+	for idx in range(walking_path.curve.point_count):
+		var point_position := walking_path.curve.get_point_position(idx)
+		var p_in := walking_path.curve.get_point_in(idx)
+		var p_out := walking_path.curve.get_point_out(idx)
+		# Ignore if at this point, the in and out controls make the path continuous and not pointy:
+		# TODO: Compare length_squared() < path_pointy_tolerance
+		if idx == 0 and not _is_path_closed():
+			_standing_offsets.append(walking_path.curve.get_closest_offset(point_position))
+		elif idx == walking_path.curve.point_count - 1 and not _is_path_closed():
+			# This especial case is because get_closest_offset() returns zero for the last point
+			# if the path is closed:
+			_standing_offsets.append(walking_path.curve.get_baked_length())
+		elif (p_in or p_out) and abs(p_in.cross(p_out)) <= path_continuous_tolerance:
+			continue
+		else:
+			_standing_offsets.append(walking_path.curve.get_closest_offset(point_position))
+
+
+## Return true if the end of the path is the same point as the beginning.
+func _is_path_closed() -> bool:
+	if walking_path.curve.point_count < 3:
+		return false
+
+	var first_point_position: Vector2 = walking_path.curve.get_point_position(0)
+	var last_point_position: Vector2 = walking_path.curve.get_point_position(
+		walking_path.curve.point_count - 1
+	)
+
+	return first_point_position.is_equal_approx(last_point_position)

--- a/scenes/game_logic/path_walk_behavior.gd.uid
+++ b/scenes/game_logic/path_walk_behavior.gd.uid
@@ -1,0 +1,1 @@
+uid://id28maao3vdy


### PR DESCRIPTION
This is the result of the exploration in https://github.com/endlessm/threadbare/pull/777 for discussion https://github.com/endlessm/threadbare/discussions/774 .

These nodes are pure logic, intended to provide an easy way of creating
characters that move around the world with pure setup and no scripting. A more
advanced use is to have a script that can switch between these simple behaviors
to create more complex behaviors.

They are:
- BounceWalkBehavior: Make the character move and bounce on walls.
- ErraticWalkBehavior: Make the character walk around erratically.
- FollowWalkBehavior: Make the character follow a target.
- PathWalkBehavior: Make the character walk along a path.
- InputWalkBehavior: Control the character with input actions to walk and run.

They only take care of controlling the movement of the parent CharacterBody2D
node by setting the velocity and calling move_and_slide. For aesthetics, add a
CharacterSpriteBehavior. This is based in current player_sprite.gd and improved.
In the future, we may also want to support a behavior for animations done with
AnimationPlayer because they can include sound effects that match the visuals.

The walk behavior nodes have exported properties to configure them. There is
quite some repeated code in those. We may consider a single shared resourse
exported.

The walk behavior nodes try to emit as many signals as possible for the
different situations, like when the character turns around when walking on a
path or when the character gets stuck while moving. A script could connect to
these signals to make more interesting behaviors.

The "is stuck" logic is inspired by the one in guard_movement.gd, but changed
to use:
- The boolean returned by move_and_slide() that tells if a collision happened.
- The CharacterBody2D.get_real_velocity()
- The CharacterBody2D.is_on_wall()

For the latter, the character must be properly configured for a top-down game
with motion_mode set to MotionMode.MOTION_MODE_FLOATING.

Resolves https://github.com/endlessm/threadbare/issues/1105

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211209074317270