### PR TITLE
Remove label dizzying effect

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -181,4 +181,3 @@ sokoban_skip={
 
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
-2d/snap/snap_2d_transforms_to_pixel=true

--- a/scenes/game_elements/props/fixed_size_label/components/fixed_size_label.gd
+++ b/scenes/game_elements/props/fixed_size_label/components/fixed_size_label.gd
@@ -12,6 +12,9 @@ extends Control
 @export var label_text: String:
 	set = _set_label_text
 
+## Maximum offset allowed between the desired and existing screen position.
+@export var max_offset_allowed: float = 100.0
+
 ## Used to limit the rate at which [method Node._process] is called.
 var _update_time: float = 0
 
@@ -39,6 +42,9 @@ func _process(_delta: float) -> void:
 
 	var new_position := get_global_transform_with_canvas().origin - (label_container.size / 2.0)
 	var distance_squared := (label_container.global_position - new_position).length_squared()
+
+	if distance_squared < max_offset_allowed * max_offset_allowed:
+		return
 
 	# Next update is inversely proportional to the distance in the screen.
 	# In other words, the label will jump from one screen position to the other faster if it's far,


### PR DESCRIPTION
There is a dizzying effect in the labels when something can be interacted. This is because the labels are in a layer on top and they are positioned in screen (viewport) coordinates, by translating the anchor point of the object being interacted from world coordinates. This is so their size is independient of the camera zoom.

That translation from world coordinates to screen coordinates is always catching up with the previous frames, producing a dizzying effect and blurry text while the camera is moving.

The proposal here is to avoid repositioning the label every frame. Do it at a rate that depends on how far is the new position, thus how important it is to do so. Also allow some offset between the anchor point and the current position. And finally, also fade in and out the label while repositioning.

Playable at https://endlessm.github.io/threadbare/branches/endlessm/remove-label-dizzying-effect/#world_map/frays_end

Before:

[Grabación de pantalla desde 2025-07-30 14-12-06.webm](https://github.com/user-attachments/assets/ef88f119-8ef1-4f01-b5f5-586ba088b2ee)

After:

[Grabación de pantalla desde 2025-07-30 14-05-08.webm](https://github.com/user-attachments/assets/d7bc4c3b-33a1-4459-80d0-c028026bd41f)


Fix https://github.com/endlessm/threadbare/issues/725