### PR TITLE
Change the sequence puzzle object sprite 

### DIFF
--- a/scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn
+++ b/scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn
@@ -15,7 +15,7 @@ script = ExtResource("1_kw7av")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
-scale = Vector2(0.7, 0.7)
+scale = Vector2(1.1, 1.1)
 sprite_frames = ExtResource("2_cltuv")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]


### PR DESCRIPTION
Make the required change to the sequence object in the puzzle and verify that it matches in each scene.
Fixes https://github.com/endlessm/threadbare/issues/679