### PR TITLE
Update Flatpak app ID to org.endlessaccess.threadbare

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: threadbare.flatpak
-          manifest-path: org.endlessos.threadbare.yml
+          manifest-path: org.endlessaccess.threadbare.yml
           cache-key: "flatpak-builder-${{ github.sha }}"
 
   release:

--- a/linux/launcher.desktop
+++ b/linux/launcher.desktop
@@ -3,7 +3,7 @@
 [Desktop Entry]
 Name=Threadbare
 Comment=Rebuild an unraveling world
-Icon=org.endlessos.threadbare
+Icon=org.endlessaccess.threadbare
 Exec=godot-runner
 Type=Application
 Terminal=false

--- a/linux/metainfo.xml
+++ b/linux/metainfo.xml
@@ -11,21 +11,21 @@ SPDX-License-Identifier: CC-BY-4.0
     <color type="primary" scheme_preference="dark">#435b7d</color>
   </branding>
   <developer_name translatable="no">Endless Access</developer_name>
-  <developer id="org.endlessos">
+  <developer id="org.endlessaccess">
     <name translatable="no">Endless Access</name>
   </developer>
   <description>
     <p>Story-driven, collaborative game where players don’t just explore a world—they co-create it. In Threadbare, players rebuild a world unraveling at the seams by recovering knowledge, crafting stories, and designing characters, quests, and cultures drawn from their own lives.</p>
   </description>
-  <id>org.endlessos.threadbare</id>
-  <launchable type="desktop-id">org.endlessos.threadbare.desktop</launchable>
+  <id>org.endlessaccess.threadbare</id>
+  <launchable type="desktop-id">org.endlessaccess.threadbare.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0</project_license>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">mild</content_attribute>
     <content_attribute id="violence-fantasy">mild</content_attribute>
   </content_rating>
-  <url type="homepage">https://endlessos.org</url>
+  <url type="homepage">https://endlessaccess.org</url>
   <url type="bugtracker">https://github.com/endlessm/threadbare/issues</url>
   <screenshots>
     <screenshot type="default">

--- a/org.endlessaccess.threadbare.yml
+++ b/org.endlessaccess.threadbare.yml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
-id: org.endlessos.threadbare
+id: org.endlessaccess.threadbare
 runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 base: org.godotengine.godot.BaseApp


### PR DESCRIPTION
Our organisation has been renamed!

https://endlessaccess.org/ redirects to
https://access.endlessstudios.com/ so another option was com.endlessstudios.access.threadbare, but that's much uglier, and our email addresses will be @endlessaccess.org, so let's use that one.

Update the manifest, metainfo, desktop file and CI pipeline accordingly.

Fixes https://github.com/endlessm/threadbare/issues/1062