### PR TITLE
Void: Improve dust cloud particles & remove placeholder enemy

### DIFF
--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/dust-cloud.png
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/dust-cloud.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd5b8206a9db0c2b18212a9a26c57e7fdf7f9b5e03e1360d645d5a827d2f266b
-size 29142
+oid sha256:5b8a01835dedcdc441a3ade4663745e3547744af0526aa0c98a7fd855d317c8b
+size 603

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/tile_map_cover.gd
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/tile_map_cover.gd
@@ -116,7 +116,8 @@ func _ready() -> void:
 
 ## Cover all [param cells] with [member terrain_name], hiding any nodes in those cells which are
 ## direct children of [member consumable_node_holders].
-func consume_cells(cells: Array[Vector2i], immediate: bool = false) -> void:
+## Return true if any cells were consumed.
+func consume_cells(cells: Array[Vector2i], immediate: bool = false) -> bool:
 	for i in range(cells.size() - 1, -1, -1):
 		var c: Vector2i = cells[i]
 
@@ -129,6 +130,8 @@ func consume_cells(cells: Array[Vector2i], immediate: bool = false) -> void:
 
 		for cell in cells:
 			consume(cell, immediate)
+		return true
+	return false
 
 
 ## Hide all nodes in cell [param coord] which are direct children of

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_particles.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_particles.tscn
@@ -1,0 +1,47 @@
+[gd_scene load_steps=8 format=3 uid="uid://s2ohp10ssq7l"]
+
+[ext_resource type="Texture2D" uid="uid://crqn2002jp6ot" path="res://scenes/quests/lore_quests/quest_002/1_void_runner/components/dust-cloud.png" id="1_hohl7"]
+
+[sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_31awk"]
+particles_animation = true
+particles_anim_h_frames = 5
+particles_anim_v_frames = 1
+particles_anim_loop = false
+
+[sub_resource type="Curve" id="Curve_8l6e1"]
+_data = [Vector2(0, 0.733414), 0.0, 0.0, 0, 0, Vector2(0.315152, 0.717732), 0.0, 0.0, 0, 0, Vector2(0.9, 0), 0.0, 0.0, 0, 0, Vector2(0.99697, 0), 0.0, 0.0, 0, 0]
+point_count = 4
+
+[sub_resource type="CurveTexture" id="CurveTexture_rrhr1"]
+curve = SubResource("Curve_8l6e1")
+
+[sub_resource type="Curve" id="Curve_304le"]
+_data = [Vector2(0, 1), 0.0, 1.4, 0, 0, Vector2(1, 0.407895), 0.0, 0.0, 0, 0]
+point_count = 2
+
+[sub_resource type="CurveTexture" id="CurveTexture_45we0"]
+curve = SubResource("Curve_304le")
+
+[sub_resource type="ParticleProcessMaterial" id="ParticleProcessMaterial_rrhr1"]
+particle_flag_disable_z = true
+emission_shape = 1
+emission_sphere_radius = 120.0
+angular_velocity_min = -10.0
+angular_velocity_max = 9.99998
+radial_velocity_min = 20.0
+radial_velocity_max = 50.0
+gravity = Vector3(0, 0, 0)
+scale_min = 1.8
+scale_max = 2.0
+scale_curve = SubResource("CurveTexture_45we0")
+alpha_curve = SubResource("CurveTexture_rrhr1")
+anim_offset_max = 1.0
+
+[node name="GPUParticles2D" type="GPUParticles2D"]
+material = SubResource("CanvasItemMaterial_31awk")
+emitting = false
+amount = 80
+texture = ExtResource("1_hohl7")
+one_shot = true
+explosiveness = 1.0
+process_material = SubResource("ParticleProcessMaterial_rrhr1")

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.tscn
@@ -1,27 +1,6 @@
-[gd_scene load_steps=8 format=3 uid="uid://cokul8w425pja"]
+[gd_scene load_steps=4 format=3 uid="uid://cokul8w425pja"]
 
 [ext_resource type="Script" uid="uid://dil8mgaf03bei" path="res://scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.gd" id="1_304le"]
-[ext_resource type="Texture2D" uid="uid://crqn2002jp6ot" path="res://scenes/quests/lore_quests/quest_002/1_void_runner/components/dust-cloud.png" id="2_45we0"]
-
-[sub_resource type="Curve" id="Curve_8l6e1"]
-_data = [Vector2(0, 0.733414), 0.0, 0.0, 0, 0, Vector2(0.315152, 0.717732), 0.0, 0.0, 0, 0, Vector2(0.9, 0), 0.0, 0.0, 0, 0, Vector2(0.99697, 0), 0.0, 0.0, 0, 0]
-point_count = 4
-
-[sub_resource type="CurveTexture" id="CurveTexture_rrhr1"]
-curve = SubResource("Curve_8l6e1")
-
-[sub_resource type="ParticleProcessMaterial" id="ParticleProcessMaterial_rrhr1"]
-lifetime_randomness = 0.2
-particle_flag_disable_z = true
-emission_shape = 1
-emission_sphere_radius = 8.0
-direction = Vector3(0, 0, 0)
-angular_velocity_min = -10.0
-angular_velocity_max = 9.99998
-gravity = Vector3(0, 0, 0)
-scale_min = 1.6
-scale_max = 1.8
-alpha_curve = SubResource("CurveTexture_rrhr1")
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_8g3pn"]
 size = Vector2(68, 20)
@@ -34,12 +13,6 @@ collision_layer = 0
 collision_mask = 0
 motion_mode = 1
 script = ExtResource("1_304le")
-
-[node name="GPUParticles2D" type="GPUParticles2D" parent="."]
-unique_name_in_owner = true
-amount = 10
-texture = ExtResource("2_45we0")
-process_material = SubResource("ParticleProcessMaterial_rrhr1")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(5, 0)


### PR DESCRIPTION
This removes the placeholder storyvore sprite, and replaces the white dust cloud with black particles, better aligned with the game style, and instantiated only when tiles are consumed.

[Grabación de pantalla desde 2025-08-26 17-35-08.webm](https://github.com/user-attachments/assets/56946211-79d5-4f05-8345-048f3f16c985)
