### PR TITLE
mailmap: Map @endlessos.org committers to @endlessaccess.org

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,10 +1,18 @@
 # SPDX-FileCopyrightText: NONE
 # SPDX-License-Identifier: CC0-1.0
-Heather Drolet <heather@endlessos.org>
-Heather Drolet <heather@endlessos.org> Heather <108750056+hydrolet@users.noreply.github.com>
+<andrea@endlessaccess.org> <andrea@endlessos.org>
+<cassidy@endlessaccess.org> <cassidy@endlessos.org>
+<dbn@endlessaccess.org> <dbn@endlessos.org>
+Heather Drolet <heather@endlessaccess.org> <heather@endlessos.org>
+Heather Drolet <heather@endlessaccess.org> <108750056+hydrolet@users.noreply.github.com>
+<joana@endlessaccess.org> <joana@endlessos.org>
 Juan Manuel Fernandes dos Santos <juan9794@gmail.com> <jfdossantos@frba.utn.edu.ar>
-Justin Bourque <justin@endlessos.org>
-Manuel Quiñones <manuel.por.aca@gmail.com>
+Justin Bourque <justin@endlessaccess.org> <justin@endlessos.org>
+Justin Bourque <justin@endlessaccess.org> <164198892+jbourqueendless@users.noreply.github.com>
+Manuel Quiñones <manuq@endlessaccess.org> <manuel.por.aca@gmail.com>
+Manuel Quiñones <manuq@endlessaccess.org> <manuq@endlessos.org>
 Pablo de Haro <pablitar@gmail.com>
-Stephen Reid <stephen@endlessos.org>
 Phoenix Stroh <68404504+PhoenixStroh@users.noreply.github.com>
+Stephen Reid <stephen@endlessaccess.org> <stephen@endlessos.org>
+Will Thompson <wjt@endlessaccess.org> <wjt@endlessos.org>
+Will Thompson <wjt@endlessaccess.org> <will@willthompson.co.uk>

--- a/.mailmap
+++ b/.mailmap
@@ -14,5 +14,6 @@ Manuel Quiñones <manuq@endlessaccess.org> <manuq@endlessos.org>
 Pablo de Haro <pablitar@gmail.com>
 Phoenix Stroh <68404504+PhoenixStroh@users.noreply.github.com>
 Stephen Reid <stephen@endlessaccess.org> <stephen@endlessos.org>
+Tobías Romero <arebuayon@hotmail.com> <54726643+Arebuayon@users.noreply.github.com>
 Will Thompson <wjt@endlessaccess.org> <wjt@endlessos.org>
 Will Thompson <wjt@endlessaccess.org> <will@willthompson.co.uk>


### PR DESCRIPTION
We have changed the canonical domain name for our organisation.

It is not possible to edit the Author: and Committer: fields of old
commits, but it is possible to remap them in the output of git commands
to the new domain. Update all Endless Access team members who have
committed to date, including some of their other email addresses.

---

I also added a line to canonicalise Tobías Romero to a single email address.

---

This change is purely cosmetic. The desired result is that the following command shows a single, up-to-date email address for each user (where possible):

```console
$ git shortlog -se
     1  Andrea Victoria Pavón <andrea@endlessaccess.org>
    22  Cassidy James Blaede <cassidy@endlessaccess.org>
     2  Dan Nicholson <dbn@endlessaccess.org>
    45  Heather Drolet <heather@endlessaccess.org>
     1  Joana Filizola <joana@endlessaccess.org>
   154  Juan Manuel Fernandes dos Santos <juan9794@gmail.com>
    49  Justin Bourque <justin@endlessaccess.org>
   482  Manuel Quiñones <manuq@endlessaccess.org>
    61  Pablo de Haro <pablitar@gmail.com>
     2  Phoenix Stroh <68404504+PhoenixStroh@users.noreply.github.com>
    26  Stephen Reid <stephen@endlessaccess.org>
    10  Tobías Romero <arebuayon@hotmail.com>
   578  Will Thompson <wjt@endlessaccess.org>
     3  dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
```
