### PR TITLE
Game state: Fix type error if completed_quests is not defined

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -173,7 +173,7 @@ func restore() -> Dictionary:
 	incorporating_threads = _state.get_value(
 		GLOBAL_SECTION, GLOBAL_INCORPORATING_THREADS_KEY, false
 	)
-	completed_quests = _state.get_value(GLOBAL_SECTION, COMPLETED_QUESTS_KEY, [])
+	completed_quests = _state.get_value(GLOBAL_SECTION, COMPLETED_QUESTS_KEY, [] as Array[String])
 	return {"scene_path": scene_path, "spawn_point": current_spawn_point}
 
 


### PR DESCRIPTION
If there is a game state file to restore, but it does not contain the
completed_quests key, restoring the state would crash with:

> Trying to assign an array of type "Array" to a variable of type
> "Array[String]".

This is because the `completed_quests` variable is defined thus:

    var completed_quests: Array[String] = []

But it was initialised with this statement:

    completed_quests = _state.get_value(GLOBAL_SECTION, COMPLETED_QUESTS_KEY, [])

And the default value given in the third argument has type Array, not
Array[String].

There are two ways to construct an empty Array[String]:

1. Cast an empty array: `[] as Array[String]`
2. Explicitly create it with that type: `Array([], String, &"", null)`
   (all four parameters are required)

The first is shorter & clearer.

