### PR TITLE
LoreQuest: Remove shadow square from closing transition

### DIFF
--- a/scenes/quests/lore_quests/quest_001/4_closing_transition/closing_transition.tscn
+++ b/scenes/quests/lore_quests/quest_001/4_closing_transition/closing_transition.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=4 uid="uid://cd2p2udmkif80"]
+[gd_scene load_steps=16 format=4 uid="uid://cd2p2udmkif80"]
 
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="1_dwxhj"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="1_gyhjf"]
@@ -11,7 +11,6 @@
 [ext_resource type="Material" uid="uid://64aeyjitacv3" path="res://scenes/game_elements/props/void/void_chromakey_material.tres" id="5_ihbgv"]
 [ext_resource type="Resource" uid="uid://dund4v8fmxkoc" path="res://scenes/quests/lore_quests/quest_001/4_closing_transition/components/story_quest_closing_transition.dialogue" id="5_offe2"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="6_jx4g6"]
-[ext_resource type="Texture2D" uid="uid://dslom0xbe1if7" path="res://assets/third_party/tiny-swords/Terrain/Ground/Shadows.png" id="9_jx4g6"]
 
 [sub_resource type="Animation" id="Animation_gyhjf"]
 length = 0.001
@@ -366,11 +365,6 @@ position = Vector2(342, 345)
 sprite_frames = ExtResource("3_3dlh8")
 animation = &"idle"
 autoplay = "idle"
-
-[node name="Shadows" type="Sprite2D" parent="OnTheGround"]
-visible = false
-position = Vector2(655, 531)
-texture = ExtResource("9_jx4g6")
 
 [node name="ClosingTransitionCinematic" type="Node2D" parent="." node_paths=PackedStringArray("animation_player")]
 script = ExtResource("4_3dlh8")


### PR DESCRIPTION
Previously, there was a square shadow above the forest in the closing transition scene.
This was unintentional and looked bad. Remove it.

Fixes https://github.com/endlessm/threadbare/issues/667