### PR TITLE
Guard: Fix flipping the sprite horizontally

### DIFF
--- a/scenes/game_elements/characters/enemies/guard/components/guard.gd
+++ b/scenes/game_elements/characters/enemies/guard/components/guard.gd
@@ -98,6 +98,13 @@ var _player: Player
 @onready var sight_ray_cast: RayCast2D = %SightRayCast
 ## Control to hold debug info that can be toggled on or off.
 @onready var debug_info: Label = %DebugInfo
+
+## Reference to the node controlling the AnimationPlayer for walking / being idle,
+## so it can be disabled to play the alerted animation.
+@onready
+# gdlint:ignore = max-line-length
+var character_animation_player_behavior: CharacterAnimationPlayerBehavior = %CharacterAnimationPlayerBehavior
+
 ## Handles the velocity and movement of the guard.
 @onready var guard_movement: GuardMovement = %GuardMovement
 @onready var animated_sprite_2d: AnimatedSprite2D = %AnimatedSprite2D
@@ -269,6 +276,7 @@ func _set_state(new_state: State) -> void:
 			if not _alert_sound.playing:
 				_alert_sound.play()
 		State.ALERTED:
+			character_animation_player_behavior.process_mode = Node.PROCESS_MODE_DISABLED
 			if not _alert_sound.playing:
 				_alert_sound.play()
 			animation_player.play(&"alerted")

--- a/scenes/game_elements/characters/enemies/guard/guard.tscn
+++ b/scenes/game_elements/characters/enemies/guard/guard.tscn
@@ -7,6 +7,8 @@
 [ext_resource type="Script" uid="uid://cxsi2xqcdyw7g" path="res://scenes/game_elements/characters/enemies/guard/components/light.gd" id="4_lptvm"]
 [ext_resource type="Script" uid="uid://bnbt0iw1a1w6" path="res://scenes/game_elements/characters/enemies/guard/components/detection_area.gd" id="4_mswbt"]
 [ext_resource type="SpriteFrames" uid="uid://ovu5wqo15s5g" path="res://scenes/quests/story_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth_components/NO_EDIT_guard_enemy.tres" id="5_mswbt"]
+[ext_resource type="Script" uid="uid://dy68p7gf07pi3" path="res://scenes/game_logic/character_sprite_behavior.gd" id="7_klpct"]
+[ext_resource type="Script" uid="uid://b3hx1n2yl88qr" path="res://scenes/game_logic/character_animation_player_behavior.gd" id="9_8vt0k"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_g173s"]
 radius = 35.0
@@ -119,6 +121,35 @@ tracks/2/keys = {
 "values": [0, 1, 2, 3, 4, 5, 5]
 }
 
+[sub_resource type="Animation" id="Animation_ls1y7"]
+resource_name = "idle"
+length = 1.1
+step = 0.1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:animation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [&"idle"]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("AnimatedSprite2D:frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+"update": 1,
+"values": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10]
+}
+
 [sub_resource type="Animation" id="Animation_8vt0k"]
 resource_name = "walk"
 length = 0.6
@@ -159,35 +190,6 @@ tracks/2/keys = {
 "transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1),
 "update": 1,
 "values": [0, 1, 2, 3, 4, 5, 5]
-}
-
-[sub_resource type="Animation" id="Animation_ls1y7"]
-resource_name = "idle"
-length = 1.1
-step = 0.1
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("AnimatedSprite2D:animation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 1,
-"values": [&"idle"]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("AnimatedSprite2D:frame")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1),
-"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-"update": 1,
-"values": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_innil"]
@@ -250,6 +252,13 @@ sprite_frames = ExtResource("5_mswbt")
 animation = &"idle"
 autoplay = "idle"
 
+[node name="CharacterSpriteBehavior" type="Node2D" parent="AnimatedSprite2D" node_paths=PackedStringArray("character", "sprite")]
+script = ExtResource("7_klpct")
+character = NodePath("../..")
+play_animations = false
+sprite = NodePath("..")
+metadata/_custom_type_script = "uid://dy68p7gf07pi3"
+
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_nv25s")
 
@@ -294,6 +303,13 @@ label_settings = SubResource("LabelSettings_nv25s")
 libraries = {
 &"": SubResource("AnimationLibrary_innil")
 }
+
+[node name="CharacterAnimationPlayerBehavior" type="Node2D" parent="AnimationPlayer" node_paths=PackedStringArray("character", "animation_player")]
+unique_name_in_owner = true
+script = ExtResource("9_8vt0k")
+character = NodePath("../..")
+animation_player = NodePath("..")
+metadata/_custom_type_script = "uid://b3hx1n2yl88qr"
 
 [node name="Sounds" type="Node2D" parent="."]
 


### PR DESCRIPTION
In 57b0a2e5 I removed more than necessary:

```
if not is_zero_approx(velocity.x):
    animated_sprite_2d.flip_h = velocity.x < 0
```

Bring it back, but now using CharacterSpriteBehavior and CharacterAnimationPlayerBehavior nodes.

When the guard is alerted, disable the node controlling the AnimationPlayer for walking / being idle, so it can be disabled to play the alerted animation.

Inside the scene file, the position of the idle animation subresource changes for no reason.