### PR TITLE
Fix ObjectDB & StringName leaks on exit

### DIFF
--- a/scenes/globals/scene_switcher/transitions/transitions.gd
+++ b/scenes/globals/scene_switcher/transitions/transitions.gd
@@ -95,6 +95,18 @@ func do_transition(
 	finished.emit()
 
 
+## Transition out, leaving the screen blanked at the end of the transition.
+## [br][br]
+## This is only intended to fade out when quitting the game. Unlike [method do_transition], this
+## does not emit [signal started] or [signal finished]; use [code]await[/code] to wait for the
+## fade-out to finish.
+func do_out_transition(
+	out_transition: Transition.Effect = Transition.Effect.FADE,
+):
+	visible = true
+	await _leave_scene(out_transition)
+
+
 ## Returns true if a transition is currently running. Monitor [signal started]
 ## and [signal finished] for changes.
 func is_running() -> bool:

--- a/scenes/menus/title/components/main_menu.gd
+++ b/scenes/menus/title/components/main_menu.gd
@@ -47,7 +47,8 @@ func _on_credits_button_pressed() -> void:
 
 
 func _on_quit_button_pressed() -> void:
-	Transitions.do_transition(get_tree().quit)
+	await Transitions.do_out_transition()
+	get_tree().quit.call_deferred()
 
 
 func _on_visibility_changed() -> void:


### PR DESCRIPTION
Fix ObjectDB & StringName leaks on exit

Previously, quitting the game from the main menu would show (under
`--verbose`):

    WARNING: ObjectDB instances leaked at exit (run with --verbose for details).
        at: cleanup (core/object/object.cpp:2378)
    Leaked instance: GDScriptFunctionState:9223372096078349844
    Hint: Leaked instances typically happen when nodes are removed from the scene tree (with `remove_child()`) but not freed (with `free()` or `queue_free()`).
    Orphan StringName: quit (static: 0, total: 1)
    Orphan StringName: finished (static: 0, total: 1)
    Orphan StringName: Music (static: 0, total: 1)
    Orphan StringName: _introduce_scene (static: 0, total: 1)
    StringName: 4 unclaimed string names at exit.

`quit` is the name of the method that quits the game; `finished` and
`_introduce_scene` are members of `transitions.gd` which are used at the
end of `do_transition`. Since commit 3176904 we quit midway through
`do_transition`.

Add a new method, `do_out_transition`, which only does the fade-out and
leaves the black cover layer visible. When quitting the game, await this
method, then call quit(), deferred, at the end of the frame.

This fixes the leaks above. (There are still an error about a leaked
texture, which appears to be unrelated.)

Resolves https://github.com/endlessm/threadbare/issues/1197
