### PR TITLE
Project settings: Setup movie file in user data folder

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -58,6 +58,10 @@ mouse_cursor/tooltip_position_offset=Vector2(19, 29)
 window/size/mode.editor=0
 window/size/mode.web=0
 
+[editor]
+
+movie_writer/movie_file="user://recording.ogv"
+
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/dialogue_manager/plugin.cfg", "res://addons/git_lfs_checker/plugin.cfg", "res://addons/input_helper/plugin.cfg", "res://addons/sprite_frames_exported_textures/plugin.cfg", "res://addons/storyquest_bootstrap/plugin.cfg", "res://addons/threadbare_git_describe/plugin.cfg", "res://addons/threadbare_project_settings/plugin.cfg")


### PR DESCRIPTION
Set it to user://recording.ogv. This folder can be opened in any operating system from the Project dropdown menu.

With this, recording a video within the editor is just a matter of enabling Movie Maker Mode from the playtest buttons.