### PR TITLE
Hookable area: Make anchor_point optional

### DIFF
--- a/scenes/game_elements/characters/player/components/player_hook.gd
+++ b/scenes/game_elements/characters/player/components/player_hook.gd
@@ -124,7 +124,7 @@ func _new_hook_string() -> Line2D:
 ## [br][br]
 ## Part of group hook_listener.
 func hooked(_new_hooked_to: HookableArea, is_loop: bool) -> void:
-	var p: Vector2 = _new_hooked_to.anchor_point.global_position
+	var p: Vector2 = _new_hooked_to.get_anchor_position()
 	if not hook_string:
 		hook_string = _new_hook_string()
 	hook_string.add_point(p, 0)
@@ -260,7 +260,7 @@ func _process_hook_string(delta: float) -> void:
 	var ending_area := get_ending_area()
 	if ending_area:
 		# Move first point to the hooked position.
-		hook_string.points[0] = ending_area.anchor_point.global_position
+		hook_string.points[0] = ending_area.get_anchor_position()
 
 	else:
 		# Not hooked, so a throw that hit air or wall.

--- a/scenes/game_elements/props/hookable_area/components/hookable_area.gd
+++ b/scenes/game_elements/props/hookable_area/components/hookable_area.gd
@@ -8,14 +8,14 @@ extends Area2D
 ## Area to connect the grappling hook.
 ##
 ## An area to connect the grappling hook to a game entity (by default, this node's parent).
-## While the final connection is a single [member anchor_point],
+## While the final connection is a single position, as returned by [method get_anchor_position],
 ## the collision is checked against this area that should be big enough
 ## for player forgiveness.
 ## [br][br]
 ## This is a piece of the grappling hook mechanic.
 ## [br][br]
-## When the grappling hook ray enters, it connects at the
-## [member anchor_point].
+## When the grappling hook ray enters, it connects at [method get_anchor_position].
+## You can specify a [member anchor_point] for using something different than this node's position.
 ## [br][br]
 ## If [member hook_control] is provided, this becomes a connection
 ## so the grappling hook can in turn aim from here.
@@ -42,6 +42,8 @@ const HOOKABLE_LAYER = 13
 	set = _set_hook_control
 
 ## The exact point to attach the string.
+## [br][br]
+## Optional. [member global_position] will be used if this is not set.
 @export var anchor_point: Marker2D
 
 ## When the grappling hook pulls and this area is hooked:[br]
@@ -56,6 +58,11 @@ const HOOKABLE_LAYER = 13
 func _enter_tree() -> void:
 	if not controlled_entity and get_parent() is Node2D:
 		controlled_entity = get_parent()
+
+
+## Return the global position used to connect the hook.
+func get_anchor_position() -> Vector2:
+	return anchor_point.global_position if anchor_point else global_position
 
 
 func _get_configuration_warnings() -> PackedStringArray:


### PR DESCRIPTION
And use the area's global_position in its place, when not set.

Resolve https://github.com/endlessm/threadbare/issues/1246