### PR TITLE
Collectible: Sync physical collision with 'revealed' state

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -46,7 +46,6 @@ editor/translations/update_pot_files_automatically=false
 
 window/size/viewport_width=1920
 window/size/viewport_height=1080
-window/size/mode=4
 window/stretch/mode="viewport"
 window/stretch/aspect="expand"
 

--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -110,4 +110,3 @@ func _update_based_on_revealed() -> void:
 		sprite_2d.visible = revealed
 	if physical_collider:
 		physical_collider.disabled = not revealed
-	


### PR DESCRIPTION
The collectible's StaticBody2D remained active while the item was hidden, incorrectly blocking player movement. This change modifies the _update_based_on_revealed function to also toggle the 'disabled' property of the physical CollisionShape2D. This ensures the physical collision is only active when the item is visible and interactable.

Thanks a lot for the feedback, Will — it really helped me! I hope I got it right this time.

Fixes https://github.com/endlessm/threadbare/issues/993