### PR TITLE
Issue template: prevent unwanted breaks in descriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,7 +6,7 @@ type: Bug
 body:
   - type: markdown
     attributes:
-      value: |
+      value: >
         Thanks for taking the time to file an issue! **Please provide as much
         detail as you can** so we can properly confirm, triage, and fix your bug.
 
@@ -14,7 +14,7 @@ body:
     id: about
     attributes:
       label: Description
-      description: |
+      description: >
         Describe the bug you're seeing. Provide detail such as **where in the
         game** you experienced it and **what you were doing** in the game when
         it happened. If you can make it happen reliably, **share the steps to


### PR DESCRIPTION
Super minor nit, but I noticed the top form description breaking from the newline:

> <img width="777" height="507" alt="image" src="https://github.com/user-attachments/assets/1eae904c-ed7f-4490-9ba1-7c0ba7ed8bea" />

We don't need the literal line breaks in the Markdown string, so replace the literal string `|` with a folded string `>`.