### PR TITLE
Void particles: Make visibility rect big enough

### DIFF
--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_particles.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_particles.tscn
@@ -44,4 +44,5 @@ amount = 80
 texture = ExtResource("1_hohl7")
 one_shot = true
 explosiveness = 1.0
+visibility_rect = Rect2(-1000, -1000, 2000, 2000)
 process_material = SubResource("ParticleProcessMaterial_rrhr1")


### PR DESCRIPTION
Since the Void enemy has a trail of particles, the particles may dissapear abruptly when the enemy goes off screen. Making the visibility rect big enough ensures that it doesn't happen.

Before:

[particles-before.webm](https://github.com/user-attachments/assets/7345dcc8-66f4-4811-aa59-fbb264d2d591)

After:

[particles-after.webm](https://github.com/user-attachments/assets/c0651957-966f-4f15-a5a3-7e3e97179938)
