### PR TITLE
ci: Cache Git LFS objects

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -32,12 +32,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          lfs: true
           # TODO: can we use --filter to avoid fetching the trees & blobs for
           # all historical commits, while still fetching the commit history &
           # tags?
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Create Git LFS file list
+        run: git lfs ls-files -l |cut -d' ' -f1 |sort >.git/lfs-hashes.txt
+
+      - name: Restore Git LFS object cache
+        uses: actions/cache@v4
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfsdata-v1-${{ hashFiles('.git/lfs-hashes.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-lfsdata-v1-
+            ${{ runner.os }}-lfsdata
+
+      - name: Fetch any needed Git LFS objects and prune extraneous ones
+        run: git lfs fetch --prune
+
+      - name: Check out Git LFS content
+        run: git lfs checkout
 
       - id: changes
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
We clone the repo from scratch on every build. Previously, we fetched all LFS objects for the current commit each time, too.

GitHub has a monthly quota for free LFS bandwidth - we hit it last week.

But the LFS objects don't change at all between most builds that we run. So use GitHub Actions' built-in cache to cache and restore LFS objects. This technique is described here:
https://github.com/actions/checkout/issues/165#issuecomment-2776048200