### PR TITLE
pre-commit: Recognise piskel files via exclude_types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,17 +16,15 @@ repos:
   - id: end-of-file-fixer
     exclude: |
       (?x)(
-        \.piskel$|
         ^scenes/quests/story_quests/(?!stella/|NO_EDIT/)
       )
-    exclude_types: [image]
+    exclude_types: [svg, piskel]
   - id: trailing-whitespace
     exclude: |
       (?x)(
-        \.piskel$|
         ^scenes/quests/story_quests/(?!stella/|NO_EDIT/)
       )
-    exclude_types: [image]
+    exclude_types: [svg, piskel]
 
 - repo: https://github.com/editorconfig-checker/editorconfig-checker
   rev: v3.4.0

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,18 +39,45 @@ GDScript source code should follow the [GDScript style guide][]. This is
 enforced using `gdlint` and `gdformat` from [godot-gdscript-toolkit][] when
 changes are submitted to the project.
 
-You can use [pre-commit][] to run the same checks locally. Install `pre-commit`
-then run the following command in your Threadbare checkout:
+You can use [pre-commit][] to run the same checks locally. `pre-commit`.
+`pre-commit` is written in Python, so if you don't have Python installed, you'll
+also need to install Python. The Threadbare team recommends using [`uv`][uv] to
+install and manage `pre-commit`, as well as installing Python if needed.
 
-```
-pre-commit install
-```
+### Install `pre-commit` with `uv`
+
+1. Install `uv` using
+   [these instructions](https://docs.astral.sh/uv/#installation)
+
+2. Install `pre-commit`:
+
+   ```
+   uv tool install pre-commit
+   ```
+
+3. If you need to upgrade `pre-commit` in future, use this command:
+
+   ```
+   uv tool upgrade pre-commit
+   ```
+
+> [!NOTE]
+> If you prefer to install `pre-commit` another way, that's fine!
+
+### Set up `pre-commit` for Threadbare
+
+Run the following command in your Threadbare checkout to set up `pre-commit`:
+
+   ```
+   pre-commit install
+   ```
 
 Now, coding style checks will be enforced when you run `git commit`.
 
 [GDScript style guide]: https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html
 [godot-gdscript-toolkit]: https://github.com/Scony/godot-gdscript-toolkit
 [pre-commit]: https://pre-commit.com/
+[uv]: https://docs.astral.sh/uv/
 
 ## Git commit messages and pull request descriptions
 


### PR DESCRIPTION
My upstream pull request was merged:

- https://github.com/pre-commit/identify/pull/541

The maintainer chose to edit my contribution to not add the `image` tag
to piskel files:

> the `image` tag was an idea that didn't really pan out so I'm just
> going to remove it here

Of course that's their prerogative as maintainer!

Unfortunately this means that my plan from commit
e92fd6d85a60328d0767550d0149bcdee84eb858, to exclude all image files
with `exclude_types: [image]`, is not going to work. Instead we have to
add the `piskel` type explicitly to the list, and also any further
text-based image file formats that we find in future.

Add `piskel` to the exclude list. Replace the `image` type with `svg`:
`svg` is the only format with that type, and since that tag will not be
applied to any new formats, it's clearer to be explicit.

Remove the regex branches that match piskel files by name.

If you have `pre-commit` set up locally, this change will cause the hook
to fail:

    =====> Type tag 'piskel' is not recognized.  Try upgrading identify and pre-commit?

If you installed `pre-commit` with `uv tool install` you can run:

    uv tool upgrade pre-commit
