### PR TITLE
splash: Keep centred in viewport

### DIFF
--- a/scenes/menus/splash/components/logo_stitcher.gd
+++ b/scenes/menus/splash/components/logo_stitcher.gd
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 @tool
 class_name LogoStitcher
-extends Node2D
+extends Control
 ## Simulates stitching along a continuous path with variable width, in order to draw the Endless
 ## logo (though other things could be animated in the same way).
 

--- a/scenes/menus/splash/components/splash.gd
+++ b/scenes/menus/splash/components/splash.gd
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
-extends Node2D
+extends Control
 
 const NEXT_SCENE: PackedScene = preload("uid://stdqc6ttomff")
 

--- a/scenes/menus/splash/splash.tscn
+++ b/scenes/menus/splash/splash.tscn
@@ -18,27 +18,62 @@ _data = {
 }
 point_count = 27
 
-[node name="Splash" type="Node2D"]
+[node name="Splash" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 script = ExtResource("1_a6n0j")
 
-[node name="FabricBackground" type="Sprite2D" parent="."]
+[node name="FabricBackground" type="TextureRect" parent="."]
 modulate = Color(0.345098, 0.215686, 0.929412, 1)
-position = Vector2(960, 540)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 texture = ExtResource("2_cy8yo")
+stretch_mode = 6
 
-[node name="LogoReference" type="Sprite2D" parent="."]
+[node name="LogoReference" type="TextureRect" parent="."]
 visible = false
-position = Vector2(960, 540)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -512.0
+offset_top = -203.0
+offset_right = 512.0
+offset_bottom = 203.0
+grow_horizontal = 2
+grow_vertical = 2
 texture = ExtResource("2_a6n0j")
 
-[node name="LogoStitcher" type="Node2D" parent="." node_paths=PackedStringArray("path", "audio")]
+[node name="AspectRatioContainer" type="AspectRatioContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="LogoStitcher" type="Control" parent="AspectRatioContainer" node_paths=PackedStringArray("path", "audio")]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(1920, 1080)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 script = ExtResource("3_m61hw")
 path = NodePath("Path2D")
 width_curve = SubResource("Curve_7hvf5")
-audio = NodePath("../AudioStreamPlayer")
+audio = NodePath("../../AudioStreamPlayer")
 
-[node name="Path2D" type="Path2D" parent="LogoStitcher"]
+[node name="Path2D" type="Path2D" parent="AspectRatioContainer/LogoStitcher"]
 curve = SubResource("Curve2D_eqfq0")
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]


### PR DESCRIPTION
Since commit 73b1ba691d540e95e2c749aaf5b30bdd8f9b6d12 ("Project: Expand aspect ratio") the viewport may be wider or taller than 1920×1080. But the logo was being drawn to a plain Node2D, using points that assumed a 1920×1080 viewport. Similarly the background was a Sprite2D.

Rebuild this scene to use a Control node at the root. Change the background to a TextureRect, configured to Keep Aspect Covered.

Make the LogoStitcher node a Control rather than a Node2D, with a custom minimum size of 1920×1080 (the resolution the points in the Path2D assume) and reparent it to be centred in an AspectRatioContainer.

This keeps the logo centred in the viewport when the viewport is not at 16:9 aspect ratio.

(If we later change the base resolution of the game we will likely want to revisit this.)

Fixes https://github.com/endlessm/threadbare/issues/995