### PR TITLE
fix(collectible): sync physical collision with 'revealed' state

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -46,6 +46,7 @@ editor/translations/update_pot_files_automatically=false
 
 window/size/viewport_width=1920
 window/size/viewport_height=1080
+window/size/mode=4
 window/stretch/mode="viewport"
 window/stretch/aspect="expand"
 

--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -36,6 +36,7 @@ class_name CollectibleItem extends Node2D
 @onready var animation_player: AnimationPlayer = $AnimationPlayer
 @onready var sprite_2d: Sprite2D = $Sprite2D
 @onready var appear_sound: AudioStreamPlayer = %AppearSound
+@onready var physical_collider: CollisionShape2D = $StaticBody2D/CollisionShape2D
 
 
 func _validate_property(property: Dictionary) -> void:
@@ -107,3 +108,6 @@ func _update_based_on_revealed() -> void:
 		interact_area.disabled = not revealed
 	if sprite_2d:
 		sprite_2d.visible = revealed
+	if physical_collider:
+		physical_collider.disabled = not revealed
+	


### PR DESCRIPTION
The collectible's StaticBody2D remained active while the item was hidden, incorrectly blocking player movement. This change modifies the _update_based_on_revealed function to also toggle the 'disabled' property of the physical CollisionShape2D. This ensures the physical collision is only active when the item is visible and interactable.