### PR TITLE
Cinematic: Do not wait for animation finished

### DIFF
--- a/scenes/ui_elements/cinematic/cinematic.gd
+++ b/scenes/ui_elements/cinematic/cinematic.gd
@@ -30,8 +30,6 @@ func _ready() -> void:
 	if not GameState.intro_dialogue_shown:
 		DialogueManager.show_dialogue_balloon(dialogue, "", [self])
 		await DialogueManager.dialogue_ended
-		if animation_player and animation_player.is_playing():
-			await animation_player.animation_finished
 		cinematic_finished.emit()
 		GameState.intro_dialogue_shown = true
 


### PR DESCRIPTION
It seemed a good idea to wait until the animation finishes, but never happens for animations playing in loop (like the intro). And also if really needed, it can be done from the dialogue adding a last line:

do animation_player.animation_finished.

https://github.com/endlessm/threadbare/issues/1470