### PR TITLE
Use Threadbare logo in bootsplash

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,9 @@ config/tags=PackedStringArray("2d", "endless", "game", "tilemap", "top_down")
 run/main_scene="uid://huuo8mnwsphv"
 config/project_settings_override="user://custom_overrides.cfg"
 config/features=PackedStringArray("4.5", "GL Compatibility")
+boot_splash/fullsize=false
+boot_splash/use_filter=false
+boot_splash/image="uid://dvfpk2yguwjfv"
 config/icon="uid://dhwqkdin6refx"
 
 [autoload]


### PR DESCRIPTION
This is the 512px variant with no text and a needle through the spool.

Configure the splash screen not to scale the logo, and (in case we later do want
to scale it) to use nearest-neighbour interpolation rather than linear
interpolation.

Resolves https://github.com/endlessm/threadbare/issues/1338

