### PR TITLE
Set minimum window size to 1280×720 (720p)

### DIFF
--- a/scenes/globals/settings/settings.gd
+++ b/scenes/globals/settings/settings.gd
@@ -13,6 +13,14 @@ const DEFAULT_VOLUMES: Dictionary[String, float] = {
 const VIDEO_SECTION := "Video"
 const VIDEO_WINDOW_MODE_KEY := "Window Mode"
 
+## This is deliberately smaller than the base resolution of the game, so that the game is playable
+## on smaller screens even if it is not perfectly legible.
+##
+## If we later reduce the base resolution of the game, we should replace this constant with looking
+## up the base resolution from the project settings at runtime, so that the window cannot be smaller
+## than the base resolution.
+const MINIMUM_WINDOW_SIZE := Vector2i(1280, 720)
+
 var _settings := ConfigFile.new()
 
 
@@ -23,6 +31,7 @@ func _ready() -> void:
 
 	_restore_volumes()
 	_restore_video_settings()
+	_set_minimum_window_size()
 
 
 func _restore_volumes() -> void:
@@ -47,6 +56,10 @@ func _restore_video_settings() -> void:
 	if window_mode == DisplayServer.window_get_mode():
 		return
 	DisplayServer.window_set_mode(window_mode)
+
+
+func _set_minimum_window_size() -> void:
+	get_window().min_size = MINIMUM_WINDOW_SIZE
 
 
 func get_volume(bus: String) -> float:


### PR DESCRIPTION
Since commit 73b1ba69, the game has been allowed to expand to fill the viewport if its aspect ratio is not 16:9 (the ratio of the base resolution). This has the downside that you can now see beyond the intended bounds of some scenes.

The problem is much more pronounced if the window is resized to very extreme aspect ratios. We can limit this by setting the minimum window size to the smallest resolution we want to support. Currently this is smaller than the base resolution of the game, so that the game is playable on screens smaller than 1920×1080, but as noted in a comment if we reduce the base resolution to the lowest resolution we support, we should probably set the minimum size to the base resolution instead.

This code is placed in the Settings global not because it is a setting, but because it's closer to being a setting than to any of the other globals we already have in the project! (There is a proposal upstream to expose the minimum window size for the main game window in the project settings: https://github.com/godotengine/godot-proposals/issues/7586.)

Helps https://github.com/endlessm/threadbare/issues/638