### PR TITLE
Void chromakey: remove unused wipe_progress parameter

### DIFF
--- a/scenes/game_elements/props/void/components/void_chromakey.gdshader
+++ b/scenes/game_elements/props/void/components/void_chromakey.gdshader
@@ -36,8 +36,6 @@ uniform vec4 chroma_key: source_color = vec4(1.0, 0.0, 0.0, 1.0);
  */
 uniform vec4 background_color: source_color = vec4(0.086, 0.11, 0.18, 1.0);
 
-uniform vec2 wipe_progress;
-
 // The origin is the upper-left corner of the screen and coordinates ranging from (0.0, 0.0) to viewport size.
 varying vec2 screen_pos;
 

--- a/scenes/game_elements/props/void/void_chromakey_material.tres
+++ b/scenes/game_elements/props/void/void_chromakey_material.tres
@@ -17,4 +17,3 @@ shader_parameter/sparsity = 20.0
 shader_parameter/flicker_rate = 7.0
 shader_parameter/chroma_key = Color(1, 0, 0, 1)
 shader_parameter/background_color = Color(0.086, 0.11, 0.18, 1)
-shader_parameter/wipe_progress = Vector2(0, 0)


### PR DESCRIPTION
I think I had planned to do a left-to-right transition at some point; I
abandoned that idea but left this unused parameter. Remove it
