### PR TITLE
Sequence puzzle: Remove wobble hints

### DIFF
--- a/scenes/game_logic/sequence_puzzle.gd
+++ b/scenes/game_logic/sequence_puzzle.gd
@@ -92,15 +92,6 @@ func _on_kicked(object: SequencePuzzleObject) -> void:
 		_debug("Didn't match")
 		_position = 0
 		_debug("Matching again at start of sequence...")
-
-	if sequence[_position] != object:
-		_debug("Didn't match")
-		for r: SequencePuzzleObject in _objects:
-			r.stop_hint()
-		if hint_levels.get(get_progress(), 0) >= wobble_hint_min_level:
-			hint_timer.start()
-		return
-
 	_position += 1
 	hint_timer.start()
 	if _position != sequence.size():


### PR DESCRIPTION
Sequence puzzle wobble hints trigger incorrectly
fixes [#686](https://github.com/endlessm/threadbare/issues/686) 