### PR TITLE
Re-enable threadbare_project_settings plugin

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -59,7 +59,7 @@ window/size/mode.web=0
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/dialogue_manager/plugin.cfg", "res://addons/git_lfs_checker/plugin.cfg", "res://addons/input_helper/plugin.cfg", "res://addons/sprite_frames_exported_textures/plugin.cfg", "res://addons/storyquest_bootstrap/plugin.cfg", "res://addons/threadbare_git_describe/plugin.cfg")
+enabled=PackedStringArray("res://addons/dialogue_manager/plugin.cfg", "res://addons/git_lfs_checker/plugin.cfg", "res://addons/input_helper/plugin.cfg", "res://addons/sprite_frames_exported_textures/plugin.cfg", "res://addons/storyquest_bootstrap/plugin.cfg", "res://addons/threadbare_git_describe/plugin.cfg", "res://addons/threadbare_project_settings/plugin.cfg")
 
 [file_customization]
 


### PR DESCRIPTION
This was accidentally disabled in commit
783701b70678719f77ae2b15415a459a5b06ceb6, probably by me when I resolved
merge conflicts in this file.