### PR TITLE
Reverse frame order so targerts star visible

### DIFF
--- a/scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_target_spriteframes.tres
+++ b/scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_target_spriteframes.tres
@@ -2,36 +2,36 @@
 
 [ext_resource type="Texture2D" uid="uid://do4tec8oedbcx" path="res://scenes/quests/story_quests/template/2_template_combat/template_combat_components/template_target.png" id="1_4v1rc"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_4v1rc"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_kf7lf"]
 atlas = ExtResource("1_4v1rc")
-region = Rect2(0, 0, 64, 64)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_he37w"]
-atlas = ExtResource("1_4v1rc")
-region = Rect2(64, 0, 64, 64)
+region = Rect2(64, 64, 64, 64)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_q0cj1"]
 atlas = ExtResource("1_4v1rc")
 region = Rect2(0, 64, 64, 64)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_kf7lf"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_he37w"]
 atlas = ExtResource("1_4v1rc")
-region = Rect2(64, 64, 64, 64)
+region = Rect2(64, 0, 64, 64)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_4v1rc"]
+atlas = ExtResource("1_4v1rc")
+region = Rect2(0, 0, 64, 64)
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_4v1rc")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_he37w")
+"texture": SubResource("AtlasTexture_kf7lf")
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_q0cj1")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_kf7lf")
+"texture": SubResource("AtlasTexture_he37w")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_4v1rc")
 }],
 "loop": true,
 "name": &"filling",


### PR DESCRIPTION
This Pull Request addresses issue #703 by reversing the animation frame sequence. As a result, targets now appear fully visible at the start and gradually fade out.