### PR TITLE
HookControl: Use a timer to allow D-pad diagonal aiming

### DIFF
--- a/scenes/game_elements/props/hook_control/hook_control.tscn
+++ b/scenes/game_elements/props/hook_control/hook_control.tscn
@@ -16,3 +16,10 @@ unique_name_in_owner = true
 target_position = Vector2(300, 0)
 collision_mask = 4112
 collide_with_areas = true
+
+[node name="DPadTimer" type="Timer" parent="."]
+unique_name_in_owner = true
+wait_time = 0.2
+one_shot = true
+
+[connection signal="timeout" from="DPadTimer" to="." method="_on_d_pad_timer_timeout"]


### PR DESCRIPTION
The previous solution of just returning from _unhandled_input when a key is released is not enough. Because when the player is walking in a horizontal or vertical direction, it may continue aiming diagonally.

Factor out the axis calculation for rotating the aim control.

Add a Timer node and connect its timeout to the axis calculation.

Start / reset the timer when any key of the D-pad is released.

Fix https://github.com/endlessm/threadbare/issues/1366