### PR TITLE
Reindent REUSE.toml; move Flatpak manifest

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,7 @@ indent_size = 4
 [*.{yaml,yml,xml}]
 indent_style = space
 indent_size = 2
+
+[*.toml]
+indent_style = tab
+indent_size = 4

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: threadbare.flatpak
-          manifest-path: org.endlessaccess.threadbare.yml
+          manifest-path: linux/org.endlessaccess.threadbare.yml
           cache-key: "flatpak-builder-${{ github.sha }}"
 
       - name: Create Linux metadata bundle

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,8 +4,8 @@ version = 1
 # creative work.
 [[annotations]]
 path = [
-    "addons/**/*.uid",
-    "scenes/**/*.uid",
+	"addons/**/*.uid",
+	"scenes/**/*.uid",
 ]
 SPDX-FileCopyrightText = "NONE"
 SPDX-License-Identifier = "CC0-1.0"
@@ -15,19 +15,19 @@ SPDX-License-Identifier = "CC0-1.0"
 # when saving changes to these files.
 [[annotations]]
 path = [
-    "addons/git_lfs_checker/plugin.cfg",
-    "addons/sprite_frames_exported_textures/plugin.cfg",
-    "addons/storyquest_bootstrap/plugin.cfg",
-    "addons/storyquest_bootstrap/*.tscn",
-    "addons/threadbare_project_settings/plugin.cfg",
-    "scenes/*.tscn",
-    "scenes/**/*.tscn",
-    "scenes/**/*.tres",
-    # .import files are largely machine-generated but developers can tweak their contents
-    "**/*.import",
-    "default_bus_layout.tres",
-    "export_presets.cfg",
-    "project.godot",
+	"addons/git_lfs_checker/plugin.cfg",
+	"addons/sprite_frames_exported_textures/plugin.cfg",
+	"addons/storyquest_bootstrap/plugin.cfg",
+	"addons/storyquest_bootstrap/*.tscn",
+	"addons/threadbare_project_settings/plugin.cfg",
+	"scenes/*.tscn",
+	"scenes/**/*.tscn",
+	"scenes/**/*.tres",
+	# .import files are largely machine-generated but developers can tweak their contents
+	"**/*.import",
+	"default_bus_layout.tres",
+	"export_presets.cfg",
+	"project.godot",
 ]
 SPDX-FileCopyrightText = "The Threadbare Authors"
 SPDX-License-Identifier = "MPL-2.0"
@@ -55,47 +55,47 @@ SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = [
-    "assets/third_party/tiny-swords/**/*.png",
-    "assets/third_party/tiny-swords/**/*.aseprite",
+	"assets/third_party/tiny-swords/**/*.png",
+	"assets/third_party/tiny-swords/**/*.aseprite",
 ]
 SPDX-FileCopyrightText = "Pixel Frog"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = [
-    "assets/third_party/fonts/jersey/*.ttf",
+	"assets/third_party/fonts/jersey/*.ttf",
 ]
 SPDX-FileCopyrightText = "Copyright 2023 The Soft Type Project Authors (https://github.com/scfried/soft-type-jersey)"
 SPDX-License-Identifier = "OFL-1.1"
 
 [[annotations]]
 path = [
-    "assets/first_party/**/*.aseprite",
-    "assets/first_party/**/*.mp3",
-    "assets/first_party/**/*.ogg",
-    "assets/first_party/**/*.ogv",
-    "assets/first_party/**/*.piskel",
-    "assets/first_party/**/*.png",
-    "assets/first_party/**/*.svg",
-    "assets/first_party/**/*.wav",
-    "icon-256.png",
-    "icon.aseprite",
-    "icon.png",
-    "scenes/**/*.aseprite",
-    "scenes/**/*.mp3",
-    "scenes/**/*.ogg",
-    "scenes/**/*.ogv",
-    "scenes/**/*.piskel",
-    "scenes/**/*.png",
-    "scenes/**/*.svg",
-    "scenes/**/*.wav",
+	"assets/first_party/**/*.aseprite",
+	"assets/first_party/**/*.mp3",
+	"assets/first_party/**/*.ogg",
+	"assets/first_party/**/*.ogv",
+	"assets/first_party/**/*.piskel",
+	"assets/first_party/**/*.png",
+	"assets/first_party/**/*.svg",
+	"assets/first_party/**/*.wav",
+	"icon-256.png",
+	"icon.aseprite",
+	"icon.png",
+	"scenes/**/*.aseprite",
+	"scenes/**/*.mp3",
+	"scenes/**/*.ogg",
+	"scenes/**/*.ogv",
+	"scenes/**/*.piskel",
+	"scenes/**/*.png",
+	"scenes/**/*.svg",
+	"scenes/**/*.wav",
 ]
 SPDX-FileCopyrightText = "The Threadbare Authors"
 SPDX-License-Identifier = "CC-BY-SA-4.0"
 
 [[annotations]]
 path = [
-    "assets/third_party/inputs/**/*.png",
+	"assets/third_party/inputs/**/*.png",
 ]
 SPDX-FileCopyrightText = "Nicolae (XELU) Berbece"
 SPDX-License-Identifier = "CC0-1.0"

--- a/linux/org.endlessaccess.threadbare.yml
+++ b/linux/org.endlessaccess.threadbare.yml
@@ -20,7 +20,7 @@ modules:
   sources:
 
   - type: dir
-    path: .
+    path: ..
 
   build-commands:
   # PCK file automatically exported in CI; if building locally, in Godot go to


### PR DESCRIPTION
Having these two files at the top level of the repo means it's easy to accidentally edit them in Godot. And in both cases, opening & saving the file would reindent it with tabs rather than spaces.

Fix this in 2 different ways:

- Reindent `REUSE.toml`
- Move the Flatpak manifest