### PR TITLE
Change game base resolution to 720p

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -45,9 +45,9 @@ editor/translations/update_pot_files_automatically=false
 
 [display]
 
-window/size/viewport_width=1920
-window/size/viewport_height=1080
-window/stretch/mode="viewport"
+window/size/viewport_width=1280
+window/size/viewport_height=720
+window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 
 [editor_plugins]

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_1a.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_1a.tscn
@@ -33,7 +33,6 @@ metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(0, -32)
-zoom = Vector2(2, 2)
 
 [node name="Board2D" type="Node2D" parent="."]
 script = ExtResource("3_jabbo")

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_1b.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_1b.tscn
@@ -26,7 +26,6 @@ color = Color(0.0740935, 0.0496062, 0.0467346, 1)
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(-96, -64)
-zoom = Vector2(2, 2)
 
 [node name="Board2D" type="Node2D" parent="."]
 script = ExtResource("5_644u0")

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_1c.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_1c.tscn
@@ -25,7 +25,6 @@ grow_vertical = 2
 color = Color(0.0740935, 0.0496062, 0.0467346, 1)
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(2, 2)
 
 [node name="Board2D" type="Node2D" parent="."]
 script = ExtResource("5_16ydi")

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_2a.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_2a.tscn
@@ -32,7 +32,6 @@ dialogue = ExtResource("2_2i86o")
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(2, 2)
 position_smoothing_enabled = true
 editor_draw_limits = true
 

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_2b.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_2b.tscn
@@ -25,7 +25,6 @@ grow_vertical = 2
 color = Color(0.0740935, 0.0496062, 0.0467346, 1)
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(2, 2)
 position_smoothing_enabled = true
 editor_draw_limits = true
 

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_2c.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_2c.tscn
@@ -26,7 +26,6 @@ color = Color(0.0740935, 0.0496062, 0.0467346, 1)
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(0, -32)
-zoom = Vector2(2, 2)
 position_smoothing_enabled = true
 editor_draw_limits = true
 

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_3a.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_3a.tscn
@@ -27,7 +27,6 @@ grow_vertical = 2
 color = Color(0.0740935, 0.0496062, 0.0467346, 1)
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(1.5, 1.5)
 
 [node name="Cinematic" type="Node2D" parent="."]
 script = ExtResource("1_5r6en")

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_3b.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_3b.tscn
@@ -26,7 +26,6 @@ color = Color(0.0740935, 0.0496062, 0.0467346, 1)
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(32, 0)
-zoom = Vector2(1.5, 1.5)
 
 [node name="Board2D" type="Node2D" parent="."]
 script = ExtResource("5_5baf1")

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_3c.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_3c.tscn
@@ -26,7 +26,6 @@ color = Color(0.0740935, 0.0496062, 0.0467346, 1)
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(32, -32)
-zoom = Vector2(1.5, 1.5)
 
 [node name="Board2D" type="Node2D" parent="."]
 script = ExtResource("5_m5u3b")

--- a/scenes/eternal_loom_sokoban/levels/sokoban_template.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_template.tscn
@@ -30,7 +30,6 @@ metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(-32, -32)
-zoom = Vector2(2, 2)
 
 [node name="Board2D" type="Node2D" parent="."]
 script = ExtResource("3_o2mty")

--- a/scenes/game_elements/characters/components/gym_area_test.tscn
+++ b/scenes/game_elements/characters/components/gym_area_test.tscn
@@ -41,7 +41,6 @@ position = Vector2(1312, 740)
 sprite_frames = ExtResource("3_6axvd")
 
 [node name="Camera2D" type="Camera2D" parent="OnTheGround/Player"]
-zoom = Vector2(2, 2)
 limit_left = -320
 limit_top = -640
 editor_draw_limits = true

--- a/scenes/game_elements/props/area_filler/components/area_filler_test.tscn
+++ b/scenes/game_elements/props/area_filler/components/area_filler_test.tscn
@@ -38,7 +38,6 @@ player_name = "StoryWeaver"
 sprite_frames = ExtResource("4_5lqse")
 
 [node name="Camera2D" type="Camera2D" parent="OnTheGround/Player"]
-zoom = Vector2(2, 2)
 limit_left = -256
 limit_top = -192
 limit_right = 1900

--- a/scenes/game_elements/props/void/components/void_chromakey_test.tscn
+++ b/scenes/game_elements/props/void/components/void_chromakey_test.tscn
@@ -37,7 +37,6 @@ player_name = "StoryWeaver"
 sprite_frames = ExtResource("4_g484a")
 
 [node name="Camera2D" type="Camera2D" parent="OnTheGround/Player"]
-zoom = Vector2(2, 2)
 limit_left = -256
 limit_top = -192
 limit_right = 2944

--- a/scenes/game_logic/stealth_game_logic.gd
+++ b/scenes/game_logic/stealth_game_logic.gd
@@ -4,14 +4,10 @@
 class_name StealthGameLogic
 extends Node
 
-@export_range(0.5, 3.0, 0.1, "or_greater", "or_less") var zoom: float = 1.0:
-	set = _set_zoom
-
 
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
-	_set_zoom(zoom)
 	for guard: Guard in get_tree().get_nodes_in_group(&"guard_enemy"):
 		guard.player_detected.connect(self._on_player_detected)
 
@@ -20,13 +16,3 @@ func _on_player_detected(player: Player) -> void:
 	player.mode = Player.Mode.DEFEATED
 	await get_tree().create_timer(2.0).timeout
 	SceneSwitcher.reload_with_transition(Transition.Effect.FADE, Transition.Effect.FADE)
-
-
-func _set_zoom(new_value: float) -> void:
-	zoom = new_value
-	if Engine.is_editor_hint():
-		return
-	if not is_node_ready():
-		return
-	var camera: Camera2D = get_viewport().get_camera_2d()
-	camera.zoom = Vector2.ONE * zoom

--- a/scenes/globals/aspect_ratio_debugger/aspect_ratio_debugger.tscn
+++ b/scenes/globals/aspect_ratio_debugger/aspect_ratio_debugger.tscn
@@ -7,7 +7,6 @@
 script = ExtResource("1_mi05q")
 
 [node name="OutOfBoundsBars" type="Control" parent="."]
-custom_minimum_size = Vector2(1920, 1080)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1360,7 +1360,6 @@ player_name = "StoryWeaver"
 sprite_frames = ExtResource("15_s3slv")
 
 [node name="Camera2D" type="Camera2D" parent="OnTheGround/Player"]
-zoom = Vector2(2, 2)
 limit_left = -400
 limit_top = 125
 limit_right = 1500

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_1.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_1.tscn
@@ -238,7 +238,7 @@ text = "Repel"
 [node name="HUD" parent="." instance=ExtResource("9_na0be")]
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 2048

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_2.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_2.tscn
@@ -172,7 +172,7 @@ position = Vector2(417, 592)
 [node name="HUD" parent="." instance=ExtResource("10_muw2v")]
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 2048

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
@@ -188,7 +188,6 @@ dialogue_title = &"well_done"
 [node name="HUD" parent="." instance=ExtResource("10_i5hhc")]
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(1.6, 1.6)
 limit_left = 0
 limit_top = 0
 limit_right = 2048

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -154,7 +154,6 @@ y_sort_enabled = true
 
 [node name="StealthGameLogic" type="Node" parent="."]
 script = ExtResource("1_f6lvl")
-zoom = 1.7
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("1_t8tj0")]
 stream = ExtResource("2_p2u32")

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -706,7 +706,6 @@ sprite_frames = ExtResource("21_p2u32")
 [node name="Camera2D" type="Camera2D" parent="Player"]
 unique_name_in_owner = true
 process_mode = 3
-zoom = Vector2(1.7, 1.7)
 limit_left = 0
 limit_top = 0
 position_smoothing_enabled = true

--- a/scenes/quests/lore_quests/quest_001/4_closing_transition/closing_transition.tscn
+++ b/scenes/quests/lore_quests/quest_001/4_closing_transition/closing_transition.tscn
@@ -197,7 +197,6 @@ texture = ExtResource("5_00ry4")
 y_sort_enabled = true
 position = Vector2(175, 63)
 anchor_mode = 0
-zoom = Vector2(1.8, 1.8)
 
 [node name="OnTheGround" type="Node2D" parent="."]
 

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
@@ -112,7 +112,6 @@ player_name = "StoryWeaver"
 sprite_frames = ExtResource("5_46vkj")
 
 [node name="Camera2D" type="Camera2D" parent="OnTheGround/Player"]
-zoom = Vector2(2, 2)
 limit_left = 0
 limit_top = 700
 limit_right = 4200

--- a/scenes/quests/story_quests/el_juguete_perdido/0_intro/intro.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/0_intro/intro.tscn
@@ -158,7 +158,7 @@ position = Vector2(417, 327)
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(153, 366)
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 960

--- a/scenes/quests/story_quests/el_juguete_perdido/1_stealth/stealth.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/1_stealth/stealth.tscn
@@ -163,7 +163,6 @@ sprite_frames = ExtResource("9_ppx7f")
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 process_mode = 3
-zoom = Vector2(2.5, 2.5)
 limit_left = 0
 limit_top = 0
 position_smoothing_enabled = true

--- a/scenes/quests/story_quests/el_juguete_perdido/1_stealth/stealth.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/1_stealth/stealth.tscn
@@ -72,7 +72,6 @@ y_sort_enabled = true
 
 [node name="StealthGameLogic" type="Node" parent="."]
 script = ExtResource("1_ppx7f")
-zoom = 1.7
 
 [node name="CanvasModulate" type="CanvasModulate" parent="."]
 color = Color(0.481789, 0.48179, 0.481789, 1)

--- a/scenes/quests/story_quests/el_juguete_perdido/2_combat/combat.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/2_combat/combat.tscn
@@ -370,7 +370,7 @@ sprite_frames = ExtResource("14_3qwhi")
 
 [node name="Camera2D" type="Camera2D" parent="OnTheGround/Player"]
 process_mode = 3
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 position_smoothing_enabled = true
@@ -470,7 +470,7 @@ color = Color(1, 1, 1, 1)
 [node name="HUD" parent="." instance=ExtResource("10_obsym")]
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 2048

--- a/scenes/quests/story_quests/el_juguete_perdido/3_sequence_puzzle/sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/3_sequence_puzzle/sequence_puzzle.tscn
@@ -45,7 +45,7 @@ sprite_frames = ExtResource("3_yiahn")
 
 [node name="Camera2D" type="Camera2D" parent="OnTheGround/Player"]
 process_mode = 3
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 position_smoothing_enabled = true
@@ -96,7 +96,7 @@ position = Vector2(1812, 191)
 position = Vector2(1812, 550)
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 1754

--- a/scenes/quests/story_quests/el_juguete_perdido/4_outro/outro.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/4_outro/outro.tscn
@@ -102,7 +102,7 @@ texture = ExtResource("11_igupu")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(153, 366)
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 960

--- a/scenes/quests/story_quests/stella/0_stella_intro/stella_intro.tscn
+++ b/scenes/quests/story_quests/stella/0_stella_intro/stella_intro.tscn
@@ -125,7 +125,7 @@ tile_set = ExtResource("1_k0kvg")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(153, 366)
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 960

--- a/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
+++ b/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
@@ -219,7 +219,6 @@ sprite_frames = ExtResource("4_rlkm0")
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 process_mode = 3
-zoom = Vector2(1.7, 1.7)
 limit_left = 0
 limit_top = 0
 position_smoothing_enabled = true

--- a/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
+++ b/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
@@ -177,7 +177,6 @@ y_sort_enabled = true
 
 [node name="StealthGameLogic" type="Node" parent="."]
 script = ExtResource("1_hmya5")
-zoom = 1.7
 
 [node name="CanvasModulate" type="CanvasModulate" parent="."]
 color = Color(0.481789, 0.48179, 0.481789, 1)

--- a/scenes/quests/story_quests/stella/2_stella_combat/stella_combat.tscn
+++ b/scenes/quests/story_quests/stella/2_stella_combat/stella_combat.tscn
@@ -183,7 +183,7 @@ dialogue_title = &"well_done"
 [node name="HUD" parent="." instance=ExtResource("10_xeai8")]
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(1.3, 1.3)
+zoom = Vector2(0.867, 0.867)
 limit_left = 0
 limit_top = 0
 limit_right = 2048

--- a/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_puzzle.tscn
@@ -329,7 +329,7 @@ sprite_frames = ExtResource("31_xd6u5")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 anchor_mode = 0
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 position_smoothing_enabled = true
 
 [node name="Cinematic" type="Node2D" parent="."]

--- a/scenes/quests/story_quests/stella/4_stella_outro/stella_outro.tscn
+++ b/scenes/quests/story_quests/stella/4_stella_outro/stella_outro.tscn
@@ -38,7 +38,7 @@ tile_set = ExtResource("2_k0po6")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(153, 366)
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 960

--- a/scenes/quests/story_quests/template/0_template_intro/template_intro.tscn
+++ b/scenes/quests/story_quests/template/0_template_intro/template_intro.tscn
@@ -117,7 +117,7 @@ tile_set = ExtResource("1_2qnws")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(153, 366)
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 960

--- a/scenes/quests/story_quests/template/1_template_stealth/template_stealth.tscn
+++ b/scenes/quests/story_quests/template/1_template_stealth/template_stealth.tscn
@@ -61,7 +61,6 @@ position = Vector2(131, 463)
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 process_mode = 3
-zoom = Vector2(1.7, 1.7)
 limit_left = 0
 limit_top = 0
 position_smoothing_enabled = true

--- a/scenes/quests/story_quests/template/1_template_stealth/template_stealth.tscn
+++ b/scenes/quests/story_quests/template/1_template_stealth/template_stealth.tscn
@@ -39,7 +39,6 @@ y_sort_enabled = true
 
 [node name="StealthGameLogic" type="Node" parent="."]
 script = ExtResource("1_eujsg")
-zoom = 1.7
 
 [node name="CanvasModulate" type="CanvasModulate" parent="."]
 color = Color(0.481789, 0.48179, 0.481789, 1)

--- a/scenes/quests/story_quests/template/2_template_combat/template_combat.tscn
+++ b/scenes/quests/story_quests/template/2_template_combat/template_combat.tscn
@@ -94,7 +94,7 @@ dialogue_title = &"well_done"
 [node name="HUD" parent="." instance=ExtResource("14_ttfgd")]
 
 [node name="Camera2D" type="Camera2D" parent="."]
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 2048

--- a/scenes/quests/story_quests/template/3_template_sequence_puzzle/template_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/template/3_template_sequence_puzzle/template_sequence_puzzle.tscn
@@ -125,7 +125,7 @@ text = "First melody: yellow, green, blue."
 
 [node name="Camera2D" type="Camera2D" parent="."]
 anchor_mode = 0
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 position_smoothing_enabled = true
 
 [node name="Cinematic" type="Node2D" parent="."]

--- a/scenes/quests/story_quests/template/4_template_outro/template_outro.tscn
+++ b/scenes/quests/story_quests/template/4_template_outro/template_outro.tscn
@@ -19,7 +19,7 @@ metadata/_edit_lock_ = true
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(153, 366)
-zoom = Vector2(2, 2)
+zoom = Vector2(1.333, 1.333)
 limit_left = 0
 limit_top = 0
 limit_right = 960

--- a/scenes/quests/story_quests/template/template_tileset/tileset_test.tscn
+++ b/scenes/quests/story_quests/template/template_tileset/tileset_test.tscn
@@ -17,6 +17,5 @@ tile_set = ExtResource("1_ujxu7")
 position = Vector2(188, 361)
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
-zoom = Vector2(3, 3)
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="."]

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -123,7 +123,6 @@ player_name = "StoryWeaver"
 sprite_frames = ExtResource("6_06x6x")
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
-zoom = Vector2(2, 2)
 limit_left = 0
 limit_top = 0
 limit_right = 2048


### PR DESCRIPTION
Downscale the viewport size by two thirds, from 1080p to 720p. Because this is
the resolution of handheld consoles like Steam Deck or Nintendo Switch.
    
Also: change the window stretch mode from Viewport to Canvas Items. This is not
a pixel-perfect game. Otherwise by just downscaling the viewport size, the
background shows shakiness while the player (and thus the camera) moves.
    
Change the zoom of Camera2D nodes in scenes depending on their content.

Resolves https://github.com/endlessm/threadbare/issues/638