### PR TITLE
Player: Add defeat() method

### DIFF
--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -223,3 +223,22 @@ func _set_walk_sound_stream(new_value: AudioStream) -> void:
 	if not is_node_ready():
 		await ready
 	_walk_sound.stream = walk_sound_stream
+
+
+## Sets the player's [member mode] to [constant DEFEATED], if it is
+## not already. Reloads the current scene after a short interval.
+## [br][br]
+## If [param falling] is [code]true[/code], scale the player to zero, as if they
+## are falling into the screen as they unravel.
+func defeat(falling: bool = false) -> void:
+	if mode == Player.Mode.DEFEATED:
+		return
+
+	mode = Player.Mode.DEFEATED
+
+	if falling:
+		var tween := create_tween()
+		tween.tween_property(self, "scale", Vector2.ZERO, 2.0)
+
+	await get_tree().create_timer(2.0).timeout
+	SceneSwitcher.reload_with_transition(Transition.Effect.FADE, Transition.Effect.FADE)

--- a/scenes/game_logic/stealth_game_logic.gd
+++ b/scenes/game_logic/stealth_game_logic.gd
@@ -13,6 +13,4 @@ func _ready() -> void:
 
 
 func _on_player_detected(player: Player) -> void:
-	player.mode = Player.Mode.DEFEATED
-	await get_tree().create_timer(2.0).timeout
-	SceneSwitcher.reload_with_transition(Transition.Effect.FADE, Transition.Effect.FADE)
+	player.defeat()

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.gd
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.gd
@@ -141,8 +141,4 @@ func _on_player_capture_area_body_entered(body: Node2D) -> void:
 	state = State.CAUGHT
 
 	var player := body as Player
-	player.mode = Player.Mode.DEFEATED
-	var tween := create_tween()
-	tween.tween_property(player, "scale", Vector2.ZERO, 2.0)
-	await get_tree().create_timer(2.0).timeout
-	SceneSwitcher.reload_with_transition(Transition.Effect.FADE, Transition.Effect.FADE)
+	player.defeat(true)


### PR DESCRIPTION
Player: Add defeat() method

Previously the code to mark the player as defeated, wait a few seconds,
then reload the current scene was duplicated between two kinds of enemy.
In addition, it was not idempotent: if a second guard caught the player
during the 2-second pause, the scene would reload twice.

Add a defeat() method to the player that does nothing if the mode is
already DEFEATED, and otherwise carries out the same set of steps. Call
this in the two relevant places.

It's a bit of a kludge to have the `falling` parameter but I think this
is still an improvement.

Resolves https://github.com/endlessm/threadbare/issues/1334
