### PR TITLE
Sokoban HUD: Don't override mouse cursor shape

### DIFF
--- a/scenes/eternal_loom_sokoban/components/hud/sokoban_hud.tscn
+++ b/scenes/eternal_loom_sokoban/components/hud/sokoban_hud.tscn
@@ -50,7 +50,6 @@ size_flags_vertical = 8
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 8
-mouse_default_cursor_shape = 2
 texture = ExtResource("1_78eme")
 script = ExtResource("2_805gl")
 action_name = &"sokoban_undo"


### PR DESCRIPTION
The “Z” key indicator in the Sokoban input hints HUD had its mouse cursor shape
set to CURSOR_POINTING_HAND:

> Pointing hand cursor. Usually used to indicate the pointer is over a link or
> other interactable item.

But this icon isn't interactable.

This has been set this way since commit a52f9b03e3f5066d356c63bcc56d4f47899e72d0
when the Sokoban input hints were added. I'm sure this was not intentional.
Unset it.

<img width="552" height="261" alt="image" src="https://github.com/user-attachments/assets/e7425790-8946-432b-a1ba-ac48164e956f" />
