### PR TITLE
ci: Don't fetch all LFS objects for Flatpak build

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -126,7 +126,7 @@ jobs:
   flatpak:
     name: Build Flatpak
     needs: build
-    if: ${{ inputs.build_flatpak || github.event_name == 'release' || needs.build.outputs.linux-changed == 'true' }}
+    #if: ${{ inputs.build_flatpak || github.event_name == 'release' || needs.build.outputs.linux-changed == 'true' }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
@@ -135,12 +135,16 @@ jobs:
       - uses: actions/checkout@v5
         with:
           lfs: true
+          sparse-checkout: |
+            linux
+
       - name: Download Artifact
         uses: actions/download-artifact@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: pck
           path: build
+
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: threadbare.flatpak

--- a/linux/icon-256.png
+++ b/linux/icon-256.png
@@ -1,1 +1,3 @@
-../assets/first_party/logo/thread-256-tb.png
+version https://git-lfs.github.com/spec/v1
+oid sha256:5eb7f48811ce465c323aeef77497c374751b0f367436e1625e0f951e0763578c
+size 6294

--- a/linux/icon-256.png.license
+++ b/linux/icon-256.png.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: The Threadbare Authors
+SPDX-License-Identifier: CC-BY-SA-4.0


### PR DESCRIPTION
Git LFS. But it doesn't need the other tens of megabytes of assets,
which take time to fetch and also count against our monthly Git LFS
bandwidth quota.

It is possible to tell Git LFS to only check out certain large files,
rather than all LFS objects referenced in the working copy. But there is
an easier way: we can use git's sparse-checkout feature to only check
out the linux/ directory (plus the files in .) for this job. Then Git
LFS will only fetch the objects used in that directory.

To make this work we have to change linux/icon-256.png from a symbolic
link to a copy of the icon from assets, but I think that is a price
worth paying.

I also updated the workflow to run the Flatpak job automatically if the workflow itself changes; and to use the 25.08 flatpak-builder image.