### PR TITLE
Walk behaviors: Warn if character motion mode is grounded

### DIFF
--- a/scenes/game_elements/characters/components/gym_area_test.tscn
+++ b/scenes/game_elements/characters/components/gym_area_test.tscn
@@ -351,6 +351,7 @@ curve = SubResource("Curve2D_wq1h3")
 [node name="CharacterBody2D6" type="CharacterBody2D" parent="OnTheGround"]
 collision_layer = 2
 collision_mask = 19
+motion_mode = 1
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/CharacterBody2D6"]
 rotation = -1.55475

--- a/scenes/game_logic/base_character_behavior.gd
+++ b/scenes/game_logic/base_character_behavior.gd
@@ -21,6 +21,13 @@ func _enter_tree() -> void:
 		character = get_parent()
 
 
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		set_physics_process(false)
+	elif character.motion_mode != CharacterBody2D.MotionMode.MOTION_MODE_FLOATING:
+		push_warning("Consider setting %s Motion Mode to Floating." % character.name)
+
+
 func _set_character(new_character: CharacterBody2D) -> void:
 	character = new_character
 	update_configuration_warnings()

--- a/scenes/game_logic/walk_behaviors/bounce_walk_behavior.gd
+++ b/scenes/game_logic/walk_behaviors/bounce_walk_behavior.gd
@@ -47,8 +47,8 @@ func _update_direction() -> void:
 
 
 func _ready() -> void:
+	super._ready()
 	if Engine.is_editor_hint():
-		set_physics_process(false)
 		return
 
 	if not speeds:

--- a/scenes/game_logic/walk_behaviors/erratic_walk_behavior.gd
+++ b/scenes/game_logic/walk_behaviors/erratic_walk_behavior.gd
@@ -51,8 +51,8 @@ func _update_direction() -> void:
 
 
 func _ready() -> void:
+	super._ready()
 	if Engine.is_editor_hint():
-		set_physics_process(false)
 		return
 
 	if not speeds:

--- a/scenes/game_logic/walk_behaviors/follow_walk_behavior.gd
+++ b/scenes/game_logic/walk_behaviors/follow_walk_behavior.gd
@@ -72,8 +72,8 @@ func _update_direction() -> void:
 
 
 func _ready() -> void:
+	super._ready()
 	if Engine.is_editor_hint():
-		set_physics_process(false)
 		return
 
 	if not speeds:

--- a/scenes/game_logic/walk_behaviors/input_walk_behavior.gd
+++ b/scenes/game_logic/walk_behaviors/input_walk_behavior.gd
@@ -30,8 +30,8 @@ func _set_is_running(new_is_running: bool) -> void:
 
 
 func _ready() -> void:
+	super._ready()
 	if Engine.is_editor_hint():
-		set_physics_process(false)
 		return
 
 	if not speeds:

--- a/scenes/game_logic/walk_behaviors/navigation_follow_walk_behavior.gd
+++ b/scenes/game_logic/walk_behaviors/navigation_follow_walk_behavior.gd
@@ -122,8 +122,8 @@ func _on_agent_navigation_finished() -> void:
 
 
 func _ready() -> void:
+	super._ready()
 	if Engine.is_editor_hint():
-		set_physics_process(false)
 		return
 
 	if not speeds:

--- a/scenes/game_logic/walk_behaviors/path_walk_behavior.gd
+++ b/scenes/game_logic/walk_behaviors/path_walk_behavior.gd
@@ -83,8 +83,8 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 
 func _ready() -> void:
+	super._ready()
 	if Engine.is_editor_hint():
-		set_physics_process(false)
 		return
 
 	if not speeds:


### PR DESCRIPTION
And also factor out disabling physics process of these behaviors in the editor.

Helps https://github.com/endlessm/threadbare/issues/1224