### PR TITLE
Void runner: improve tree collisions

### DIFF
--- a/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=37 format=4 uid="uid://bm4ewr8p48x0i"]
+[gd_scene load_steps=36 format=4 uid="uid://bm4ewr8p48x0i"]
 
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="1_g2rto"]
 [ext_resource type="TileSet" uid="uid://07fq3rspk8ia" path="res://scenes/tileset.tres" id="1_wy2h8"]
@@ -45,9 +45,6 @@ _data = {
 "points": PackedVector2Array(0, 0, 0, 0, 726, 3145, 30.2699, 20.711, -30.2699, -20.711, 698, 3104, 34.7308, -1.27452, -34.7308, 1.27452, 625, 3138, 22.9414, -0.318631, -22.9414, 0.318631, 553, 3097, 0, 0, 0, 0, 490, 3146, 0, 0, 0, 0, 420, 3094, 0, 0, 0, 0, 356, 3147, 0, 0, 0, 0, 269, 3091, 0, 0, 0, 0, 198, 3154, 0, 0, 0, 0, 132, 3097, 0, 0, 0, 0, 49, 3146, 0, 0, 0, 0, -39, 3095, 0, 0, 0, 0, -100, 3141, 0, 0, 0, 0, -157, 3099, 0, 0, 0, 0, -203, 3140, 0, 0, 0, 0, -258, 3093, 0, 0, 0, 0, -303, 3141)
 }
 point_count = 17
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_g2rto"]
-size = Vector2(449, 337)
 
 [sub_resource type="Resource" id="Resource_8l6e1"]
 script = ExtResource("23_amu0w")
@@ -838,9 +835,9 @@ sprite_frames = ExtResource("21_xqo3t")
 [node name="StaticBody2D" type="StaticBody2D" parent="OnTheGround/SanctuaryWoods"]
 position = Vector2(3551, 1666)
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/SanctuaryWoods/StaticBody2D"]
-position = Vector2(5.5, -61.5)
-shape = SubResource("RectangleShape2D_g2rto")
+[node name="CollisionShape2D" type="CollisionPolygon2D" parent="OnTheGround/SanctuaryWoods/StaticBody2D"]
+position = Vector2(5, -60)
+polygon = PackedVector2Array(-221.5, 55.5, -226.5, 102.5, -174.5, 105.5, -158.5, 99.5, -139.5, 127.5, -90.5, 134.5, -71.5, 153.5, -44.5, 157.5, -12.5, 148.5, 2.5, 148.5, 13.5, 153.5, 33.5, 157.5, 51.5, 152.5, 69.5, 144.5, 105.5, 145.5, 125.5, 161.5, 147.5, 168.5, 171.5, 167.5, 186.5, 162.5, 202.5, 163.5, 225.5, 166.5, 237.5, 156.5, 231.5, 80.5, 210.5, 20.5, 208.5, -27.5, 178.5, -94.5, 133.5, -134.5, 38.5, -132.5, -96.5, -117.5, -178.5, -59.5, -228.5, -14.5)
 
 [node name="CollectibleItem" parent="OnTheGround" instance=ExtResource("22_auh5r")]
 position = Vector2(474, 1058)


### PR DESCRIPTION
Corrected an issue where the player's progression was blocked due to unexpected collisions with certain tree assets.
The update adjusts the bounding boxes and collision meshes for the problematic tree models, ensuring accurate interaction while maintaining their visual appearance.
This fix restores proper player movement through the environment, eliminating the progression-blocking scenario reported by the community.

Fixes #1424

<img width="535" height="585" alt="image" src="https://github.com/user-attachments/assets/b21db79e-e099-4a14-9585-57027cb7a250" />
