### PR TITLE
Fix: prevent intro dialogue from replaying on respawn in stealth challenges

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -42,6 +42,7 @@ var incorporating_threads: bool = false
 var persist_progress: bool
 var _state := ConfigFile.new()
 
+var intro_dialogue_shown: bool = false
 
 func _ready() -> void:
 	var initial_scene_uid := ResourceLoader.get_resource_uid(

--- a/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
+++ b/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
@@ -2884,6 +2884,6 @@ scale = Vector2(0.3, 0.3)
 
 [node name="Firekeeper" parent="." instance=ExtResource("15_wgqmn")]
 position = Vector2(205, 546)
-npc_name = "Firekeeper"
 dialogue = ExtResource("16_rlkm0")
+npc_name = "Firekeeper"
 sprite_frames = ExtResource("17_0ownb")

--- a/scenes/ui_elements/cinematic/cinematic.gd
+++ b/scenes/ui_elements/cinematic/cinematic.gd
@@ -21,16 +21,15 @@ extends Node2D
 
 
 func _ready() -> void:
-	DialogueManager.show_dialogue_balloon(dialogue, "", [self])
-	await DialogueManager.dialogue_ended
+	if not GameState.intro_dialogue_shown:
+		DialogueManager.show_dialogue_balloon(dialogue, "", [self])
+		await DialogueManager.dialogue_ended
+		GameState.intro_dialogue_shown = true
 
 	if next_scene:
-		(
-			SceneSwitcher
-			. change_to_file_with_transition(
-				next_scene,
-				spawn_point_path,
-				Transition.Effect.FADE,
-				Transition.Effect.FADE,
-			)
+		SceneSwitcher.change_to_file_with_transition(
+			next_scene,
+			spawn_point_path,
+			Transition.Effect.FADE,
+			Transition.Effect.FADE,
 		)


### PR DESCRIPTION
This PR fixes #949 by ensuring the intro dialogue only plays once at the start of the level, and no longer replays after respawning.