### PR TITLE
Nora: Reset combat & stealth camera zoom to 1×

### DIFF
--- a/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat.tscn
+++ b/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat.tscn
@@ -344,7 +344,6 @@ sprite_frames = ExtResource("18_2bah4")
 
 [node name="Camera2D" type="Camera2D" parent="OnTheGround/Player"]
 process_mode = 3
-zoom = Vector2(1.4, 1.4)
 limit_left = -500
 limit_top = -500
 position_smoothing_enabled = true

--- a/scenes/quests/story_quests/verso/2_verso_stealth_sadness/verso_stealth.tscn
+++ b/scenes/quests/story_quests/verso/2_verso_stealth_sadness/verso_stealth.tscn
@@ -627,7 +627,6 @@ sprite_frames = ExtResource("13_4e5pa")
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
 process_mode = 3
-zoom = Vector2(1.4, 1.4)
 limit_left = 0
 limit_top = 0
 position_smoothing_enabled = true


### PR DESCRIPTION
Previously these were set to 1.4. This causes ugly flickering on 1px
horizontal/vertical lines as the camera pans around. I think it's a
leftover from the game being at 1080p resolution.

Reset the zoom to 1×, which also makes a little more of the level
visible (which I think makes it fairer).

The sequence puzzle is set to 0.7×; this has the same problem but is not
so easy to fix because if you reset it to 1× then you can't see all of
the objects when interacting with the book.
