### PR TITLE
AreaFiller: Support undo/redo

### DIFF
--- a/scenes/game_elements/props/area_filler/area_filler.gd
+++ b/scenes/game_elements/props/area_filler/area_filler.gd
@@ -49,6 +49,12 @@ func _exit_tree() -> void:
 	update_configuration_warnings()
 
 
+func _ready() -> void:
+	if not Engine.is_editor_hint():
+		self.queue_free()
+		return
+
+
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: PackedStringArray
 

--- a/scenes/game_elements/props/area_filler/area_filler.gd
+++ b/scenes/game_elements/props/area_filler/area_filler.gd
@@ -100,7 +100,8 @@ func _generate_points() -> PackedVector2Array:
 
 
 func _prepare_child(pos: Vector2) -> Node2D:
-	var child: Node2D = scenes.pick_random().instantiate()
+	var scene: PackedScene = scenes.pick_random()
+	var child: Node2D = scene.instantiate(PackedScene.GenEditState.GEN_EDIT_STATE_INSTANCE)
 	child.position = pos
 	if sprite_frames and "sprite_frames" in child:
 		child.sprite_frames = sprite_frames.pick_random()

--- a/scenes/game_elements/props/area_filler/components/area_filler_test.tscn
+++ b/scenes/game_elements/props/area_filler/components/area_filler_test.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=4 uid="uid://wrwe3x1ens4w"]
+[gd_scene load_steps=11 format=4 uid="uid://wrwe3x1ens4w"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_0gk0u"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="3_idsd5"]
@@ -8,8 +8,6 @@
 [ext_resource type="PackedScene" uid="uid://bbsc3wssndtfe" path="res://scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.tscn" id="6_86ofm"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="7_rciqa"]
 [ext_resource type="SpriteFrames" uid="uid://djwymcffy83" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_red.tres" id="8_2334v"]
-[ext_resource type="Script" uid="uid://eenl0b7aoxuq" path="res://scenes/game_elements/props/decoration/flower/components/flower.gd" id="9_cbbm0"]
-[ext_resource type="Script" uid="uid://dnb4ys8yvi1pj" path="res://scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd" id="9_ccj6l"]
 [ext_resource type="SpriteFrames" uid="uid://2ek86nvw6y28" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_yellow.tres" id="9_erlwp"]
 [ext_resource type="PackedScene" uid="uid://c0104ickpm3ru" path="res://scenes/game_elements/props/decoration/flower/flower.tscn" id="10_cbbm0"]
 
@@ -191,89 +189,68 @@ scenes = Array[PackedScene]([ExtResource("10_cbbm0"), ExtResource("6_86ofm")])
 minimum_separation = 128.0
 metadata/_custom_type_script = "uid://bdhjixygupit1"
 
-[node name="Flower" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(816.928, 202.694)
-script = ExtResource("9_cbbm0")
 
-[node name="Flower2" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower2" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(1066.38, 210.062)
-script = ExtResource("9_cbbm0")
 
-[node name="Flower3" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower3" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(702.267, 140.715)
-script = ExtResource("9_cbbm0")
 
-[node name="Flower4" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower4" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(806.782, 47.5946)
-script = ExtResource("9_cbbm0")
 
-[node name="HidingMushroom" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
+[node name="HidingMushroom" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
 position = Vector2(948.902, 117.208)
-script = ExtResource("9_ccj6l")
 
-[node name="Flower5" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower5" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(589.042, -34.2899)
-script = ExtResource("9_cbbm0")
 
-[node name="Flower6" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower6" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(1196.16, 127.975)
-script = ExtResource("9_cbbm0")
 
-[node name="Flower7" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower7" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(1157.3, 5.00844)
-script = ExtResource("9_cbbm0")
 
-[node name="HidingMushroom2" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
+[node name="HidingMushroom2" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
 position = Vector2(1024.46, -2.36847)
-script = ExtResource("9_ccj6l")
 
-[node name="HidingMushroom3" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
+[node name="HidingMushroom3" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
 position = Vector2(1009.1, 684.073)
-script = ExtResource("9_ccj6l")
 
-[node name="Flower8" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower8" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(1162.41, 496.511)
-script = ExtResource("9_cbbm0")
 
-[node name="Flower9" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower9" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(1029.54, 503.905)
-script = ExtResource("9_cbbm0")
 
-[node name="Flower10" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower10" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(878.909, 665.972)
-script = ExtResource("9_cbbm0")
 
-[node name="Flower11" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower11" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(735.607, 583.837)
-script = ExtResource("9_cbbm0")
 
-[node name="HidingMushroom4" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
+[node name="HidingMushroom4" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
 position = Vector2(889.863, 513.511)
-script = ExtResource("9_ccj6l")
 
-[node name="Flower12" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower12" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(743.965, 432.988)
-script = ExtResource("9_cbbm0")
 
-[node name="HidingMushroom5" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
+[node name="HidingMushroom5" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
 position = Vector2(609.304, 672.168)
-script = ExtResource("9_ccj6l")
 
-[node name="Flower13" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower13" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(1128.81, 622.34)
-script = ExtResource("9_cbbm0")
 
-[node name="Flower14" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower14" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(601.397, 435.927)
-script = ExtResource("9_cbbm0")
 
-[node name="HidingMushroom6" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
+[node name="HidingMushroom6" parent="OnTheGround/Flowerbed" instance=ExtResource("6_86ofm")]
 position = Vector2(1408.24, 454.371)
-script = ExtResource("9_ccj6l")
 
-[node name="Flower15" type="Node2D" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
+[node name="Flower15" parent="OnTheGround/Flowerbed" instance=ExtResource("10_cbbm0")]
 position = Vector2(1289.73, 532.109)
-script = ExtResource("9_cbbm0")
 
 [node name="ForestSign" parent="OnTheGround" instance=ExtResource("7_rciqa")]
 position = Vector2(1422, 305)


### PR DESCRIPTION
It has often annoyed me that the "Refill" action cannot be undone with Ctrl-Z.

Integrate with EditorUndoRedoManager to make this possible.

In addition, change how the child nodes are instantiated so they are persisted to the scene in just the same way as if they were instantiated by hand, fixing an issue where loading and saving the scene later, without changes, would change the `.tscn`.