### PR TITLE
Musician dialogue: Remove call to stop_hints()

### DIFF
--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-do puzzle.stop_hints()
 if puzzle.is_solved():
 	=> item_hint
 


### PR DESCRIPTION
Which was removed in 6dde5c9c

Helps https://github.com/endlessm/threadbare/issues/686