### PR TITLE
Add global enum for collision layers

### DIFF
--- a/scenes/game_elements/characters/player/components/player_hook.gd
+++ b/scenes/game_elements/characters/player/components/player_hook.gd
@@ -17,8 +17,6 @@ extends Node2D
 ## Emitted when the string is thrown from the primary control.
 signal string_thrown
 
-const NON_WALKABLE_FLOOR_LAYER: int = 10
-
 ## The character using the grapping hook tool.
 ## [br][br]
 ## [b]Note:[/b] If the parent node is a CharacterBody2D and character isn't set,
@@ -198,7 +196,7 @@ func remove_string() -> void:
 ## While pulling, the player is allowed to go through non-walkable floor.
 func pull_string() -> void:
 	pulling = true
-	character.set_collision_mask_value(NON_WALKABLE_FLOOR_LAYER, false)
+	character.set_collision_mask_value(Enums.CollisionLayers.NON_WALKABLE_FLOOR, false)
 
 
 ## Stop pulling and remove the [member hook_string].
@@ -206,7 +204,7 @@ func pull_string() -> void:
 ## After pulling, the player is back to normal and not able to go through
 ## non-walkable floor.
 func stop_pulling() -> void:
-	character.set_collision_mask_value(NON_WALKABLE_FLOOR_LAYER, true)
+	character.set_collision_mask_value(Enums.CollisionLayers.NON_WALKABLE_FLOOR, true)
 	pulling = false
 	remove_string()
 

--- a/scenes/game_elements/props/door/components/door.gd
+++ b/scenes/game_elements/props/door/components/door.gd
@@ -3,8 +3,6 @@
 @tool
 extends Toggleable
 
-const WALLS_COLLISION_LAYER = 5
-const PLAYER_COLLISION_LAYER = 1
 @export var play_victory_fanfare_on_open: bool = false
 @export var opened: bool = false:
 	set(new_val):
@@ -33,5 +31,5 @@ func update_opened_state() -> void:
 	%DoorClosed.visible = !opened
 	%DoorOpened.visible = opened
 
-	%ColliderWhenClosed.set_collision_layer_value(WALLS_COLLISION_LAYER, !opened)
-	%ColliderWhenClosed.set_collision_mask_value(PLAYER_COLLISION_LAYER, !opened)
+	%ColliderWhenClosed.set_collision_layer_value(Enums.CollisionLayers.WALLS, not opened)
+	%ColliderWhenClosed.set_collision_mask_value(Enums.CollisionLayers.PLAYERS, not opened)

--- a/scenes/game_elements/props/hookable_area/components/hookable_area.gd
+++ b/scenes/game_elements/props/hookable_area/components/hookable_area.gd
@@ -28,8 +28,6 @@ extends Area2D
 ## [br][br]
 ## [b]Note:[/b] This area is expected to be in the "hookable" collision layer.
 
-const HOOKABLE_LAYER = 13
-
 ## The game entity that becomes hookable.
 ## [br][br]
 ## [b]Note:[/b] If the parent node is a Node2D and this isn't set,
@@ -69,8 +67,13 @@ func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: PackedStringArray
 	if not controlled_entity:
 		warnings.append("Controlled Entity must be set.")
-	if not get_collision_layer_value(HOOKABLE_LAYER):
-		warnings.append("Consider enabling collision with the hookable layer: %d." % HOOKABLE_LAYER)
+	if not get_collision_layer_value(Enums.CollisionLayers.HOOKABLE):
+		warnings.append(
+			(
+				"Consider enabling collision with the hookable layer: %d."
+				% Enums.CollisionLayers.HOOKABLE
+			)
+		)
 	return warnings
 
 

--- a/scenes/game_elements/props/interact_area/components/interact_area.gd
+++ b/scenes/game_elements/props/interact_area/components/interact_area.gd
@@ -9,7 +9,6 @@ signal interaction_ended
 
 const EXAMPLE_INTERACTION_FONT = preload("uid://c3bb7lmvdqc5e")
 const EXAMPLE_INTERACTION_FONT_SIZE = 34
-const INTERACTABLE_LAYER = 6
 
 ## Vector2 that approximates the position in which the interact label would
 ## appear when a player is close.
@@ -21,7 +20,7 @@ var interact_label_position: Vector2:
 @export var disabled: bool = false:
 	set(new_value):
 		disabled = new_value
-		set_collision_layer_value(INTERACTABLE_LAYER, not disabled)
+		set_collision_layer_value(Enums.CollisionLayers.INTERACTABLE, not disabled)
 @export var action: String = "Talk"
 
 
@@ -39,9 +38,12 @@ func get_global_interact_label_position() -> Vector2:
 
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: PackedStringArray
-	if not disabled and not get_collision_layer_value(INTERACTABLE_LAYER):
+	if not disabled and not get_collision_layer_value(Enums.CollisionLayers.INTERACTABLE):
 		warnings.append(
-			"Consider enabling collision with the interactable layer: %d." % INTERACTABLE_LAYER
+			(
+				"Consider enabling collision with the interactable layer: %d."
+				% Enums.CollisionLayers.INTERACTABLE
+			)
 		)
 	return warnings
 

--- a/scenes/game_elements/props/projectile/components/projectile.gd
+++ b/scenes/game_elements/props/projectile/components/projectile.gd
@@ -5,9 +5,6 @@
 class_name Projectile
 extends RigidBody2D
 
-const PLAYER_HITBOX_LAYER: int = 6
-const ENEMY_HITBOX_LAYER: int = 7
-
 ## The projectile can fill barrels with the matching label.
 @export var label: String = "???"
 
@@ -97,12 +94,12 @@ func _set_direction(new_direction: Vector2) -> void:
 
 func _set_can_hit_player(new_can_hit_player: bool) -> void:
 	can_hit_player = new_can_hit_player
-	set_collision_mask_value(PLAYER_HITBOX_LAYER, can_hit_player)
+	set_collision_mask_value(Enums.CollisionLayers.PLAYERS_HITBOX, can_hit_player)
 
 
 func _set_can_hit_enemy(new_can_hit_enemy: bool) -> void:
 	can_hit_enemy = new_can_hit_enemy
-	set_collision_mask_value(ENEMY_HITBOX_LAYER, can_hit_enemy)
+	set_collision_mask_value(Enums.CollisionLayers.ENEMIES_HITBOX, can_hit_enemy)
 
 
 func _ready() -> void:

--- a/scenes/globals/enums.gd
+++ b/scenes/globals/enums.gd
@@ -7,3 +7,21 @@ enum LookAtSide {
 	LEFT = -1,
 	RIGHT = 1,
 }
+
+## Collision layer names.
+## [br][br]
+## To access collision layers and masks by name rather than by number.
+## Please keep this in sync with Project Settings layer_names/2d_physics/
+enum CollisionLayers {
+	PLAYERS = 1,
+	NPCS = 2,
+	PLAYER_DETECTORS = 3,
+	SIGHT_OCCLUDERS = 4,
+	WALLS = 5,
+	INTERACTABLE = 6,
+	PLAYERS_HITBOX = 7,
+	ENEMIES_HITBOX = 8,
+	PROJECTILES = 9,
+	NON_WALKABLE_FLOOR = 10,
+	HOOKABLE = 13,
+}

--- a/scenes/quests/story_quests/shjourney/8_shjourney_outro/puerta.gd
+++ b/scenes/quests/story_quests/shjourney/8_shjourney_outro/puerta.gd
@@ -3,8 +3,6 @@
 @tool
 extends Toggleable
 
-const WALLS_COLLISION_LAYER = 5
-const PLAYER_COLLISION_LAYER = 1
 @export var play_victory_fanfare_on_open: bool = false
 @export var opened: bool = false:
 	set(new_val):
@@ -62,5 +60,5 @@ func set_toggled(value: bool) -> void:
 func update_opened_state() -> void:
 	%DoorClosed.visible = !opened
 	%DoorOpened.visible = opened
-	%ColliderWhenClosed.set_collision_layer_value(WALLS_COLLISION_LAYER, !opened)
-	%ColliderWhenClosed.set_collision_mask_value(PLAYER_COLLISION_LAYER, !opened)
+	%ColliderWhenClosed.set_collision_layer_value(Enums.CollisionLayers.WALLS, not opened)
+	%ColliderWhenClosed.set_collision_mask_value(Enums.CollisionLayers.PLAYERS, not opened)


### PR DESCRIPTION
So collision layers can referenced by a constant name rather than by an integer number. And they are all defined in a single place.

Also use "not" boolean operator instead of deprecated "!" in door.gd.