### PR TITLE
Player: Set wall min slide angle to one degree

### DIFF
--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -506,6 +506,7 @@ _data = {
 [node name="Player" type="CharacterBody2D" groups=["player"]]
 collision_mask = 531
 motion_mode = 1
+wall_min_slide_angle = 0.017453292
 script = ExtResource("1_g2els")
 
 [node name="HitBox" type="Area2D" parent="."]


### PR DESCRIPTION
So the player slides nicely when colliding with non-walkable floor tiles or any wall tile. The default of 15 degrees made the player capsule collision shape get stuck in tile corners.

Zero can't be used, otherwise the player moves up when trying to go left or right colliding with a vertical shape.

Before:

[stuck-before.webm](https://github.com/user-attachments/assets/11e21861-0442-4e8f-954a-fba4ac81153c)

After:

[stuck-after.webm](https://github.com/user-attachments/assets/c6993647-9c96-4b25-aed9-153565165921)

The grappling hook raycast and arrow happens to help showing exactly the input direction (using keyboard).