### PR TITLE
Remove 'bug' label from Bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 name: Bug
 description: An unexpected problem or behavior
-labels: bug
 type: Bug
 body:
   - type: markdown


### PR DESCRIPTION
I have removed this label: it is redundant with the 'Bug' issue type.

https://github.com/endlessm/threadbare/issues/1060