### PR TITLE
Fray's End: Remove y_sort_enabled from two trees

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -633,13 +633,11 @@ position = Vector2(814.302, 473.196)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree72" parent="Trees" instance=ExtResource("7_7v00g")]
-y_sort_enabled = true
 position = Vector2(138.704, 1164.6)
 scale = Vector2(1.002, 1.002)
 metadata/_edit_pinned_properties_ = [&"scale"]
 
 [node name="Tree75" parent="Trees" instance=ExtResource("7_7v00g")]
-y_sort_enabled = true
 position = Vector2(384.998, 1028.21)
 scale = Vector2(1.002, 1.002)
 metadata/_edit_pinned_properties_ = [&"scale"]


### PR DESCRIPTION
This causes StoryWeaver to appear on top of the tree, even when they are
conceptually behind it.

y_sort_enabled needs to be set on the *parent* nodes, not on the props
themselves.

| Before | After |
| --- | --- |
| <img width="640" height="360" alt="StoryWeaver character floating on top of a tree" src="https://github.com/user-attachments/assets/787909b6-6152-4244-8dbc-69c5b58d293f" /> | <img width="640" height="360" alt="StoryWeaver character hidden behind a tree" src="https://github.com/user-attachments/assets/3e717c48-bb1c-4c65-a2f0-b00d3c1fa732" /> |