### PR TITLE
Reorder fields of project.godot

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,10 +11,10 @@ config_version=5
 [application]
 
 config/name="Threadbare"
+config/tags=PackedStringArray("2d", "endless", "game", "tilemap", "top_down")
 run/main_scene="uid://huuo8mnwsphv"
 config/features=PackedStringArray("4.4", "GL Compatibility")
 config/icon="uid://bc70phmq55dkf"
-config/tags=PackedStringArray("2d", "endless", "game", "tilemap", "top_down")
 
 [autoload]
 


### PR DESCRIPTION
Commit b99c0e81f87434e6c3b5a13020c76f16c4b9fadf added config/tags to this file; whenever I save the project, Godot reorders the file.

Reorder it to be the way that it is saved.