### PR TITLE
pre-commit: Disable style checks for StoryQuests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,13 +24,26 @@ repos:
   rev: v3.4.0
   hooks:
   - id: editorconfig-checker
+    exclude: |
+      (?x)^(
+        scenes/quests/story_quests/(?!stella/|template/)
+      )
 
 - repo: https://github.com/Scony/godot-gdscript-toolkit
   rev: 4.3.4
   hooks:
   - id: gdformat
+    exclude: |
+      (?x)^(
+        scenes/quests/story_quests/(?!stella/|template/)
+      )
   - id: gdlint
-    exclude: script_templates/
+    exclude: |
+      (?x)^(
+        script_templates/|
+        scenes/quests/story_quests/(?!stella/|template/)
+      )
+
 exclude: |
   (?x)^(
     addons/dialogue_manager/(.*)|


### PR DESCRIPTION
We enforce coding style and formatting checks on the project as a whole
because we want the reusable code in this project to be exemplary, and
we believe that consistent style and formatting helps to maintain code
quality – and to avoid discussions about style and formatting!

There is less need to apply the same checks to scripts, shaders, and dialogue
files in StoryQuests: these are only used within that specific StoryQuest,
rather than being intended for other quests or components to reuse or extend.
The exceptions is the template quest, and Stella: we do want to maintain
consistent style there.

Exclude all storyquests, except the template and stella, from GDScript style
checks and editorconfig formatting checks. Keep other checks enabled, such as
for large files that should be stored in Git LFS.

This is currently mostly hypothetical – none of the StoryQuests in the tree have
any scripts or shaders, just dialogue files – but there are other quests being
developed which do include custom scripts and shaders.

In addition, treat `.piskel` files like `.svg` files: don't apply end-of-line checks to them, even though they are text files, because they are not intended to be human-edited.

Resolves #1227 