### PR TITLE
ci: Update amalgamate-pages to v2

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -18,13 +18,14 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  pull-requests: write
 
 jobs:
   publish:
     name: Publish all branches to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: endlessm/amalgamate-pages@v1
+      - uses: endlessm/amalgamate-pages@v2
         with:
           workflow_name: "Build and Export Game"
           artifact_name: web


### PR DESCRIPTION
This version posts a comment to the corresponding PR for each branch with a link to the playable build. It requires a new permission.

https://github.com/endlessm/amalgamate-pages/releases/tag/v2.0 https://github.com/endlessm/amalgamate-pages/issues/18