### PR TITLE
Improve layout of input hints in Fray's End

### DIFF
--- a/scenes/game_elements/props/hint/input_key/gamepad_input.gd
+++ b/scenes/game_elements/props/hint/input_key/gamepad_input.gd
@@ -36,7 +36,6 @@ func _physics_process(_delta: float) -> void:
 
 		if is_pressed:
 			visible = true
-			modulate = Color.WHITE
 			match current_device:
 				InputHelper.DEVICE_XBOX_CONTROLLER:
 					texture = (
@@ -64,7 +63,6 @@ func _physics_process(_delta: float) -> void:
 					texture = controller_pressed_texture
 		elif not any_direction_pressed:
 			visible = true
-			modulate = Color.WHITE
 			match current_device:
 				InputHelper.DEVICE_XBOX_CONTROLLER:
 					texture = xbox_controller_texture

--- a/scenes/game_elements/props/hint/input_key/gamepad_input.gd
+++ b/scenes/game_elements/props/hint/input_key/gamepad_input.gd
@@ -26,8 +26,8 @@ func _physics_process(_delta: float) -> void:
 		return
 
 	if is_controller_main_display:
-		var is_pressed = Input.is_action_pressed(action_name)
-		var any_direction_pressed = (
+		var is_pressed := Input.is_action_pressed(action_name)
+		var any_direction_pressed := (
 			Input.is_action_pressed("ui_up")
 			or Input.is_action_pressed("ui_down")
 			or Input.is_action_pressed("ui_left")

--- a/scenes/game_elements/props/hint/input_key/gamepad_input.gd
+++ b/scenes/game_elements/props/hint/input_key/gamepad_input.gd
@@ -82,27 +82,10 @@ func _physics_process(_delta: float) -> void:
 
 func _ready() -> void:
 	InputHelper.device_changed.connect(_on_input_device_changed)
-	_detect_initial_device()
-
-
-func _detect_initial_device():
-	var joypads = Input.get_connected_joypads()
-	if joypads.size() > 0:
-		var device_id = joypads[0]
-		var joy_name = Input.get_joy_name(device_id).to_lower()
-
-		if joy_name.find("xbox") != -1:
-			_on_input_device_changed(InputHelper.DEVICE_XBOX_CONTROLLER, device_id)
-		elif joy_name.find("sony") != -1 or joy_name.find("ps") != -1:
-			_on_input_device_changed(InputHelper.DEVICE_PLAYSTATION_CONTROLLER, device_id)
-		elif joy_name.find("nintendo") != -1 or joy_name.find("switch") != -1:
-			_on_input_device_changed(InputHelper.DEVICE_SWITCH_CONTROLLER, device_id)
-		elif joy_name.find("steam") != -1:
-			_on_input_device_changed(InputHelper.DEVICE_STEAMDECK_CONTROLLER, device_id)
-		else:
-			_on_input_device_changed(InputHelper.DEVICE_XBOX_CONTROLLER, device_id)  # fallback
-	else:
-		_on_input_device_changed(InputHelper.DEVICE_KEYBOARD, 0)
+	_on_input_device_changed(
+		InputHelper.last_known_joypad_device,
+		InputHelper.last_known_joypad_index,
+	)
 
 
 func _on_input_device_changed(device: String, _device_index: int) -> void:

--- a/scenes/game_elements/props/hint/input_key/gamepad_input.gd
+++ b/scenes/game_elements/props/hint/input_key/gamepad_input.gd
@@ -116,3 +116,8 @@ func _on_input_device_changed(device: String, _device_index: int) -> void:
 			if is_controller_main_display:
 				visible = true
 				texture = steam_controller_texture
+
+		_:
+			if is_controller_main_display:
+				visible = true
+				texture = controller_default_texture

--- a/scenes/game_elements/props/hint/input_key/gamepad_input.gd
+++ b/scenes/game_elements/props/hint/input_key/gamepad_input.gd
@@ -89,34 +89,30 @@ func _ready() -> void:
 func _on_input_device_changed(device: String, _device_index: int) -> void:
 	current_device = device
 
+	is_keyboard_mode = (device == InputHelper.DEVICE_KEYBOARD)
 	match device:
 		InputHelper.DEVICE_KEYBOARD:
-			is_keyboard_mode = true
 			if is_controller_main_display:
 				visible = false
 			else:
 				visible = false
 
 		InputHelper.DEVICE_XBOX_CONTROLLER:
-			is_keyboard_mode = false
 			if is_controller_main_display:
 				visible = true
 				texture = xbox_controller_texture
 
 		InputHelper.DEVICE_PLAYSTATION_CONTROLLER:
-			is_keyboard_mode = false
 			if is_controller_main_display:
 				visible = true
 				texture = playstation_controller_texture
 
 		InputHelper.DEVICE_SWITCH_CONTROLLER:
-			is_keyboard_mode = false
 			if is_controller_main_display:
 				visible = true
 				texture = nintendo_controller_texture
 
 		InputHelper.DEVICE_STEAMDECK_CONTROLLER:
-			is_keyboard_mode = false
 			if is_controller_main_display:
 				visible = true
 				texture = steam_controller_texture

--- a/scenes/game_elements/props/hint/input_key/interact_input.gd
+++ b/scenes/game_elements/props/hint/input_key/interact_input.gd
@@ -28,15 +28,10 @@ func _physics_process(_delta: float) -> void:
 
 func _ready() -> void:
 	InputHelper.device_changed.connect(_on_input_device_changed)
-	_detect_initial_device()
-
-
-func _detect_initial_device():
-	var joy_count = Input.get_connected_joypads().size()
-	if joy_count > 0:
-		_on_input_device_changed(InputHelper.DEVICE_XBOX_CONTROLLER, 0)
-	else:
-		_on_input_device_changed(InputHelper.DEVICE_KEYBOARD, 0)
+	_on_input_device_changed(
+		InputHelper.last_known_joypad_device,
+		InputHelper.last_known_joypad_index,
+	)
 
 
 func _on_input_device_changed(device: String, _device_index: int) -> void:

--- a/scenes/game_elements/props/hint/input_key/interact_input.gd
+++ b/scenes/game_elements/props/hint/input_key/interact_input.gd
@@ -59,3 +59,7 @@ func _on_input_device_changed(device: String, _device_index: int) -> void:
 		InputHelper.DEVICE_STEAMDECK_CONTROLLER:
 			is_keyboard_mode = false
 			texture = steam_controller_texture
+
+		_:
+			is_keyboard_mode = false
+			texture = xbox_controller_texture

--- a/scenes/game_elements/props/hint/input_key/keyboard_input.gd
+++ b/scenes/game_elements/props/hint/input_key/keyboard_input.gd
@@ -20,27 +20,10 @@ func _physics_process(_delta: float) -> void:
 
 func _ready() -> void:
 	InputHelper.device_changed.connect(_on_input_device_changed)
-	_initialize_device_state()
-
-
-func _initialize_device_state() -> void:
-	var joypads = Input.get_connected_joypads()
-	if joypads.size() > 0:
-		var device_id = joypads[0]
-		var joy_name = Input.get_joy_name(device_id).to_lower()
-
-		if joy_name.find("xbox") != -1:
-			_on_input_device_changed(InputHelper.DEVICE_XBOX_CONTROLLER, device_id)
-		elif joy_name.find("sony") != -1 or joy_name.find("ps") != -1:
-			_on_input_device_changed(InputHelper.DEVICE_PLAYSTATION_CONTROLLER, device_id)
-		elif joy_name.find("nintendo") != -1 or joy_name.find("switch") != -1:
-			_on_input_device_changed(InputHelper.DEVICE_SWITCH_CONTROLLER, device_id)
-		elif joy_name.find("steam") != -1:
-			_on_input_device_changed(InputHelper.DEVICE_STEAMDECK_CONTROLLER, device_id)
-		else:
-			_on_input_device_changed(InputHelper.DEVICE_XBOX_CONTROLLER, device_id)  # fallback
-	else:
-		_on_input_device_changed(InputHelper.DEVICE_KEYBOARD, 0)
+	_on_input_device_changed(
+		InputHelper.last_known_joypad_device,
+		InputHelper.last_known_joypad_index,
+	)
 
 
 func _on_input_device_changed(device: String, _device_index: int) -> void:

--- a/scenes/ui_elements/input_hints/movement_input_hints.tscn
+++ b/scenes/ui_elements/input_hints/movement_input_hints.tscn
@@ -1,0 +1,140 @@
+[gd_scene load_steps=27 format=3 uid="uid://dt1y8odxq0xys"]
+
+[ext_resource type="Script" uid="uid://dlw8vfm7wuubv" path="res://scenes/game_elements/props/hint/input_key/keyboard_input.gd" id="2_1ltvj"]
+[ext_resource type="Texture2D" uid="uid://cc5wontx8obvi" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Arrow_Right_Key_Dark.png" id="3_fthuf"]
+[ext_resource type="Texture2D" uid="uid://lj8iogm46p3g" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Arrow_Left_Key_Dark.png" id="3_p5612"]
+[ext_resource type="Texture2D" uid="uid://ckwsauhbhlod6" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Arrow_Down_Key_Dark.png" id="4_faj6p"]
+[ext_resource type="Texture2D" uid="uid://bytssd0mbo28u" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Arrow_Up_Key_Dark.png" id="5_l3cfo"]
+[ext_resource type="Texture2D" uid="uid://dxo4iq63x0rid" path="res://assets/third_party/inputs/Steam Deck/SteamDeck_Dpad.png" id="6_wxrj2"]
+[ext_resource type="Script" uid="uid://d4bfnn5upde7h" path="res://scenes/game_elements/props/hint/input_key/gamepad_input.gd" id="7_f3r71"]
+[ext_resource type="Texture2D" uid="uid://cbd8r54x1pwc" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_Dpad.png" id="8_qxexh"]
+[ext_resource type="Texture2D" uid="uid://dkr5diuagappc" path="res://assets/third_party/inputs/PS5/PS5_Dpad.png" id="9_iwjfo"]
+[ext_resource type="Texture2D" uid="uid://dw5oy5xm1p0u5" path="res://assets/third_party/inputs/Switch/Switch_Dpad.png" id="10_8bt2l"]
+[ext_resource type="Texture2D" uid="uid://pvjwue1t8c5p" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_Dpad_Up.png" id="11_124up"]
+[ext_resource type="Texture2D" uid="uid://bnjfxy84pi7cw" path="res://assets/third_party/inputs/PS5/PS5_Dpad_Up.png" id="12_4ntd1"]
+[ext_resource type="Texture2D" uid="uid://c20i88rg3hakm" path="res://assets/third_party/inputs/Switch/Switch_Dpad_Up.png" id="13_el0of"]
+[ext_resource type="Texture2D" uid="uid://cqvmi7spn2pds" path="res://assets/third_party/inputs/Steam Deck/SteamDeck_Dpad_Up.png" id="14_qwdde"]
+[ext_resource type="Texture2D" uid="uid://ib34iqhtfl35" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_Dpad_Down.png" id="15_vxq6f"]
+[ext_resource type="Texture2D" uid="uid://d4ctpsqp75ehw" path="res://assets/third_party/inputs/PS5/PS5_Dpad_Down.png" id="16_yknso"]
+[ext_resource type="Texture2D" uid="uid://ddox5jcraslgt" path="res://assets/third_party/inputs/Switch/Switch_Dpad_Down.png" id="17_so858"]
+[ext_resource type="Texture2D" uid="uid://v8qvyifu4k7n" path="res://assets/third_party/inputs/Steam Deck/SteamDeck_Dpad_Down.png" id="18_e4xy8"]
+[ext_resource type="Texture2D" uid="uid://5t0k861jkx5h" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_Dpad_Left.png" id="19_wabxv"]
+[ext_resource type="Texture2D" uid="uid://bv3om7y533jjs" path="res://assets/third_party/inputs/PS5/PS5_Dpad_Left.png" id="20_j138o"]
+[ext_resource type="Texture2D" uid="uid://omnkqwkxadb7" path="res://assets/third_party/inputs/Switch/Switch_Dpad_Left.png" id="21_dm2t2"]
+[ext_resource type="Texture2D" uid="uid://vx567ck7d6ne" path="res://assets/third_party/inputs/Steam Deck/SteamDeck_Dpad_Left.png" id="22_4sq11"]
+[ext_resource type="Texture2D" uid="uid://c0cu2e4kl48ev" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_Dpad_Right.png" id="23_5y0lj"]
+[ext_resource type="Texture2D" uid="uid://deqctlc4b02x4" path="res://assets/third_party/inputs/PS5/PS5_Dpad_Right.png" id="24_37d04"]
+[ext_resource type="Texture2D" uid="uid://dcl8egjs5xyp" path="res://assets/third_party/inputs/Switch/Switch_Dpad_Right.png" id="25_gesij"]
+[ext_resource type="Texture2D" uid="uid://docmrhl2spwe" path="res://assets/third_party/inputs/Steam Deck/SteamDeck_Dpad_Right.png" id="26_nv01m"]
+
+[node name="MovementInputHints" type="HBoxContainer"]
+texture_filter = 2
+offset_right = 312.0
+offset_bottom = 204.0
+size_flags_horizontal = 0
+
+[node name="Keyboard" type="GridContainer" parent="."]
+layout_mode = 2
+columns = 3
+
+[node name="TopLeftBlank" type="Control" parent="Keyboard"]
+layout_mode = 2
+
+[node name="UpInput" type="TextureRect" parent="Keyboard"]
+layout_mode = 2
+texture = ExtResource("5_l3cfo")
+script = ExtResource("2_1ltvj")
+action_name = &"ui_up"
+
+[node name="TopRightBlank" type="Control" parent="Keyboard"]
+layout_mode = 2
+
+[node name="LeftInput" type="TextureRect" parent="Keyboard"]
+layout_mode = 2
+texture = ExtResource("3_p5612")
+script = ExtResource("2_1ltvj")
+action_name = &"ui_left"
+
+[node name="DownInput" type="TextureRect" parent="Keyboard"]
+layout_mode = 2
+texture = ExtResource("4_faj6p")
+script = ExtResource("2_1ltvj")
+action_name = &"ui_down"
+
+[node name="RightInput" type="TextureRect" parent="Keyboard"]
+layout_mode = 2
+texture = ExtResource("3_fthuf")
+script = ExtResource("2_1ltvj")
+action_name = &"ui_right"
+
+[node name="Controller" type="CenterContainer" parent="."]
+layout_mode = 2
+size_flags_vertical = 8
+
+[node name="ControllerUp" type="TextureRect" parent="Controller"]
+layout_mode = 2
+texture = ExtResource("6_wxrj2")
+script = ExtResource("7_f3r71")
+action_name = &"ui_up"
+xbox_controller_texture = ExtResource("8_qxexh")
+playstation_controller_texture = ExtResource("9_iwjfo")
+nintendo_controller_texture = ExtResource("10_8bt2l")
+steam_controller_texture = ExtResource("6_wxrj2")
+is_controller_main_display = true
+controller_default_texture = ExtResource("8_qxexh")
+controller_pressed_texture = ExtResource("11_124up")
+xbox_pressed_texture = ExtResource("11_124up")
+playstation_pressed_texture = ExtResource("12_4ntd1")
+nintendo_pressed_texture = ExtResource("13_el0of")
+steam_pressed_texture = ExtResource("14_qwdde")
+
+[node name="ControllerDown" type="TextureRect" parent="Controller"]
+layout_mode = 2
+texture = ExtResource("6_wxrj2")
+script = ExtResource("7_f3r71")
+action_name = &"ui_down"
+xbox_controller_texture = ExtResource("8_qxexh")
+playstation_controller_texture = ExtResource("9_iwjfo")
+nintendo_controller_texture = ExtResource("10_8bt2l")
+steam_controller_texture = ExtResource("6_wxrj2")
+is_controller_main_display = true
+controller_default_texture = ExtResource("8_qxexh")
+controller_pressed_texture = ExtResource("15_vxq6f")
+xbox_pressed_texture = ExtResource("15_vxq6f")
+playstation_pressed_texture = ExtResource("16_yknso")
+nintendo_pressed_texture = ExtResource("17_so858")
+steam_pressed_texture = ExtResource("18_e4xy8")
+
+[node name="ControllerLeft" type="TextureRect" parent="Controller"]
+layout_mode = 2
+texture = ExtResource("6_wxrj2")
+script = ExtResource("7_f3r71")
+action_name = &"ui_left"
+xbox_controller_texture = ExtResource("8_qxexh")
+playstation_controller_texture = ExtResource("9_iwjfo")
+nintendo_controller_texture = ExtResource("10_8bt2l")
+steam_controller_texture = ExtResource("6_wxrj2")
+is_controller_main_display = true
+controller_default_texture = ExtResource("8_qxexh")
+controller_pressed_texture = ExtResource("19_wabxv")
+xbox_pressed_texture = ExtResource("19_wabxv")
+playstation_pressed_texture = ExtResource("20_j138o")
+nintendo_pressed_texture = ExtResource("21_dm2t2")
+steam_pressed_texture = ExtResource("22_4sq11")
+
+[node name="ControllerRight" type="TextureRect" parent="Controller"]
+layout_mode = 2
+texture = ExtResource("6_wxrj2")
+script = ExtResource("7_f3r71")
+action_name = &"ui_right"
+xbox_controller_texture = ExtResource("8_qxexh")
+playstation_controller_texture = ExtResource("9_iwjfo")
+nintendo_controller_texture = ExtResource("10_8bt2l")
+steam_controller_texture = ExtResource("6_wxrj2")
+is_controller_main_display = true
+controller_default_texture = ExtResource("8_qxexh")
+controller_pressed_texture = ExtResource("23_5y0lj")
+xbox_pressed_texture = ExtResource("23_5y0lj")
+playstation_pressed_texture = ExtResource("24_37d04")
+nintendo_pressed_texture = ExtResource("25_gesij")
+steam_pressed_texture = ExtResource("26_nv01m")

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=74 format=4 uid="uid://cufkthb25mpxy"]
+[gd_scene load_steps=49 format=4 uid="uid://cufkthb25mpxy"]
 
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_4evgk"]
 [ext_resource type="Script" uid="uid://8div00rgvsds" path="res://scenes/world_map/components/frays_end.gd" id="1_4gse6"]
@@ -24,48 +24,23 @@
 [ext_resource type="PackedScene" uid="uid://crqjcicx0vdu" path="res://scenes/game_elements/props/decoration/bush/bush.tscn" id="18_yntpr"]
 [ext_resource type="PackedScene" uid="uid://n8dhed3nvf50" path="res://scenes/game_elements/characters/npcs/npc_prop/fray_hammerman.tscn" id="19_yntpr"]
 [ext_resource type="SpriteFrames" uid="uid://caou2u7vffhei" path="res://scenes/world_map/components/cat.tres" id="20_6r0j2"]
-[ext_resource type="PackedScene" uid="uid://buuh0p3bjdpkv" path="res://scenes/game_elements/props/hint/input_key/input_key.tscn" id="20_i7vhm"]
 [ext_resource type="PackedScene" uid="uid://v2uakefmp67y" path="res://scenes/game_elements/characters/npcs/elder/story_quest_elder.tscn" id="20_jqkod"]
 [ext_resource type="PackedScene" uid="uid://6tkhqe1nvwop" path="res://scenes/game_elements/characters/npcs/npc_prop/fray_idle.tscn" id="20_xa7wa"]
 [ext_resource type="PackedScene" uid="uid://bytkm0r5fe5xb" path="res://scenes/game_elements/characters/npcs/elder/lore_quest_elder.tscn" id="20_xt3dw"]
-[ext_resource type="Script" uid="uid://d4bfnn5upde7h" path="res://scenes/game_elements/props/hint/input_key/gamepad_input.gd" id="21_i7vhm"]
 [ext_resource type="Texture2D" uid="uid://p8kty3uxifxu" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Space_Key_Dark.png" id="24_h30yx"]
 [ext_resource type="Resource" uid="uid://qva3nnhkgirm" path="res://scenes/world_map/components/farmer_npc.dialogue" id="25_6r0j2"]
 [ext_resource type="PackedScene" uid="uid://hafqgtdg2nvp" path="res://scenes/game_elements/props/hint/hint.tscn" id="26_w8iew"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="27_aj6tp"]
-[ext_resource type="Texture2D" uid="uid://cc5wontx8obvi" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Arrow_Right_Key_Dark.png" id="27_w8iew"]
 [ext_resource type="Texture2D" uid="uid://drfnq08l2wbgy" path="res://assets/third_party/tiny-swords/Deco/03.png" id="28_6r0j2"]
-[ext_resource type="Texture2D" uid="uid://ckwsauhbhlod6" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Arrow_Down_Key_Dark.png" id="28_h30yx"]
-[ext_resource type="Texture2D" uid="uid://bytssd0mbo28u" path="res://assets/third_party/inputs/keyboard-and-mouse/Dark/Arrow_Up_Key_Dark.png" id="29_djq26"]
-[ext_resource type="Script" uid="uid://dlw8vfm7wuubv" path="res://scenes/game_elements/props/hint/input_key/keyboard_input.gd" id="29_ppslc"]
-[ext_resource type="Texture2D" uid="uid://5t0k861jkx5h" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_Dpad_Left.png" id="30_ns5r3"]
-[ext_resource type="Texture2D" uid="uid://bv3om7y533jjs" path="res://assets/third_party/inputs/PS5/PS5_Dpad_Left.png" id="31_5j6h7"]
+[ext_resource type="PackedScene" uid="uid://dt1y8odxq0xys" path="res://scenes/ui_elements/input_hints/movement_input_hints.tscn" id="28_lftgk"]
 [ext_resource type="Resource" uid="uid://byhqan5a7vkgg" path="res://scenes/world_map/components/tutorial_npc.dialogue" id="32_djq26"]
-[ext_resource type="Texture2D" uid="uid://omnkqwkxadb7" path="res://assets/third_party/inputs/Switch/Switch_Dpad_Left.png" id="32_duxxr"]
-[ext_resource type="Texture2D" uid="uid://vx567ck7d6ne" path="res://assets/third_party/inputs/Steam Deck/SteamDeck_Dpad_Left.png" id="33_2vvub"]
-[ext_resource type="Texture2D" uid="uid://cbd8r54x1pwc" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_Dpad.png" id="34_r1ek1"]
-[ext_resource type="Texture2D" uid="uid://dkr5diuagappc" path="res://assets/third_party/inputs/PS5/PS5_Dpad.png" id="35_ns5r3"]
-[ext_resource type="Texture2D" uid="uid://dw5oy5xm1p0u5" path="res://assets/third_party/inputs/Switch/Switch_Dpad.png" id="36_5j6h7"]
-[ext_resource type="Texture2D" uid="uid://c0cu2e4kl48ev" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_Dpad_Right.png" id="36_ojao8"]
-[ext_resource type="Texture2D" uid="uid://deqctlc4b02x4" path="res://assets/third_party/inputs/PS5/PS5_Dpad_Right.png" id="37_6fau3"]
-[ext_resource type="Texture2D" uid="uid://dxo4iq63x0rid" path="res://assets/third_party/inputs/Steam Deck/SteamDeck_Dpad.png" id="37_duxxr"]
 [ext_resource type="PackedScene" uid="uid://d0c4l7ev6ca3c" path="res://scenes/game_elements/props/spawn_point/spawn_point.tscn" id="37_thm8h"]
 [ext_resource type="Script" uid="uid://bdhjixygupit1" path="res://scenes/game_elements/props/area_filler/area_filler.gd" id="38_cjmkx"]
 [ext_resource type="PackedScene" uid="uid://dv4f232y8w8dv" path="res://scenes/game_elements/props/decoration/water_rock/water_rock.tscn" id="38_jqkod"]
-[ext_resource type="Texture2D" uid="uid://dcl8egjs5xyp" path="res://assets/third_party/inputs/Switch/Switch_Dpad_Right.png" id="38_qgpx3"]
-[ext_resource type="Texture2D" uid="uid://docmrhl2spwe" path="res://assets/third_party/inputs/Steam Deck/SteamDeck_Dpad_Right.png" id="39_6b07c"]
 [ext_resource type="PackedScene" uid="uid://bqkui35x5ly0" path="res://scenes/game_elements/props/decoration/crops/tomato.tscn" id="39_ljovl"]
-[ext_resource type="Texture2D" uid="uid://ib34iqhtfl35" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_Dpad_Down.png" id="41_qgpx3"]
-[ext_resource type="Texture2D" uid="uid://d4ctpsqp75ehw" path="res://assets/third_party/inputs/PS5/PS5_Dpad_Down.png" id="42_6b07c"]
 [ext_resource type="PackedScene" uid="uid://ccpgw7k4rlmea" path="res://scenes/game_elements/props/decoration/crops/barley.tscn" id="42_eodqy"]
 [ext_resource type="PackedScene" uid="uid://c78fj5em5tpm5" path="res://scenes/game_elements/props/decoration/crops/carrot.tscn" id="42_ljovl"]
-[ext_resource type="Texture2D" uid="uid://ddox5jcraslgt" path="res://assets/third_party/inputs/Switch/Switch_Dpad_Down.png" id="43_t7c6s"]
-[ext_resource type="Texture2D" uid="uid://pvjwue1t8c5p" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_Dpad_Up.png" id="44_ljovl"]
-[ext_resource type="Texture2D" uid="uid://v8qvyifu4k7n" path="res://assets/third_party/inputs/Steam Deck/SteamDeck_Dpad_Down.png" id="44_ulm71"]
 [ext_resource type="PackedScene" uid="uid://c0104ickpm3ru" path="res://scenes/game_elements/props/decoration/flower/flower.tscn" id="45_cjmkx"]
-[ext_resource type="Texture2D" uid="uid://bnjfxy84pi7cw" path="res://assets/third_party/inputs/PS5/PS5_Dpad_Up.png" id="45_eodqy"]
-[ext_resource type="Texture2D" uid="uid://c20i88rg3hakm" path="res://assets/third_party/inputs/Switch/Switch_Dpad_Up.png" id="46_2eaa5"]
-[ext_resource type="Texture2D" uid="uid://cqvmi7spn2pds" path="res://assets/third_party/inputs/Steam Deck/SteamDeck_Dpad_Up.png" id="47_6ss6a"]
 [ext_resource type="Texture2D" uid="uid://d4b0kmnbktqeh" path="res://assets/third_party/inputs/Xbox Series/XboxSeriesX_A.png" id="51_uxfrp"]
 [ext_resource type="Texture2D" uid="uid://dm4a8fn88sjf5" path="res://assets/third_party/inputs/PS5/PS5_Cross.png" id="52_wymun"]
 [ext_resource type="Texture2D" uid="uid://bc2ktlkypid78" path="res://assets/third_party/inputs/Switch/Switch_A.png" id="53_f3823"]
@@ -366,155 +341,24 @@ sprite_frames = ExtResource("20_6r0j2")
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="."]
 
-[node name="MovementInputHints" type="Control" parent="ScreenOverlay"]
-texture_filter = 2
-layout_mode = 3
-anchors_preset = 0
-offset_left = 324.0
-offset_top = 875.0
-offset_right = 324.0
-offset_bottom = 875.0
-scale = Vector2(1.5, 1.5)
-size_flags_horizontal = 8
+[node name="HBoxContainer" type="HBoxContainer" parent="ScreenOverlay"]
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -204.0
+offset_right = 312.0
+grow_vertical = 0
+
+[node name="MovementInputHints" parent="ScreenOverlay/HBoxContainer" instance=ExtResource("28_lftgk")]
+layout_mode = 2
+
+[node name="InteractionInputHints" type="CenterContainer" parent="ScreenOverlay/HBoxContainer"]
+layout_mode = 2
 size_flags_vertical = 8
 
-[node name="LeftInput" parent="ScreenOverlay/MovementInputHints" instance=ExtResource("20_i7vhm")]
-layout_mode = 0
-offset_left = -131.333
-offset_top = 34.0
-offset_right = -31.3333
-offset_bottom = 134.0
-script = ExtResource("29_ppslc")
-keyboard_texture = null
-
-[node name="RightInput" type="TextureRect" parent="ScreenOverlay/MovementInputHints"]
-layout_mode = 0
-offset_left = 28.6667
-offset_top = 34.0
-offset_right = 128.667
-offset_bottom = 134.0
-texture = ExtResource("27_w8iew")
-script = ExtResource("29_ppslc")
-action_name = &"ui_right"
-
-[node name="DownInput" type="TextureRect" parent="ScreenOverlay/MovementInputHints"]
-layout_mode = 0
-offset_left = -51.3333
-offset_top = 33.3333
-offset_right = 48.6667
-offset_bottom = 133.333
-texture = ExtResource("28_h30yx")
-script = ExtResource("29_ppslc")
-action_name = &"ui_down"
-
-[node name="UpInput" type="TextureRect" parent="ScreenOverlay/MovementInputHints"]
-layout_mode = 0
-offset_left = -80.6667
-offset_top = -86.6666
-offset_right = 19.3333
-offset_bottom = 13.3334
-texture = ExtResource("29_djq26")
-script = ExtResource("29_ppslc")
-action_name = &"ui_up"
-
-[node name="ControllerUp" type="TextureRect" parent="ScreenOverlay/MovementInputHints"]
-layout_mode = 0
-offset_left = -80.6667
-offset_top = -28.6667
-offset_right = 80.3334
-offset_bottom = 119.333
-texture = ExtResource("37_duxxr")
-script = ExtResource("21_i7vhm")
-action_name = &"ui_up"
-xbox_controller_texture = ExtResource("34_r1ek1")
-playstation_controller_texture = ExtResource("35_ns5r3")
-nintendo_controller_texture = ExtResource("36_5j6h7")
-steam_controller_texture = ExtResource("37_duxxr")
-is_controller_main_display = true
-controller_pressed_texture = ExtResource("44_ljovl")
-xbox_pressed_texture = ExtResource("44_ljovl")
-playstation_pressed_texture = ExtResource("45_eodqy")
-nintendo_pressed_texture = ExtResource("46_2eaa5")
-steam_pressed_texture = ExtResource("47_6ss6a")
-
-[node name="ControllerDown" type="TextureRect" parent="ScreenOverlay/MovementInputHints"]
-layout_mode = 0
-offset_left = -80.6667
-offset_top = -28.6667
-offset_right = 80.3334
-offset_bottom = 119.333
-texture = ExtResource("37_duxxr")
-script = ExtResource("21_i7vhm")
-action_name = &"ui_down"
-xbox_controller_texture = ExtResource("34_r1ek1")
-playstation_controller_texture = ExtResource("35_ns5r3")
-nintendo_controller_texture = ExtResource("36_5j6h7")
-steam_controller_texture = ExtResource("37_duxxr")
-is_controller_main_display = true
-controller_pressed_texture = ExtResource("41_qgpx3")
-xbox_pressed_texture = ExtResource("41_qgpx3")
-playstation_pressed_texture = ExtResource("42_6b07c")
-nintendo_pressed_texture = ExtResource("43_t7c6s")
-steam_pressed_texture = ExtResource("44_ulm71")
-
-[node name="ControllerLeft" type="TextureRect" parent="ScreenOverlay/MovementInputHints"]
-layout_mode = 0
-offset_left = -81.3333
-offset_top = -29.3333
-offset_right = 79.6667
-offset_bottom = 118.667
-texture = ExtResource("37_duxxr")
-script = ExtResource("21_i7vhm")
-action_name = &"ui_left"
-xbox_controller_texture = ExtResource("34_r1ek1")
-playstation_controller_texture = ExtResource("35_ns5r3")
-nintendo_controller_texture = ExtResource("36_5j6h7")
-steam_controller_texture = ExtResource("37_duxxr")
-is_controller_main_display = true
-controller_pressed_texture = ExtResource("30_ns5r3")
-xbox_pressed_texture = ExtResource("30_ns5r3")
-playstation_pressed_texture = ExtResource("31_5j6h7")
-nintendo_pressed_texture = ExtResource("32_duxxr")
-steam_pressed_texture = ExtResource("33_2vvub")
-
-[node name="ControllerRight" type="TextureRect" parent="ScreenOverlay/MovementInputHints"]
-layout_mode = 0
-offset_left = -80.6667
-offset_top = -28.6667
-offset_right = 80.3333
-offset_bottom = 119.333
-texture = ExtResource("37_duxxr")
-script = ExtResource("21_i7vhm")
-action_name = &"ui_right"
-xbox_controller_texture = ExtResource("34_r1ek1")
-playstation_controller_texture = ExtResource("35_ns5r3")
-nintendo_controller_texture = ExtResource("36_5j6h7")
-steam_controller_texture = ExtResource("37_duxxr")
-is_controller_main_display = true
-controller_pressed_texture = ExtResource("36_ojao8")
-xbox_pressed_texture = ExtResource("36_ojao8")
-playstation_pressed_texture = ExtResource("37_6fau3")
-nintendo_pressed_texture = ExtResource("38_qgpx3")
-steam_pressed_texture = ExtResource("39_6b07c")
-
-[node name="InteractionInputHint" type="Control" parent="ScreenOverlay"]
-texture_filter = 2
-layout_mode = 3
-anchors_preset = 0
-offset_left = 255.0
-offset_top = 869.0
-offset_right = 255.0
-offset_bottom = 869.0
-scale = Vector2(2, 2)
-size_flags_horizontal = 8
+[node name="InteractionInputHint" type="TextureRect" parent="ScreenOverlay/HBoxContainer/InteractionInputHints"]
+layout_mode = 2
 size_flags_vertical = 8
-
-[node name="InteractInput" type="TextureRect" parent="ScreenOverlay/InteractionInputHint"]
-layout_mode = 0
-offset_left = 175.5
-offset_top = -10.0
-offset_right = 275.5
-offset_bottom = 90.0
 texture = ExtResource("51_uxfrp")
 script = ExtResource("55_wymun")
 action_name = &"ui_accept"
@@ -1226,7 +1070,7 @@ y_sort_enabled = true
 
 [node name="MovementInputHint" parent="Tutorial" node_paths=PackedStringArray("hint_node") instance=ExtResource("26_w8iew")]
 position = Vector2(474, 1658)
-hint_node = NodePath("../../ScreenOverlay/MovementInputHints")
+hint_node = NodePath("../../ScreenOverlay/HBoxContainer/MovementInputHints")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Tutorial/MovementInputHint"]
 visible = false
@@ -1238,7 +1082,7 @@ position = Vector2(514, 1613)
 dialogue = ExtResource("32_djq26")
 
 [node name="InteractInputHint" parent="Tutorial/Talker" node_paths=PackedStringArray("hint_node") instance=ExtResource("26_w8iew")]
-hint_node = NodePath("../../../ScreenOverlay/InteractionInputHint")
+hint_node = NodePath("../../../ScreenOverlay/HBoxContainer/InteractionInputHints")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Tutorial/Talker/InteractInputHint"]
 position = Vector2(0.5, -8.5)


### PR DESCRIPTION
This anchors the whole row of controls to the bottom-right, improves the layout within the row, and adds support for "generic" controller types.

I also made some small code cleanups to the new joypad input hint logic.

Fixes #997 