### PR TITLE
REUSE: Treat MP3s in assets/first_party as first-party

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -60,6 +60,7 @@ path = [
     "assets/first_party/**/*.aseprite",
     "assets/first_party/**/*.png",
     "assets/first_party/**/*.ogg",
+    "assets/first_party/**/*.mp3",
     "icon-256.png",
     "icon.aseprite",
     "icon.png",


### PR DESCRIPTION
We don't currently have any MP3s, but the Hu- -sh sound effect recorded by Stephen in https://github.com/endlessm/threadbare/issues/671 is in MP3 format.

Even if we later convert this to WAV or Ogg to standardise, we can still handle it correctly.