### PR TITLE
Intro: Play dialogue at normal speed

### DIFF
--- a/scenes/menus/intro/components/intro.dialogue
+++ b/scenes/menus/intro/components/intro.dialogue
@@ -3,8 +3,8 @@
 ~ start
 # Wait a moment before starting the dialogue proper. In particular, this allows
 # time for any fade-in transition from the previous scene to finish.
-do animation_player.play(&"delay_start")
-do animation_player.animation_finished
+if Transitions.is_running():
+	do Transitions.finished
 do animation_player.play(&"sketches")
 [speed=0.5]You know that feeling you get when you wrap yourself in your favorite blanket? Like a cozy hug from a loved one.
 [speed=0.5]What if I told you there is a world made of fabric, not too far away and not too near, that used to feel just like that hug?

--- a/scenes/menus/intro/components/intro.dialogue
+++ b/scenes/menus/intro/components/intro.dialogue
@@ -6,7 +6,7 @@
 if Transitions.is_running():
 	do Transitions.finished
 do animation_player.play(&"sketches")
-[speed=0.5]You know that feeling you get when you wrap yourself in your favorite blanket? Like a cozy hug from a loved one.
-[speed=0.5]What if I told you there is a world made of fabric, not too far away and not too near, that used to feel just like that hug?
-[speed=0.5]This world was made of stitches and stories, and people were happy. Until ...
+You know that feeling you get when you wrap yourself in your favorite blanket? Like a cozy hug from a loved one.
+What if I told you there is a world made of fabric, not too far away and not too near, that used to feel just like that hug?
+This world was made of stitches and stories, and people were happy. Until…
 => END

--- a/scenes/menus/intro/intro.tscn
+++ b/scenes/menus/intro/intro.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://dow5vc7yb5k2c"]
+[gd_scene load_steps=15 format=3 uid="uid://dow5vc7yb5k2c"]
 
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="1_1dipm"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="1_qeukb"]
@@ -136,69 +136,6 @@ tracks/9/keys = {
 "values": [Color(1, 1, 1, 1)]
 }
 
-[sub_resource type="Animation" id="Animation_rpon1"]
-resource_name = "delay_start"
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("CanvasLayer/Control/Sketch01:visible")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("CanvasLayer/Control/Sketch02:visible")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("CanvasLayer/Control/Sketch03:visible")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/3/type = "value"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath("CanvasLayer/Control/Sketch04:visible")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-tracks/4/type = "value"
-tracks/4/imported = false
-tracks/4/enabled = true
-tracks/4/path = NodePath("CanvasLayer/Control/Sketch05:visible")
-tracks/4/interp = 1
-tracks/4/loop_wrap = true
-tracks/4/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [false]
-}
-
 [sub_resource type="Animation" id="Animation_5fnp7"]
 resource_name = "sketches"
 length = 13.0
@@ -327,7 +264,6 @@ tracks/9/keys = {
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_ir5dn"]
 _data = {
 &"RESET": SubResource("Animation_8twl8"),
-&"delay_start": SubResource("Animation_rpon1"),
 &"sketches": SubResource("Animation_5fnp7")
 }
 


### PR DESCRIPTION
The dialogue in the intro is set to play at half speed. I added this way back in March when I added this dialogue #46 but there's no explanation there for why I made it half speed.
Play it at the normal speed.

Also, simplify how we wait for the fade-in to finish before starting the intro dialogue.