### PR TITLE
Add wooden staircase tiles

### DIFF
--- a/assets/first_party/tiles/Cliff_Tiles.png
+++ b/assets/first_party/tiles/Cliff_Tiles.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e18fa6cab18c7edc9a1a038d01279b224e470e2cc1e0c00821f4a088e4228c6
-size 37198
+oid sha256:68951b2c45981b3c90e98fc8e994919e7e961ddc6c7d9ea4877e58b48ce1e4f4
+size 26113


### PR DESCRIPTION
Add wooden staircase tiles

Previously, the staircase tiles in Cliff_Tiles were inherited from Tiny
Swords.

Replace them with very nice new wooden stairs, drawn by 159adrian on
https://github.com/endlessm/threadbare/issues/171. I modified the PNG on
that ticket to move the stairs to exactly the same region, so that no
changes are needed to scenes that already use the old stairs.

The only such scenes are in StoryQuests: Stella and El Juguete Perdido.
I think the wooden stairs look better in both; but if someone wanted to
use the previous stone stairs, they could use
assets/third_party/tiny-swords/Terrain/Ground/Tilemap_Elevation.png in
their own TileSet.

Co-authored-by: 159adrian <213216604+159adrian@users.noreply.github.com>
