### PR TITLE
linux: Add 0.1.6 to releases file

### DIFF
--- a/linux/releases.xml
+++ b/linux/releases.xml
@@ -4,6 +4,9 @@ SPDX-FileCopyrightText: The Threadbare Authors
 SPDX-License-Identifier: CC0-1.0
 -->
 <releases>
+  <release version="0.1.6" date="2025-10-14">
+    <url type="details">https://github.com/endlessm/threadbare/releases/tag/v0.1.6</url>
+  </release>
   <release version="0.1.5" date="2025-10-10">
     <url type="details">https://github.com/endlessm/threadbare/releases/tag/v0.1.5</url>
   </release>


### PR DESCRIPTION
linux: Add 0.1.6 to releases file

We should really automate this…
