### PR TITLE
ci: Use treeless clone for export workflow

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -31,9 +31,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           lfs: true
-          # TODO: can we use --filter to avoid fetching the trees & blobs for
-          # all historical commits, while still fetching the commit history &
-          # tags?
+          filter: tree:0
           fetch-depth: 0
           fetch-tags: true
 


### PR DESCRIPTION
ci: Use treeless clone for export workflow

When building & exporting the game, we need the full history of commits so that
`git describe` works, but we do not need the contents of any historical commits.
It is wasteful to download it all, only to discard it as soon as the clone is
finished.

Use a treeless clone, which fetches the full commit history, but only downloads
trees (and blobs, i.e. files) when needed.

https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
