### PR TITLE
[1/1] Speed up typing out dialogue

### DIFF
--- a/scenes/ui_elements/dialogue/balloon.tscn
+++ b/scenes/ui_elements/dialogue/balloon.tscn
@@ -47,6 +47,8 @@ layout_mode = 2
 size_flags_vertical = 3
 text = "¡Ah! ¿Another wanderer? It’s been a while siñce aňyone çame löõkiŋ for  instead of «treaßure»."
 skip_action = &"dialogue_skip"
+seconds_per_step = 0.01
+seconds_per_pause_step = 0.15
 
 [node name="NextButton" type="Button" parent="Balloon/PanelContainer/VBoxContainer"]
 unique_name_in_owner = true


### PR DESCRIPTION
**Stack:**

* https://github.com/endlessm/threadbare/pull/1271


---

Speed up typing out dialogue

By default, dialogue is shown at 0.02 seconds per "step" (which I think means
character), with a 0.3 second pause each time a full stop, question mark or
exclamation mark is encountered. Looking at two lines of the musician's opening
exposition:

> Now, if I remember correctly, there's a song that used to open the portal to
> the Ink Well, where songwriters found the ink to write all the songs of the
> world.

This is 160 characters × 0.02 seconds = 3.2 seconds.

> The songs can make wonderful things happen... make items or creatures appear,
> or even open portals to other regions of Threadbare.

This is 130 characters with an ellipsis, which is treated as 3 full stops, i.e.
3 pauses. 130 * 0.02 + 3 * 0.03 = 3.5 seconds.

If we adjust the two parameters to be twice as fast, these become 1.6 seconds
and 1.75 seconds, respectively. This to me makes the wordier dialogue snappier
without feeling rushed.

