### PR TITLE
Remove wobble hints from sequence puzzle

### DIFF
--- a/scenes/game_elements/props/sequence_puzzle_object/components/sequence_puzzle_object.gd
+++ b/scenes/game_elements/props/sequence_puzzle_object/components/sequence_puzzle_object.gd
@@ -82,10 +82,6 @@ func _stop() -> void:
 		animated_sprite.play("default")
 
 
-func wobble_silently() -> void:
-	await play(true)
-
-
 ## Stop the silent hint animation, if playing.
 func stop_hint() -> void:
 	await _stop()


### PR DESCRIPTION
These hints are supposed to gently point the player in the right
direction when they are stuck. But now:

- The musician just tells you the answer if you keep talking to him;
- You can interact with the hints and see the answer.

So this is unnecessary, and actually it confuses the matter because the
wobble hints can play while another rock is being sounded by the sign
demoing the sequence: I've seen people being confused by this in
playtesting.

Remove the wobble hint logic, and the
SequencePuzzleObject.wobble_silently() method. I left the code in
SequencePuzzleObject.play() to optionally play the animation without
sound, in case this is useful somehow.

Resolves https://github.com/endlessm/threadbare/issues/686
