### PR TITLE
Ignore temporary files ending with ~

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ __MACOSX
 # Temporary files, created in particular by Godot on Windows if you modify and
 # save a scene in the editor while it is in use by the running game.
 *.tmp
+
+*~


### PR DESCRIPTION
I found one of these for a .png file I had edited. I don't recall which app created it.