### PR TITLE
Factor NavigationFollowWalkBehavior out of void_spreading_enemy.gd

### DIFF
--- a/scenes/game_elements/characters/components/gym_area_test.tscn
+++ b/scenes/game_elements/characters/components/gym_area_test.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=4 uid="uid://ikgvi75j5dls"]
+[gd_scene load_steps=37 format=4 uid="uid://ikgvi75j5dls"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_5xpm5"]
 [ext_resource type="SpriteFrames" uid="uid://07di3updrwh0" path="res://scenes/game_elements/characters/components/sprite_frames/storyweaver_purple.tres" id="3_6axvd"]
@@ -19,6 +19,13 @@
 [ext_resource type="Script" uid="uid://csev4hv57utxv" path="res://scenes/game_logic/walk_behaviors/character_speeds.gd" id="17_itker"]
 [ext_resource type="SpriteFrames" uid="uid://r3dn5pxqk1sv" path="res://scenes/game_elements/characters/enemies/guard/components/storyvore_frames_gray.tres" id="17_w4jvh"]
 [ext_resource type="Script" uid="uid://id28maao3vdy" path="res://scenes/game_logic/walk_behaviors/path_walk_behavior.gd" id="18_wq1h3"]
+[ext_resource type="SpriteFrames" uid="uid://dnq8cw1cio2we" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_green.tres" id="20_jdub8"]
+[ext_resource type="Script" uid="uid://r1kriwyodjlt" path="res://scenes/game_logic/walk_behaviors/navigation_follow_walk_behavior.gd" id="21_jdub8"]
+
+[sub_resource type="NavigationPolygon" id="NavigationPolygon_oojqe"]
+vertices = PackedVector2Array(2612.09, 882.242, 1372.27, 799.719, 1388.82, 670.781, 2393.78, 645.758, 2512.78, -340, 2413.06, -200.32, 1470.91, -340, 1455.69, -202.648, -91.9688, -367.812, 1185.81, -149, 214.844, -149, 1448.35, 0.960938, 1188.65, 0.03125, -89.0234, 939, 227.094, 641.859, 380.844, 893.93, 378.094, 727.859)
+polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3), PackedInt32Array(4, 0, 3, 5), PackedInt32Array(6, 4, 5, 7), PackedInt32Array(8, 6, 7, 9, 10), PackedInt32Array(11, 12, 9, 7), PackedInt32Array(13, 8, 10, 14), PackedInt32Array(15, 13, 14, 16)])
+outlines = Array[PackedVector2Array]([PackedVector2Array(-99, 950, 391, 903, 388, 722, 237, 636, 225, -139, 1176, -139, 1178.83, 10, 1458, 11, 1465.33, -192.625, 2402.83, -190.337, 2384, 636, 1380, 661, 1361, 809, 2623, 893, 2522, -350, 1471, -350, -102, -378)])
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_oojqe"]
 
@@ -102,6 +109,10 @@ _data = {
 }
 point_count = 11
 
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_jdub8"]
+radius = 6.0
+height = 21.9972
+
 [node name="TestGymArea" type="Node2D"]
 
 [node name="TileMapLayers" type="Node2D" parent="."]
@@ -125,6 +136,9 @@ tile_set = ExtResource("1_5xpm5")
 [node name="TileMapLayerElevation" type="TileMapLayer" parent="TileMapLayers"]
 tile_map_data = PackedByteArray("AAALABIABAABAAAAAAAMABIABAABAAAAAAANABIABAABAAAAAAAOABIABAABAAAAAAAPABIABAABAAAAAAAQABIABAABAAAAAAARABIABAABAAAAAAAWABIABAAAAAAAAAAXABIABAABAAAAAAAYABIABAABAAAAAAAZABIABAABAAAAAAAaABIABAABAAAAAAAbABIABAABAAAAAAAcABIABAABAAAAAAAdABIABAABAAAAAAAeABIABAABAAAAAAAKABIABAABAAAAAAAKABMABAABAAIAAAALABMABAABAAIAAAANABMABAABAAIAAAAMABMABAABAAIAAAAOABMABAABAAIAAAAPABMABAABAAIAAAAQABMABAABAAIAAAARABMABAABAAIAAAAWABMABAAAAAIAAAAXABMABAABAAIAAAAYABMABAABAAIAAAAZABMABAABAAIAAAAaABMABAABAAIAAAAbABMABAABAAIAAAAcABMABAABAAIAAAAdABMABAABAAIAAAAeABMABAABAAIAAAAKABQABAABAAMAAAALABQABAABAAMAAAAMABQABAABAAMAAAANABQABAABAAMAAAAOABQABAABAAMAAAAPABQABAABAAMAAAAQABQABAABAAMAAAARABQABAABAAMAAAAWABQABAAAAAMAAAAXABQABAABAAMAAAAYABQABAABAAMAAAAZABQABAABAAMAAAAaABQABAABAAMAAAAbABQABAABAAMAAAAcABQABAABAAMAAAAdABQABAABAAMAAAAeABQABAABAAMAAAASABQABAACAAMAAAASABMABAACAAEAAAASABIABAACAAAAAAAJABMABAABAAIAAAAJABIABAABAAEAAAAJABEABAACAAEAAAAJABAABAACAAEAAAAJAA8ABAACAAEAAAAJAA4ABAACAAEAAAAJAA0ABAACAAAAAAAIABMABAAAAAIAAAAIABIABAAAAAEAAAAIABEABAAAAAEAAAAIABAABAAAAAEAAAAIAA8ABAAAAAEAAAAIAA4ABAAAAAEAAAAIAA0ABAAAAAAAAAAgABMABAACAAIAAAAgABIABAACAAEAAAAgABEABAACAAEAAAAgABAABAACAAEAAAAgAA8ABAACAAEAAAAgAA4ABAACAAEAAAAfABMABAABAAIAAAAfABIABAABAAEAAAAfABEABAAAAAEAAAAfABAABAAAAAEAAAAfAA8ABAAAAAEAAAAfAA4ABAAAAAEAAAAfAA0ABAAAAAAAAAAJABQABAABAAMAAAAIABQABAAAAAMAAAAgABQABAACAAMAAAAfABQABAABAAMAAAAgAA0ABAACAAAAAAAIAAMABAAAAAEAAAAIAAQABAAAAAEAAAAIAAUABAAAAAEAAAAIAAYABAAAAAEAAAAIAAcABAAAAAEAAAAIAAgABAAAAAIAAAAIAAkABAAAAAMAAAAJAAMABAABAAEAAAAJAAQABAACAAEAAAAJAAUABAACAAEAAAAJAAYABAACAAEAAAAJAAcABAACAAEAAAAJAAgABAACAAIAAAAJAAkABAACAAMAAAAKAAMABAABAAIAAAAKAAQABAABAAMAAAALAAMABAABAAEAAAALAAQABAABAAMAAAAMAAMABAABAAEAAAAMAAQABAABAAMAAAANAAMABAABAAEAAAANAAQABAABAAMAAAAOAAMABAABAAEAAAAOAAQABAABAAMAAAAPAAMABAABAAEAAAAPAAQABAABAAMAAAAQAAMABAABAAEAAAAQAAQABAABAAMAAAARAAMABAABAAEAAAARAAQABAABAAMAAAASAAMABAACAAEAAAASAAQABAACAAMAAAAWAAMABAAAAAIAAAAWAAQABAAAAAMAAAAXAAMABAABAAEAAAAXAAQABAABAAMAAAAYAAMABAABAAEAAAAYAAQABAABAAMAAAAZAAMABAABAAEAAAAZAAQABAABAAMAAAAaAAMABAABAAEAAAAaAAQABAABAAMAAAAbAAMABAABAAEAAAAbAAQABAABAAMAAAAcAAMABAABAAEAAAAcAAQABAABAAMAAAAdAAMABAABAAEAAAAdAAQABAABAAMAAAAeAAMABAABAAIAAAAeAAQABAABAAMAAAAfAAMABAABAAEAAAAfAAQABAAAAAEAAAAfAAUABAAAAAEAAAAfAAYABAAAAAEAAAAfAAcABAAAAAEAAAAfAAgABAAAAAIAAAAfAAkABAAAAAMAAAAgAAMABAACAAEAAAAgAAQABAACAAEAAAAgAAUABAACAAEAAAAgAAYABAACAAEAAAAgAAcABAACAAEAAAAgAAgABAACAAIAAAAgAAkABAACAAMAAAAIAAIABAAAAAAAAAAJAAIABAABAAAAAAAKAAIABAABAAAAAAALAAIABAABAAAAAAAMAAIABAABAAAAAAANAAIABAABAAAAAAAOAAIABAABAAAAAAAPAAIABAABAAAAAAAQAAIABAABAAAAAAARAAIABAABAAAAAAASAAIABAACAAAAAAAWAAIABAAAAAAAAAAXAAIABAABAAAAAAAYAAIABAABAAAAAAAZAAIABAABAAAAAAAaAAIABAABAAAAAAAbAAIABAABAAAAAAAcAAIABAABAAAAAAAdAAIABAABAAAAAAAeAAIABAABAAAAAAAfAAIABAABAAAAAAAgAAIABAACAAAAAAA=")
 tile_set = ExtResource("1_5xpm5")
+
+[node name="NavigationRegion2D" type="NavigationRegion2D" parent="."]
+navigation_polygon = SubResource("NavigationPolygon_oojqe")
 
 [node name="OnTheGround" type="Node2D" parent="."]
 y_sort_enabled = true
@@ -334,7 +348,37 @@ character = NodePath("..")
 position = Vector2(839, 865)
 curve = SubResource("Curve2D_wq1h3")
 
+[node name="CharacterBody2D6" type="CharacterBody2D" parent="OnTheGround"]
+collision_layer = 2
+collision_mask = 19
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/CharacterBody2D6"]
+rotation = -1.55475
+shape = SubResource("CapsuleShape2D_jdub8")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="OnTheGround/CharacterBody2D6"]
+position = Vector2(0, -39)
+sprite_frames = ExtResource("20_jdub8")
+animation = &"idle"
+
+[node name="CharacterSpriteBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D6/AnimatedSprite2D" node_paths=PackedStringArray("character", "sprite")]
+script = ExtResource("15_utmd2")
+character = NodePath("../..")
+sprite = NodePath("..")
+metadata/_custom_type_script = "uid://dy68p7gf07pi3"
+
+[node name="NavigationAgent2D" type="NavigationAgent2D" parent="OnTheGround/CharacterBody2D6"]
+path_desired_distance = 64.0
+target_desired_distance = 64.0
+
+[node name="NavigationFollowWalkBehavior" type="Node2D" parent="OnTheGround/CharacterBody2D6" node_paths=PackedStringArray("target", "agent", "character")]
+script = ExtResource("21_jdub8")
+target = NodePath("../../CharacterBody2D4")
+agent = NodePath("../NavigationAgent2D")
+character = NodePath("..")
+
 [node name="ScreenOverlay" type="CanvasLayer" parent="."]
 
 [connection signal="running_changed" from="OnTheGround/CharacterBody2D4/InputWalkBehavior" to="OnTheGround/CharacterBody2D4/GPUParticles2D" method="_on_input_walk_behavior_running_changed"]
 [connection signal="running_changed" from="OnTheGround/CharacterBody2D4/InputWalkBehavior" to="OnTheGround/CharacterBody2D4/AnimatedSprite2D/CharacterSpriteBehavior" method="on_running_changed"]
+[connection signal="running_changed" from="OnTheGround/CharacterBody2D6/NavigationFollowWalkBehavior" to="OnTheGround/CharacterBody2D6/AnimatedSprite2D/CharacterSpriteBehavior" method="on_running_changed"]

--- a/scenes/game_logic/walk_behaviors/navigation_follow_walk_behavior.gd
+++ b/scenes/game_logic/walk_behaviors/navigation_follow_walk_behavior.gd
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name NavigationFollowWalkBehavior
+extends BaseCharacterBehavior
+## @experimental
+##
+## Make the character follow a target, using a [NavigationAgent2D] to
+## route towards it.
+
+## Emitted when the character starts or stops running.
+signal running_changed(is_running: bool)
+
+## Emitted when [member target] becomes reached or not.
+signal target_reached_changed(is_reached: bool)
+
+## Emitted when [member is_target_reachable] changes.
+signal target_unreachable_changed(is_reachable: bool)
+
+## Parameters controlling the speed at which this character walks. If unset, the default values of
+## [CharacterSpeeds] are used.
+@export var speeds: CharacterSpeeds
+
+## The target to follow.
+@export var target: Node2D:
+	set = _set_target
+
+## The [NavigationAgent2D] to use to navigate to [member target]
+@export var agent: NavigationAgent2D:
+	set = _set_agent
+
+## The distance to travel between retargetting.
+## If zero, it will constantly retarget.
+@export_range(0, 100, 1, "or_greater", "suffix:px") var travel_distance: float = 50.0
+
+## The distance to [member target] above which this character will start running.
+## If this is 0, this character will always move at [member CharacterSpeeds.run_speed];
+## if this is [const INF], this character will always move at [member CharacterSpeeds.walk_speed].
+@export_range(0, 640, 32, "or_greater", "suffix:px") var running_distance: float = 196.0
+
+## The current distance travelled since last direction update.
+var distance: float = 0
+
+## True if the character is running
+var is_running: bool:
+	set = _set_is_running
+
+## True if the character has reached [member target].
+var is_target_reached: bool:
+	set = _set_is_target_reached
+
+## True if navigation has finished and [member target] is unreachable.
+var is_target_unreachable: bool:
+	set = _set_is_target_unreachable
+
+
+func _set_target(new_target: Node2D) -> void:
+	target = new_target
+	update_configuration_warnings()
+
+
+func _set_agent(new_agent: NavigationAgent2D) -> void:
+	if agent:
+		agent.target_reached.disconnect(_on_agent_target_reached)
+		agent.navigation_finished.disconnect(_on_agent_navigation_finished)
+	agent = new_agent
+	if agent:
+		agent.target_reached.connect(_on_agent_target_reached)
+		agent.navigation_finished.connect(_on_agent_navigation_finished)
+	update_configuration_warnings()
+
+
+func _set_is_running(new_is_running: bool) -> void:
+	if is_running == new_is_running:
+		return
+	is_running = new_is_running
+	running_changed.emit(is_running)
+
+
+func _set_is_target_reached(new_is_target_reached: bool) -> void:
+	if is_target_reached == new_is_target_reached:
+		return
+	is_target_reached = new_is_target_reached
+	target_reached_changed.emit(is_target_reached)
+
+
+func _set_is_target_unreachable(new_is_target_unreachable: bool) -> void:
+	if is_target_unreachable == new_is_target_unreachable:
+		return
+	is_target_unreachable = new_is_target_unreachable
+	target_unreachable_changed.emit(is_target_unreachable)
+
+
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings := super._get_configuration_warnings()
+	if not target:
+		warnings.append("Target property must be set.")
+	if not agent:
+		warnings.append("Agent property must be set.")
+	return warnings
+
+
+func _update_target_position() -> void:
+	if agent and target:
+		agent.target_position = target.global_position
+
+
+func _on_agent_target_reached() -> void:
+	is_target_reached = true
+	is_target_unreachable = false
+
+
+func _on_agent_navigation_finished() -> void:
+	if agent.is_target_reachable():
+		# The NavigationAgent2D documentation specifies that target_reached will
+		# be emitted just before navigation_finished when the target is
+		# reachable.
+		assert(is_target_reached)
+	else:
+		is_target_reached = false
+		is_target_unreachable = true
+
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		set_physics_process(false)
+		return
+
+	if not speeds:
+		speeds = CharacterSpeeds.new()
+
+	_update_target_position()
+
+
+func _physics_process(delta: float) -> void:
+	var retarget := false
+
+	if agent.is_navigation_finished():
+		character.velocity = character.velocity.move_toward(
+			Vector2.ZERO, speeds.stopping_step * delta
+		)
+		# Retarget if the target has moved more than some threshold
+		# TODO: should this be a separate threshold?
+		retarget = agent.target_position.distance_to(target.global_position) > travel_distance
+	else:
+		is_target_reached = false
+
+		var next_path_position := agent.get_next_path_position()
+		var direction := global_position.direction_to(next_path_position)
+		is_running = agent.distance_to_target() > running_distance
+		var speed := speeds.run_speed if is_running else speeds.walk_speed
+		character.velocity = character.velocity.move_toward(
+			direction * speed, speeds.moving_step * delta
+		)
+
+	character.move_and_slide()
+	distance += character.get_position_delta().length()
+
+	if retarget or distance > travel_distance:
+		_update_target_position()
+		distance = 0.0

--- a/scenes/game_logic/walk_behaviors/navigation_follow_walk_behavior.gd.uid
+++ b/scenes/game_logic/walk_behaviors/navigation_follow_walk_behavior.gd.uid
@@ -1,0 +1,1 @@
+uid://r1kriwyodjlt

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.gd
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.gd
@@ -3,6 +3,16 @@
 extends CharacterBody2D
 ## @experimental
 
+## The state of this enemy
+enum State {
+	## The void is lying in wait
+	IDLE,
+	## The void is chasing the player
+	CHASING,
+	## The void has engulfed the player
+	CAUGHT,
+}
+
 const VOID_PARTICLES = preload(
 	"res://scenes/quests/lore_quests/quest_002/1_void_runner/components/void_particles.tscn"
 )
@@ -17,47 +27,44 @@ const NEIGHBORS := [
 
 @export var void_layer: TileMapCover
 
-@export_range(10, 100000, 10) var walk_speed: float = 300.0
-@export_range(10, 100000, 10) var run_speed: float = 500.0
+var player: Player:
+	set = _set_player
 
-var player: Player
+var state := State.IDLE:
+	set = _set_state
 
-var _moving: bool = false
-var _update_interval: float = 10.0 / 60.0
-var _next_update: float
+@onready var walk: NavigationFollowWalkBehavior = %NavigationFollowWalkBehavior
 
-@onready var navigation_agent: NavigationAgent2D = %NavigationAgent2D
+
+func _set_player(new_player: Player) -> void:
+	player = new_player
+	if walk:
+		walk.target = player
+
+
+func _set_state(new_state: State) -> void:
+	state = new_state
+	if walk:
+		match state:
+			State.IDLE:
+				walk.process_mode = Node.PROCESS_MODE_DISABLED
+			State.CHASING:
+				walk.process_mode = Node.PROCESS_MODE_INHERIT
+
+
+func _ready() -> void:
+	player = player
+	state = state
 
 
 func start(detected_node: Node2D) -> void:
-	assert(detected_node is Player)
-	player = detected_node as Player
-	_moving = true
-	navigation_agent.target_position = player.global_position
-
-
-func _physics_process(delta: float) -> void:
-	if not _moving:
-		velocity = Vector2.ZERO
-		return
-
-	_next_update -= delta
-	if navigation_agent.is_navigation_finished() or _next_update < 0:
-		_next_update = _update_interval
-		navigation_agent.target_position = player.global_position
-		return
-
-	var current_agent_position: Vector2 = global_position
-	var next_path_position: Vector2 = navigation_agent.get_next_path_position()
-	var running := navigation_agent.distance_to_target() > (64 * 3)
-	var speed := run_speed if running else walk_speed
-	# TODO: smoothly change between running & walking speed?
-	velocity = current_agent_position.direction_to(next_path_position) * speed
-	move_and_slide()
+	if detected_node is Player:
+		player = detected_node
+		state = State.CHASING
 
 
 func _process(_delta: float) -> void:
-	if not _moving:
+	if state == State.IDLE:
 		return
 
 	var coord := void_layer.coord_for(self)
@@ -82,10 +89,10 @@ func _on_player_capture_area_body_entered(body: Node2D) -> void:
 	if body != player:
 		return
 
-	if not _moving:
+	if state != State.CHASING:
 		return
 
-	_moving = false
+	state = State.CAUGHT
 	player.mode = Player.Mode.DEFEATED
 	var tween := create_tween()
 	tween.tween_property(player, "scale", Vector2.ZERO, 2.0)

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://cokul8w425pja"]
+[gd_scene load_steps=5 format=3 uid="uid://cokul8w425pja"]
 
 [ext_resource type="Script" uid="uid://dil8mgaf03bei" path="res://scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.gd" id="1_304le"]
+[ext_resource type="Script" uid="uid://r1kriwyodjlt" path="res://scenes/game_logic/walk_behaviors/navigation_follow_walk_behavior.gd" id="2_31awk"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_8g3pn"]
 size = Vector2(68, 20)
@@ -27,5 +28,12 @@ collision_layer = 0
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PlayerCaptureArea"]
 shape = SubResource("CircleShape2D_8l6e1")
 debug_color = Color(0.911153, 9.95344e-05, 0.727585, 0.42)
+
+[node name="NavigationFollowWalkBehavior" type="Node2D" parent="." node_paths=PackedStringArray("agent", "character")]
+unique_name_in_owner = true
+script = ExtResource("2_31awk")
+agent = NodePath("../NavigationAgent2D")
+character = NodePath("..")
+metadata/_custom_type_script = "uid://r1kriwyodjlt"
 
 [connection signal="body_entered" from="PlayerCaptureArea" to="." method="_on_player_capture_area_body_entered"]


### PR DESCRIPTION
Previously, void_spreading_enemy.gd contained movement logic somewhat
entwined with the other logic for this entity. But the movement logic
was relatively generic – follow a target using a NavigationAgent2D – and
you could imagine a different flavour of this entity that moves in a
different way, perhaps following a path.

Create NavigationFollowWalkBehavior based on the logic in
void_spreading_enemy.gd, with similar functionality to
FollowWalkBehavior but using a NavigationAgent2D rather than
straight-line pathfinding.

As with the previous implementation, if the distance to the target is
above a configurable threshold, the character runs; otherwise, they
walk. Like InputWalkBehavior, a running_changed signal is emitted, which
can be connected to CharacterSpriteBehavior to control animations,
though this is not used in the void runner scene.

Signals are emitted when navigation ends (either indicating that the
target has been reached, or that it cannot be reached), though this is
also not used in the void runner scene.

I also added an example of this behavior to the gym.

Fixes #1175
