### PR TITLE
Fray's End: Remove stacks of bushes

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -814,18 +814,6 @@ scale = Vector2(1.1, 1.1)
 position = Vector2(1561, 424)
 scale = Vector2(0.2, 0.3)
 
-[node name="Bush34" parent="Bushes" instance=ExtResource("18_yntpr")]
-position = Vector2(1561, 424)
-scale = Vector2(0.2, 0.3)
-
-[node name="Bush35" parent="Bushes" instance=ExtResource("18_yntpr")]
-position = Vector2(1561, 424)
-scale = Vector2(0.2, 0.3)
-
-[node name="Bush36" parent="Bushes" instance=ExtResource("18_yntpr")]
-position = Vector2(1561, 424)
-scale = Vector2(0.2, 0.3)
-
 [node name="Bush37" parent="Bushes" instance=ExtResource("18_yntpr")]
 position = Vector2(1695, 424)
 scale = Vector2(0.2, 0.3)
@@ -843,18 +831,6 @@ position = Vector2(1594, 424)
 scale = Vector2(0.2, 0.3)
 
 [node name="Bush41" parent="Bushes" instance=ExtResource("18_yntpr")]
-position = Vector2(1561, 455)
-scale = Vector2(0.2, 0.3)
-
-[node name="Bush42" parent="Bushes" instance=ExtResource("18_yntpr")]
-position = Vector2(1561, 455)
-scale = Vector2(0.2, 0.3)
-
-[node name="Bush43" parent="Bushes" instance=ExtResource("18_yntpr")]
-position = Vector2(1561, 455)
-scale = Vector2(0.2, 0.3)
-
-[node name="Bush44" parent="Bushes" instance=ExtResource("18_yntpr")]
 position = Vector2(1561, 455)
 scale = Vector2(0.2, 0.3)
 
@@ -907,18 +883,6 @@ position = Vector2(1594, 455)
 scale = Vector2(0.2, 0.3)
 
 [node name="Bush49" parent="Bushes" instance=ExtResource("18_yntpr")]
-position = Vector2(1562, 490)
-scale = Vector2(0.2, 0.3)
-
-[node name="Bush50" parent="Bushes" instance=ExtResource("18_yntpr")]
-position = Vector2(1562, 490)
-scale = Vector2(0.2, 0.3)
-
-[node name="Bush51" parent="Bushes" instance=ExtResource("18_yntpr")]
-position = Vector2(1562, 490)
-scale = Vector2(0.2, 0.3)
-
-[node name="Bush52" parent="Bushes" instance=ExtResource("18_yntpr")]
 position = Vector2(1562, 490)
 scale = Vector2(0.2, 0.3)
 


### PR DESCRIPTION
The farmer's "crops" are currently scaled bushes.

For some reason, the leftmost column has 4 copies of each bush.

Remove 3 of each.

<img width="244" height="456" alt="Screenshot from 2025-09-26 09-35-24" src="https://github.com/user-attachments/assets/2cdf6e7e-7aed-4d21-b791-498b74ff0101" />
