### PR TITLE
Change the introductory dialogue for the Sokoban puzzle.

### DIFF
--- a/scenes/eternal_loom_sokoban/sokoban.dialogue
+++ b/scenes/eternal_loom_sokoban/sokoban.dialogue
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-Oh dear… it looks like a few threads inside the Eternal Loom have come loose!
+Oh dear... it looks like a few threads inside the Eternal Loom have come loose!
 Without them, the fabric of the world might start to unravel — what a mess that would be!
 Your task is to push each bow onto its matching frayed thread to mend the weave.
 Don’t worry if things get tangled — you can always undo your last step or reset the puzzle entirely.


### PR DESCRIPTION
The dialogue now feels friendlier and more expressive, while keeping the explanation of the Sokoban rules and controls.

Fixes https://github.com/endlessm/threadbare/issues/491