### PR TITLE
Repositions intro concept art 

### DIFF
--- a/scenes/menus/intro/intro.tscn
+++ b/scenes/menus/intro/intro.tscn
@@ -293,31 +293,86 @@ texture = ExtResource("2_a6oma")
 expand_mode = 3
 stretch_mode = 6
 
-[node name="Sketch01" type="Sprite2D" parent="CanvasLayer/Control"]
+[node name="Sketch01" type="TextureRect" parent="CanvasLayer/Control"]
 visible = false
 material = SubResource("CanvasItemMaterial_mqh0g")
-position = Vector2(1379, 540)
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -715.66205
+offset_top = -715.0
+grow_horizontal = 0
+grow_vertical = 0
 texture = ExtResource("3_gvvib")
+expand_mode = 1
+stretch_mode = 5
 
-[node name="Sketch02" type="Sprite2D" parent="CanvasLayer/Control"]
+[node name="Sketch02" type="TextureRect" parent="CanvasLayer/Control"]
 visible = false
-position = Vector2(1493, 540)
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -570.0
+offset_top = -721.6882
+grow_horizontal = 0
+grow_vertical = 0
 texture = ExtResource("4_gvvib")
+expand_mode = 1
+stretch_mode = 5
 
-[node name="Sketch03" type="Sprite2D" parent="CanvasLayer/Control"]
+[node name="Sketch03" type="TextureRect" parent="CanvasLayer/Control"]
 visible = false
-position = Vector2(1403, 540)
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -686.0
+offset_top = -716.51843
+grow_horizontal = 0
+grow_vertical = 0
 texture = ExtResource("5_mqh0g")
+expand_mode = 1
+stretch_mode = 5
 
-[node name="Sketch04" type="Sprite2D" parent="CanvasLayer/Control"]
+[node name="Sketch04" type="TextureRect" parent="CanvasLayer/Control"]
 visible = false
-position = Vector2(1289, 540)
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -839.4991
+offset_top = -719.0
+grow_horizontal = 0
+grow_vertical = 0
 texture = ExtResource("6_4ymxw")
+expand_mode = 1
+stretch_mode = 5
 
-[node name="Sketch05" type="Sprite2D" parent="CanvasLayer/Control"]
+[node name="Sketch05" type="TextureRect" parent="CanvasLayer/Control"]
 visible = false
-position = Vector2(1217, 451)
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -1121.5078
+offset_top = -720.0
+grow_horizontal = 0
+grow_vertical = 0
 texture = ExtResource("7_5fnp7")
+expand_mode = 1
+stretch_mode = 5
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {


### PR DESCRIPTION
This PR replaces the problematic `Sprite2D` nodes (`Sketch01` through `Sketch05`) with `TextureRect` nodes as @wjt suggested. This approach leverages Godot's UI system to handle scaling and positioning dynamically, making it robust to resolution changes.

https://github.com/user-attachments/assets/d4f5df64-9bcc-4729-83cb-af9b8484938a

The following configuration was applied to each `TextureRect` to ensure the art aligns to the right and scales correctly:

* **Layout / Anchors Preset:** Set to `Bottom Right` to anchor the art to the right edge of the parent `Control` node.
* **Expand Mode:** `Ignore Size`
* **Stretch Mode:** `Keep Aspect Centered`

Closes #1166