### PR TITLE
ci: Run Discord merge hook in target branch context

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -3,7 +3,7 @@
 name: Discord Notification
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:


### PR DESCRIPTION
The pull_request trigger runs the workflow in the context of the source branch, not the target branch. This means that, if the pull request is from a fork, the workflow does not have access to the target repository's secrets.

This is for security reasons: otherwise, a malicious contributor could change the pull_request-triggered workflow to exfiltrate the secrets. However, in this case we really need the secret to be present, or else the hook cannot work.

Run this workflow from the pull_request_target trigger, which runs in the context of the target ref. Having read the dire warnings in the [pull_request_target documentation][0], I read the source code of the action we're using and confirmed that it does what it says it does and will not download untrusted external code or steal our secrets.

[0]: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target

I believe this will fix https://github.com/endlessm/threadbare/issues/1089 but it's impossible to test without first merging this change, then testing what happens when we merge a PR from a fork and a PR from this repo.