### PR TITLE
linux: Add 0.1.5 release to metainfo

### DIFF
--- a/linux/metainfo.xml
+++ b/linux/metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 SPDX-FileCopyrightText: The Threadbare Authors
-SPDX-License-Identifier: CC-BY-4.0
+SPDX-License-Identifier: CC0-1.0
 -->
 <component type="desktop">
   <name>Threadbare</name>

--- a/linux/releases.xml
+++ b/linux/releases.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 SPDX-FileCopyrightText: The Threadbare Authors
-SPDX-License-Identifier: CC-BY-4.0
+SPDX-License-Identifier: CC0-1.0
 -->
 <releases>
   <release version="0.1.5" date="2025-10-10">


### PR DESCRIPTION
I plan to make this release today.
