### PR TITLE
Implement InkDrinker Level 4 Design

### DIFF
--- a/scenes/quests/lore_quests/quest_003/ink_drinker_levels/ink_combat_round_4.tscn
+++ b/scenes/quests/lore_quests/quest_003/ink_drinker_levels/ink_combat_round_4.tscn
@@ -46,7 +46,7 @@ _data = {
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_oj6a4"]
 size = Vector2(101, 49)
 
-[node name="InkCombatRound4" type="Node2D"]
+[node name="InkCombat" type="Node2D"]
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("1_aj2gl")]
 stream = ExtResource("2_h1kdf")


### PR DESCRIPTION
This PR implements Ink Drinker Level 4 according to the design defined in issue #1026.
The level was added under lore_quests/quest_003 and includes the terrain layout, enemies, interactive objects, and all elements for the combat encounter.

Resolves  #1383 