### PR TITLE
Fade out when quitting

### DIFF
--- a/scenes/menus/title/components/main_menu.gd
+++ b/scenes/menus/title/components/main_menu.gd
@@ -47,7 +47,7 @@ func _on_credits_button_pressed() -> void:
 
 
 func _on_quit_button_pressed() -> void:
-	get_tree().quit()
+	Transitions.do_transition(get_tree().quit)
 
 
 func _on_visibility_changed() -> void:


### PR DESCRIPTION
Previously, choosing “Exit Game” on the main menu abruptly terminated the game.

Instead, play the normal fade-out transition, which also fades out the music,
then quit.
