### PR TITLE
Record which quests have been played to completion

### DIFF
--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
@@ -36,6 +36,7 @@ func _ready() -> void:
 		GameState.set_incorporating_threads(false)
 
 
+
 func _on_interaction_ended() -> void:
 	if _have_threads:
 		# Hide interact label during scene transition
@@ -48,6 +49,9 @@ func _on_interaction_ended() -> void:
 func on_offering_succeeded() -> void:
 	loom_offering_animation_player.play(&"loom_offering")
 	await loom_offering_animation_player.animation_finished
+	#Mark mission completed
+	var quest_path: String = GameState._state.get_value(GameState.QUEST_SECTION, GameState.QUEST_PATH_KEY, "")
+	GameState.add_completed_mission(quest_path)
 	GameState.clear_inventory()
 
 

--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
@@ -36,7 +36,6 @@ func _ready() -> void:
 		GameState.set_incorporating_threads(false)
 
 
-
 func _on_interaction_ended() -> void:
 	if _have_threads:
 		# Hide interact label during scene transition
@@ -49,10 +48,8 @@ func _on_interaction_ended() -> void:
 func on_offering_succeeded() -> void:
 	loom_offering_animation_player.play(&"loom_offering")
 	await loom_offering_animation_player.animation_finished
-	#Mark mission completed
-	var quest_path: String = GameState._state.get_value(GameState.QUEST_SECTION, GameState.QUEST_PATH_KEY, "")
-	GameState.add_completed_mission(quest_path)
 	GameState.clear_inventory()
+	GameState.mark_quest_completed()
 
 
 func is_item_offering_possible() -> bool:

--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -167,4 +167,4 @@ func _save() -> void:
 		return
 	var err := _state.save(GAME_STATE_PATH)
 	if err != OK:
-		push_error("Failed to save settings to %s: %s" % [GAME_STATE_PATH, err])
+		push_error("Failed to save settings to %s : %s" % [GAME_STATE_PATH, err])

--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -21,6 +21,7 @@ const QUEST_SECTION := "quest"
 const QUEST_PATH_KEY := "resource_path"
 const QUEST_CURRENTSCENE_KEY := "current_scene"
 const QUEST_SPAWNPOINT_KEY := "current_spawn_point"
+const QUEST_COMPLETED_KEY := "completed_missions"
 const GLOBAL_SECTION := "global"
 const GLOBAL_INCORPORATING_THREADS_KEY := "incorporating_threads"
 
@@ -34,6 +35,7 @@ const TRANSIENT_SCENES := [
 ## can be added to the loom.
 @export var inventory: Array[InventoryItem] = []
 @export var current_spawn_point: NodePath
+@export var completed_missions: Array[String] = []
 
 ## Set when the loom transports the player to a trio of Sokoban puzzles, so that
 ## when the player returns to Fray's End the loom can trigger a brief cutscene.
@@ -87,6 +89,13 @@ func set_current_spawn_point(spawn_point: NodePath = ^"") -> void:
 	current_spawn_point = spawn_point
 	_state.set_value(QUEST_SECTION, QUEST_SPAWNPOINT_KEY, current_spawn_point)
 	_save()
+	
+
+func add_completed_mission(mission_name: String) -> void:
+	if mission_name not in completed_missions:
+		completed_missions.append(mission_name)
+		_state.set_value(QUEST_SECTION, QUEST_COMPLETED_KEY, completed_missions)
+		_save()
 
 
 ## Set the scene path and [member current_spawn_point] without triggering a save.
@@ -133,6 +142,7 @@ func _update_inventory_state() -> void:
 ## Clear the persisted state.
 func clear() -> void:
 	_state.clear()
+	completed_missions.clear()
 	_save()
 
 
@@ -159,6 +169,7 @@ func restore() -> Dictionary:
 	incorporating_threads = _state.get_value(
 		GLOBAL_SECTION, GLOBAL_INCORPORATING_THREADS_KEY, false
 	)
+	completed_missions = _state.get_value(QUEST_SECTION, QUEST_COMPLETED_KEY, []) 
 	return {"scene_path": scene_path, "spawn_point": current_spawn_point}
 
 


### PR DESCRIPTION
Add a new field to the game state which holds an array of the paths of completed quests. Update it when the player takes threads to the loom. Clear it when the state is cleared.

Resolves https://github.com/endlessm/threadbare/issues/771

---

I tested in a new scene simulating the collection and delivery of the objects. I deleted that and didn't add it to the changes because it was to save time during testing.

https://docs.google.com/document/d/1wQst5g8896AjaVjZsPAC9E2uumBQm0mpBo9vJWxlDOA/edit?tab=t.0