### PR TITLE
Flip player horizontally when moving left in Sokoban

### DIFF
--- a/scenes/eternal_loom_sokoban/components/player/sokoban_player.tscn
+++ b/scenes/eternal_loom_sokoban/components/player/sokoban_player.tscn
@@ -81,12 +81,12 @@ animations = [{
 "speed": 12.0
 }]
 
-[node name="SokobanPlayer" type="Node2D"]
+[node name="SokobanPlayer" type="Node2D" node_paths=PackedStringArray("sprite")]
 z_index = 2
 script = ExtResource("1_g32nx")
 id = &"player"
-layer = 2
 tags = Array[StringName]([&"controllable"])
+sprite = NodePath("AnimatedSprite2D")
 metadata/_custom_type_script = "uid://cgwu1infdhqxt"
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]

--- a/scenes/eternal_loom_sokoban/components/system/board/piece_2d.gd
+++ b/scenes/eternal_loom_sokoban/components/system/board/piece_2d.gd
@@ -30,15 +30,23 @@ const DIRECTION_TO_KEY: Dictionary[DIRECTION, StringName] = {
 
 ## Unique Identifier for this piece. Should not match any other piece.
 @export var id: StringName
+
 ## Tag Identifiers for this piece. Pieces can share the same tag.
 @export var tags: Array[StringName]
+
+## A sprite that will be flipped horizontally when the horizontal direction changes.
+@export var sprite: AnimatedSprite2D
 
 var layer: int:
 	set(value):
 		layer = value
 		z_index = layer
 
-var direction: DIRECTION = DIRECTION.NONE
+var direction: DIRECTION = DIRECTION.NONE:
+	set(value):
+		direction = value
+		if sprite:
+			_update_sprite_facing()
 
 var active: bool = true
 
@@ -47,6 +55,11 @@ var grid_position: Vector2i:
 	set = _set_grid_position
 var _board: Board2D:
 	set = _set_board
+
+
+func _ready() -> void:
+	if sprite and not Engine.is_editor_hint():
+		sprite.play("idle")
 
 
 func _enter_tree() -> void:
@@ -90,11 +103,10 @@ func set_vector(vector: Vector2i) -> void:
 		Vector2i.DOWN: DIRECTION.DOWN,
 		Vector2i.LEFT: DIRECTION.LEFT,
 	}
-
 	if VECTOR_TO_DIRECTION.has(vector):
 		direction = VECTOR_TO_DIRECTION[vector]
-		return
-	direction = DIRECTION.NONE
+	else:
+		direction = DIRECTION.NONE
 
 
 func get_new_grid_position() -> Vector2i:
@@ -154,3 +166,15 @@ func _find_ancestor_board() -> Board2D:
 		search_node = search_parent
 	# Reached max search depth
 	return null
+
+
+## Flip sprite horizontally according to the horizontal direction.
+func _update_sprite_facing() -> void:
+	# Match the current movement direction
+	match direction:
+		DIRECTION.RIGHT:
+			# Face the sprite to the right (no horizontal flip)
+			sprite.flip_h = false
+		DIRECTION.LEFT:
+			# Face the sprite to the left (apply horizontal flip)
+			sprite.flip_h = true


### PR DESCRIPTION
The spriteAnimator2D was referenced and worked with its flip_h method.

Fixes #904 