### PR TITLE
shjourney: Replace xylophone sound effects

### DIFF
--- a/scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_puzzle.tscn
@@ -5,29 +5,29 @@
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="2_24uth"]
 [ext_resource type="Script" uid="uid://c68oh8dtr21ti" path="res://scenes/game_logic/sequence_puzzle.gd" id="3_pwbbg"]
 [ext_resource type="PackedScene" uid="uid://b8sok264erfoc" path="res://scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn" id="4_8l7t1"]
-[ext_resource type="AudioStream" uid="uid://cg57q82pb243w" path="res://assets/third_party/xylophone-sampler-pack/xylophone-c3.ogg" id="5_0l36b"]
 [ext_resource type="SpriteFrames" uid="uid://drrfagdgia0bh" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_Eye5.tres" id="6_0qchv"]
 [ext_resource type="PackedScene" uid="uid://b2gk6rutivuq6" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_Ghost.tscn" id="6_6073y"]
-[ext_resource type="AudioStream" uid="uid://b83x8h0ob5mpq" path="res://assets/third_party/xylophone-sampler-pack/xylophone-d3.ogg" id="6_kcywm"]
 [ext_resource type="SpriteFrames" uid="uid://bt7rx4p6q8dof" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_Eye1.tres" id="6_m6vwj"]
-[ext_resource type="AudioStream" uid="uid://cmtiwg2cylmts" path="res://assets/third_party/xylophone-sampler-pack/xylophone-e3.ogg" id="7_kgawy"]
 [ext_resource type="SpriteFrames" uid="uid://vrthlt7kah8w" path="res://scenes/quests/story_quests/shjourney/Otros_componentes/tim_sprite_frames.tres" id="8_at0ry"]
-[ext_resource type="AudioStream" uid="uid://8k1hyi4gjae4" path="res://assets/third_party/xylophone-sampler-pack/xylophone-f3.ogg" id="8_pm8wt"]
 [ext_resource type="SpriteFrames" uid="uid://fnv8rakr1qfd" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_Eye2.tres" id="8_rijqc"]
-[ext_resource type="AudioStream" uid="uid://6oahn2ucxxjv" path="res://assets/third_party/xylophone-sampler-pack/xylophone-g3.ogg" id="9_u14ci"]
-[ext_resource type="AudioStream" uid="uid://bdboi4ndapqec" path="res://assets/third_party/xylophone-sampler-pack/xylophone-a3.ogg" id="10_1fpv6"]
 [ext_resource type="SpriteFrames" uid="uid://2gsf2tg6nyy7" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_Eye3.tres" id="10_m0770"]
 [ext_resource type="PackedScene" uid="uid://be4o3ythda4cu" path="res://scenes/game_elements/props/sequence_puzzle_hint_sign/sequence_puzzle_hint_sign.tscn" id="11_l8oes"]
+[ext_resource type="AudioStream" uid="uid://bo25y5bhus8cc" path="res://assets/third_party/nepalese_hand_bells/handBells-c4.ogg" id="12_at0ry"]
 [ext_resource type="SpriteFrames" uid="uid://db5ff7jlg18yl" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_Eye4.tres" id="12_vpkld"]
 [ext_resource type="Script" uid="uid://ccc78coj2b1li" path="res://scenes/game_logic/sequence_puzzle_step.gd" id="13_kvm4s"]
 [ext_resource type="SpriteFrames" uid="uid://cauuocuqonixc" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_sign.tres" id="14_50kek"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="14_fmuso"]
+[ext_resource type="AudioStream" uid="uid://yjrrxahyspir" path="res://assets/third_party/nepalese_hand_bells/handBells-d4.ogg" id="14_it68j"]
 [ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="15_daurq"]
+[ext_resource type="AudioStream" uid="uid://5dtwojx17yy3" path="res://assets/third_party/nepalese_hand_bells/handBells-d#4.ogg" id="16_at0ry"]
 [ext_resource type="SpriteFrames" uid="uid://b57jvrpdva2lg" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_Eye6.tres" id="16_hvqie"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="17_w086l"]
+[ext_resource type="AudioStream" uid="uid://c3atgmwmebofj" path="res://assets/third_party/nepalese_hand_bells/handBells-f4.ogg" id="18_it68j"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="18_nj0xq"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="19_2uj8m"]
+[ext_resource type="AudioStream" uid="uid://beg0oymbumyoh" path="res://assets/third_party/nepalese_hand_bells/handBells-g4.ogg" id="20_8ckgm"]
 [ext_resource type="SpriteFrames" uid="uid://cgy2ies7tyoux" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_sign_2.tres" id="20_hvqie"]
+[ext_resource type="AudioStream" uid="uid://shckj7dsimyt" path="res://assets/third_party/nepalese_hand_bells/handBells-g#4.ogg" id="22_het1f"]
 [ext_resource type="PackedScene" uid="uid://ipvcfv2g0oi1" path="res://scenes/game_elements/characters/npcs/talker/talker.tscn" id="27_m0770"]
 [ext_resource type="Resource" uid="uid://de4oyrbo2yvok" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_guardian.dialogue" id="28_vpkld"]
 [ext_resource type="SpriteFrames" uid="uid://bkg2yqajvfipw" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_guardian.tres" id="29_hvqie"]
@@ -38,7 +38,6 @@
 
 [sub_resource type="Resource" id="Resource_u8qfb"]
 script = ExtResource("15_daurq")
-name = ""
 type = 2
 metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
@@ -261,38 +260,38 @@ position = Vector2(356, 453)
 modulate = Color(0, 0.4, 0.6, 1)
 position = Vector2(123, -320)
 sprite_frames = ExtResource("6_m6vwj")
-audio_stream = ExtResource("5_0l36b")
+audio_stream = ExtResource("12_at0ry")
 
 [node name="Orange" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_8l7t1")]
 modulate = Color(0.917454, 0.399473, 0.227027, 1)
 texture_filter = 1
 position = Vector2(117, -213)
 sprite_frames = ExtResource("8_rijqc")
-audio_stream = ExtResource("6_kcywm")
+audio_stream = ExtResource("14_it68j")
 
 [node name="Yellow" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_8l7t1")]
 modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(193, -153)
 sprite_frames = ExtResource("10_m0770")
-audio_stream = ExtResource("7_kgawy")
+audio_stream = ExtResource("16_at0ry")
 
 [node name="Green" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_8l7t1")]
 modulate = Color(0.188235, 0.717647, 0, 1)
 position = Vector2(298, -136)
 sprite_frames = ExtResource("12_vpkld")
-audio_stream = ExtResource("8_pm8wt")
+audio_stream = ExtResource("18_it68j")
 
 [node name="Purple" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_8l7t1")]
 modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(383, -65)
 sprite_frames = ExtResource("6_0qchv")
-audio_stream = ExtResource("9_u14ci")
+audio_stream = ExtResource("20_8ckgm")
 
 [node name="Red" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_8l7t1")]
 modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(483, -67)
 sprite_frames = ExtResource("16_hvqie")
-audio_stream = ExtResource("10_1fpv6")
+audio_stream = ExtResource("22_het1f")
 
 [node name="Signs" type="Node2D" parent="OnTheGround/SequencePuzzle"]
 y_sort_enabled = true


### PR DESCRIPTION
In the main game, we have new, better-sounding sequence puzzle sounds. And unlike the xylophone samples that were used before, we have a full scale and a half, including all semitones.

Replace the xylophone sounds in the dragon puzzle with handbell sounds. Change the scale from C major (C D E F G A) to C minor (C D D♯=E♭ F G G♯=A♭): this matches the background music in this level, which is in C minor.