### PR TITLE
Main Menu: Fit 720p resolution

### DIFF
--- a/scenes/menus/title/components/main_menu.tscn
+++ b/scenes/menus/title/components/main_menu.tscn
@@ -26,11 +26,9 @@ grow_vertical = 2
 [node name="LogoContainer" type="MarginContainer" parent="LogoButtonSplit"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_constants/margin_left = 128
 
 [node name="Logo" type="TextureRect" parent="LogoButtonSplit/LogoContainer"]
 texture_filter = 2
-custom_minimum_size = Vector2(1200, 0)
 layout_mode = 2
 size_flags_vertical = 4
 texture = ExtResource("1_hgbs1")
@@ -40,8 +38,6 @@ stretch_mode = 4
 [node name="ButtonBoxMargins" type="MarginContainer" parent="LogoButtonSplit"]
 layout_mode = 2
 size_flags_horizontal = 8
-theme_override_constants/margin_left = 128
-theme_override_constants/margin_right = 128
 
 [node name="ButtonBox" type="VBoxContainer" parent="LogoButtonSplit/ButtonBoxMargins"]
 unique_name_in_owner = true


### PR DESCRIPTION
The main menu had some hardcoded dimensions for the previous base resolution, 1920×1080, which meant that it did not fit 1280×720:

- The logo had a custom minimum width of 1200px, and a 128px margin to its left; 1328px > 1280px.
- The button box had 128px margins to its left and right.

Remove these. To my eye the result is OK, though it will look better with a smaller button font.

Fixes https://github.com/endlessm/threadbare/issues/1138