### PR TITLE
Set all CharacterBody2D nodes to Floating

### DIFF
--- a/scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn
+++ b/scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn
@@ -241,6 +241,7 @@ _data = {
 [node name="ThrowingEnemy" type="CharacterBody2D" groups=["throwing_enemy"]]
 collision_layer = 2
 collision_mask = 17
+motion_mode = 1
 script = ExtResource("1_ffq0m")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]

--- a/scenes/game_elements/characters/npcs/elder/elder.tscn
+++ b/scenes/game_elements/characters/npcs/elder/elder.tscn
@@ -20,6 +20,7 @@ size = Vector2(67, 72)
 
 [node name="Elder" type="CharacterBody2D"]
 collision_layer = 2
+motion_mode = 1
 script = ExtResource("1_jlpjw")
 dialogue = ExtResource("2_kqtes")
 look_at_side = 0

--- a/scenes/game_elements/characters/npcs/npc_prop/fray_axeman.tscn
+++ b/scenes/game_elements/characters/npcs/npc_prop/fray_axeman.tscn
@@ -122,6 +122,7 @@ _data = {
 
 [node name="fray_axeman" type="CharacterBody2D"]
 collision_layer = 2
+motion_mode = 1
 script = ExtResource("1_h3xvp")
 sprite_frames = SubResource("SpriteFrames_0a1i7")
 

--- a/scenes/game_elements/characters/npcs/npc_prop/fray_hammerman.tscn
+++ b/scenes/game_elements/characters/npcs/npc_prop/fray_hammerman.tscn
@@ -110,6 +110,7 @@ _data = {
 
 [node name="NpcProp" type="CharacterBody2D"]
 collision_layer = 2
+motion_mode = 1
 script = ExtResource("1_31gn5")
 sprite_frames = SubResource("SpriteFrames_0a1i7")
 

--- a/scenes/game_elements/characters/npcs/npc_prop/fray_idle.tscn
+++ b/scenes/game_elements/characters/npcs/npc_prop/fray_idle.tscn
@@ -8,6 +8,7 @@ height = 42.0
 
 [node name="fray_idle" type="CharacterBody2D"]
 collision_layer = 2
+motion_mode = 1
 script = ExtResource("1_j3sup")
 sprite_frames = ExtResource("2_j3sup")
 

--- a/scenes/game_elements/characters/npcs/talker/talker.tscn
+++ b/scenes/game_elements/characters/npcs/talker/talker.tscn
@@ -13,6 +13,7 @@ size = Vector2(52, 50)
 
 [node name="Talker" type="CharacterBody2D"]
 collision_layer = 2
+motion_mode = 1
 script = ExtResource("1_yqle0")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]

--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -535,6 +535,7 @@ _data = {
 
 [node name="Player" type="CharacterBody2D" groups=["player"]]
 collision_mask = 531
+motion_mode = 1
 script = ExtResource("1_g2els")
 
 [node name="HitBox" type="Area2D" parent="."]

--- a/scenes/game_elements/props/hookable_button_item/hookable_button_item.tscn
+++ b/scenes/game_elements/props/hookable_button_item/hookable_button_item.tscn
@@ -51,6 +51,7 @@ size = Vector2(60, 60)
 [node name="HookableButtonItem" type="CharacterBody2D"]
 collision_layer = 0
 collision_mask = 0
+motion_mode = 1
 script = ExtResource("1_oue3d")
 
 [node name="ButtonItem" parent="." instance=ExtResource("1_vymxr")]

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.tscn
@@ -13,6 +13,7 @@ height = 73.6055
 size = Vector2(52, 50)
 
 [node name="Monk" type="CharacterBody2D"]
+motion_mode = 1
 script = ExtResource("1_et70a")
 npc_name = "Matilda"
 look_at_side = 0

--- a/scenes/quests/story_quests/el_juguete_perdido/player_components/npcs_components/sheep.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/player_components/npcs_components/sheep.tscn
@@ -8,6 +8,7 @@ height = 42.0
 
 [node name="sheep_idle" type="CharacterBody2D"]
 collision_layer = 2
+motion_mode = 1
 script = ExtResource("1_n541d")
 sprite_frames = ExtResource("2_0pwn2")
 


### PR DESCRIPTION
Motion mode Floating is intended for top-down games. This is so all collisions are reported as walls. The walk behavior nodes need this, their current implementation checks for CharacterBody2D.is_on_wall().

Fix https://github.com/endlessm/threadbare/issues/1224