### PR TITLE
Fix default input device when no joypad is connected

### DIFF
--- a/scenes/game_elements/props/hint/input_key/gamepad_input.gd
+++ b/scenes/game_elements/props/hint/input_key/gamepad_input.gd
@@ -80,10 +80,7 @@ func _physics_process(_delta: float) -> void:
 
 func _ready() -> void:
 	InputHelper.device_changed.connect(_on_input_device_changed)
-	_on_input_device_changed(
-		InputHelper.last_known_joypad_device,
-		InputHelper.last_known_joypad_index,
-	)
+	_on_input_device_changed(InputHelper.device, InputHelper.device_index)
 
 
 func _on_input_device_changed(device: String, _device_index: int) -> void:

--- a/scenes/game_elements/props/hint/input_key/interact_input.gd
+++ b/scenes/game_elements/props/hint/input_key/interact_input.gd
@@ -28,10 +28,7 @@ func _physics_process(_delta: float) -> void:
 
 func _ready() -> void:
 	InputHelper.device_changed.connect(_on_input_device_changed)
-	_on_input_device_changed(
-		InputHelper.last_known_joypad_device,
-		InputHelper.last_known_joypad_index,
-	)
+	_on_input_device_changed(InputHelper.device, InputHelper.device_index)
 
 
 func _on_input_device_changed(device: String, _device_index: int) -> void:

--- a/scenes/game_elements/props/hint/input_key/keyboard_input.gd
+++ b/scenes/game_elements/props/hint/input_key/keyboard_input.gd
@@ -20,10 +20,7 @@ func _physics_process(_delta: float) -> void:
 
 func _ready() -> void:
 	InputHelper.device_changed.connect(_on_input_device_changed)
-	_on_input_device_changed(
-		InputHelper.last_known_joypad_device,
-		InputHelper.last_known_joypad_index,
-	)
+	_on_input_device_changed(InputHelper.device, InputHelper.device_index)
 
 
 func _on_input_device_changed(device: String, _device_index: int) -> void:


### PR DESCRIPTION
In commit 0a547d0d3e438789a51912c923db170d63704a04 I simplified the way
that our input hint components choose a default device: rather than
reimplementing Input Helper's device detection, we use a pair of
properties from the helper.

Unfortunately I picked the wrong ones: I used last_known_joypad_device
and last_known_joypad_index. As the name suggests, the
last_known_joypad_device will never be "keyboard". Its docstring claims
it will be "" if no gamepad is connected; in fact it is currently
"generic", which I submitted
https://github.com/nathanhoad/godot_input_helper/pull/87 to fix.

As a result, if you have no gamepad connected, then gamepad hints will
always be shown.

Instead, use InputHelper.device and InputHelper.device_index, which are
the type and index of the last device that the player used to control
the game. Before any input events have been received, these default to
joypad 0 if there is a joypad connected, and "keyboard" / -1 if not.
