### PR TITLE
Transitions: Add missing function return type

### DIFF
--- a/scenes/globals/scene_switcher/transitions/transitions.gd
+++ b/scenes/globals/scene_switcher/transitions/transitions.gd
@@ -102,7 +102,7 @@ func do_transition(
 ## fade-out to finish.
 func do_out_transition(
 	out_transition: Transition.Effect = Transition.Effect.FADE,
-):
+) -> void:
 	visible = true
 	await _leave_scene(out_transition)
 


### PR DESCRIPTION
I missed this in commit fc46480dd3da3a13d0483c1f52e146f00838b685.
