### PR TITLE
Player: Add one pixel of safe margin

### DIFF
--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -507,6 +507,7 @@ _data = {
 collision_mask = 531
 motion_mode = 1
 wall_min_slide_angle = 0.017453292
+safe_margin = 1.0
 script = ExtResource("1_g2els")
 
 [node name="HitBox" type="Area2D" parent="."]


### PR DESCRIPTION
This seems enough for preventing the player getting stuck in props like trees.

Fix https://github.com/endlessm/threadbare/issues/1395