### PR TITLE
linux: Add 0.1.4 release to appstream releases file

### DIFF
--- a/linux/releases.xml
+++ b/linux/releases.xml
@@ -4,6 +4,9 @@ SPDX-FileCopyrightText: The Threadbare Authors
 SPDX-License-Identifier: CC-BY-4.0
 -->
 <releases>
+  <release version="0.1.4" date="2025-09-12">
+    <url type="details">https://github.com/endlessm/threadbare/releases/tag/v0.1.4</url>
+  </release>
   <release version="0.1.3" date="2025-08-11">
     <url type="details">https://github.com/endlessm/threadbare/releases/tag/v0.1.3</url>
   </release>


### PR DESCRIPTION
linux: Add 0.1.4 release to appstream releases file

I forgot to do this before the 0.1.4 release.

In theory, now that the release metadata is in a separate file (commit
ca4f638341051af8ec97e04ab48c46c3f3be9183), it is not a problem that this
was not part of the 0.1.4 release. Let's see if that's true!
