### PR TITLE
Revert "ci: Don't build branches/PRs that don't affect game"

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -8,32 +8,12 @@ on:
         description: 'Also build a Flatpak bundle'
         type: boolean
   pull_request:
-    paths-ignore: &paths_ignore
-      - '**.aseprite'
-      - '**.license'
-      - 'LICENSES/**'
-      - 'docs/**'
-      - 'script_templates/**'
-      - .editorconfig
-      - .github/CODEOWNERS
-      - .github/ISSUE_TEMPLATE
-      - .github/dependabot.yml
-      - .gitignore
-      - .mailmap
-      - .mailmap
-      - .pre-commit-config.yaml
-      - AUTHORS
-      - CODE_OF_CONDUCT.md
-      - COPYING
-      - README.md
-      - REUSE.toml
   release:
     types:
       - published
   push:
     branches:
       - '*'
-    paths-ignore: *paths_ignore
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
This reverts commit c7729008360616bab0d1f5bfd20c08a7744e5709.

The problem with skipping the entire workflow is that the “Build for
web” job is a required status check to be able to merge a pull request.

I tried using dorny/paths-filter to move the “what changed?” check into
a job, so that the workflow would look like this:

    check-changes
      ↓    |
    build  |
      ↓    ↓
      flatpak
         ↓
      release

with the following conditions on each:

- build: run if check-changes detected non-documentation changes, or if
  this is a release, or if the workflow was manually triggered

- flatpak: run if check-changes detected flatpak changes, or if this is
  a release, or if the workflow was manually triggered with the checkbox
  checked

- release: run only if this is a release

At this point the conditions were getting a bit unwieldy, so I decided
it's simpler to always build.
