### PR TITLE
feat: update input hint labels  (#1…

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -362,7 +362,7 @@ layout_mode = 2
 theme = ExtResource("35_ljovl")
 theme_type_variation = &"HintLabel"
 theme_override_font_sizes/font_size = 25
-text = "Walk"
+text = "Move"
 
 [node name="Repel_hint" type="HBoxContainer" parent="ScreenOverlay/HBoxContainer"]
 layout_mode = 2
@@ -391,7 +391,7 @@ offset_right = 118.0
 offset_bottom = 44.0
 theme = ExtResource("35_ljovl")
 theme_type_variation = &"HintLabel"
-text = "Repel"
+text = "Interact"
 
 [node name="HUD" parent="." instance=ExtResource("27_aj6tp")]
 unique_name_in_owner = true


### PR DESCRIPTION
This pull request addresses issue #1284, which focuses on improving the clarity and consistency of input hints across the Fray’s End world map scene.
**Details**:
-Updated hint label texts in the Fray’s End map:
"Walk" → "Move"
"Repel" → "Interact"
-Ensured all input hints maintain consistent terminology and style.
Fix #1284
 