### PR TITLE
Project: Expand aspect ratio

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -46,6 +46,7 @@ editor/translations/update_pot_files_automatically=false
 window/size/viewport_width=1920
 window/size/viewport_height=1080
 window/stretch/mode="viewport"
+window/stretch/aspect="expand"
 
 [editor_plugins]
 


### PR DESCRIPTION
The 16:9 display aspect ratio is the most common in PC desktop. But there are others, and notably the Steam Deck has a 16:10 display.

The game was letterboxed with black bars at the sides in displays with different aspect ratio when the aspect ratio wasn't exactly 16:9.

Now setting the window stretch mode to expand, the black areas are removed, filled with content. And the Control overlays on top of the world can occupy that empty space. For instance, the HUD at the top-right corner.

Note that in windowed mode the window can be resized to any aspect ratio, and the levels will look odd in ultrawide or ultratall cases.

Helps https://github.com/endlessm/threadbare/issues/638