### PR TITLE
HUD: Reduce its size

### DIFF
--- a/scenes/ui_elements/story_quest_progress/story_quest_progress.tscn
+++ b/scenes/ui_elements/story_quest_progress/story_quest_progress.tscn
@@ -5,11 +5,15 @@
 [ext_resource type="PackedScene" uid="uid://1mjm4atk2j6e" path="res://scenes/ui_elements/story_quest_progress/components/item_slot/item_slot.tscn" id="3_mwl7j"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_hqnrr"]
+content_margin_top = 32.0
+content_margin_right = 48.0
 texture = ExtResource("1_cikk2")
-texture_margin_left = 65.0
-texture_margin_top = 65.0
-texture_margin_right = 65.0
-texture_margin_bottom = 65.0
+texture_margin_left = 64.0
+texture_margin_top = 64.0
+texture_margin_right = 64.0
+texture_margin_bottom = 64.0
+expand_margin_top = 32.0
+expand_margin_right = 16.0
 axis_stretch_horizontal = 1
 axis_stretch_vertical = 1
 
@@ -17,8 +21,8 @@ axis_stretch_vertical = 1
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
-offset_left = -372.0
-offset_bottom = 208.0
+offset_left = -216.0
+offset_bottom = 128.0
 grow_horizontal = 0
 theme_override_styles/panel = SubResource("StyleBoxTexture_hqnrr")
 script = ExtResource("2_hvmtc")
@@ -26,12 +30,20 @@ script = ExtResource("2_hvmtc")
 [node name="ItemsContainer" type="HBoxContainer" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 
 [node name="ItemSlot" parent="ItemsContainer" instance=ExtResource("3_mwl7j")]
+custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
+expand_mode = 2
 
 [node name="ItemSlot2" parent="ItemsContainer" instance=ExtResource("3_mwl7j")]
+custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
+expand_mode = 2
 
 [node name="ItemSlot3" parent="ItemsContainer" instance=ExtResource("3_mwl7j")]
+custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
+expand_mode = 2


### PR DESCRIPTION
Set a minimum size of 32x32 to items (which are  TextureRects). This is the same size as the actual PNG asset.

Adjust the stylebox texture override. Set texture margins to 64 (it was 65 which is wrong). Use expand margins and content margins to reduce the transparent zone at the top and right of the texture.

Before / after:

<img width="1300" height="775" alt="Captura desde 2025-10-13 15-21-10" src="https://github.com/user-attachments/assets/db17f8a8-5339-47ed-ab94-6665a5a5520d" />

<img width="1300" height="775" alt="Captura desde 2025-10-13 15-28-04" src="https://github.com/user-attachments/assets/7be70eb7-6c80-4b6f-b4d4-c0dcca207555" />

<img width="1300" height="775" alt="Captura desde 2025-10-13 15-50-01" src="https://github.com/user-attachments/assets/262a3dcb-c54c-4e3b-b36a-dd5512e74487" />

(The one in the middle is an alternative solution, with the thread textures at double size, 64x64)

Fix https://github.com/endlessm/threadbare/issues/1143