### PR TITLE
Store .mp3 files in Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@
 *.webp filter=lfs diff=lfs merge=lfs -text
 *.zip filter=lfs diff=lfs merge=lfs -text
 *.ogv filter=lfs diff=lfs merge=lfs -text
+*.mp3 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
There are currently no .mp3 files in the project; but when they are added, they
should be stored in Git LFS, like other audio files.

See #1227 