### PR TITLE
Standardize Ink Drinker root nodes to match file name

### DIFF
--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_1.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_1.tscn
@@ -53,7 +53,7 @@ _data = {
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_lmnu5"]
 size = Vector2(101, 49)
 
-[node name="InkCombat" type="Node2D"]
+[node name="InkCombatRound1" type="Node2D"]
 y_sort_enabled = true
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("3_nlryc")]

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_2.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_2.tscn
@@ -50,7 +50,7 @@ _data = {
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_e81yh"]
 size = Vector2(101, 49)
 
-[node name="InkCombat" type="Node2D"]
+[node name="InkCombatRound2" type="Node2D"]
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("2_wqron")]
 stream = ExtResource("3_0kd4s")

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
@@ -53,7 +53,7 @@ script = ExtResource("9_rww0x")
 type = 1
 metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
-[node name="InkCombat" type="Node2D"]
+[node name="InkCombatRound3" type="Node2D"]
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("2_je2ou")]
 stream = ExtResource("3_je2ou")

--- a/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_4.tscn
+++ b/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_4.tscn
@@ -54,7 +54,7 @@ _data = {
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_oj6a4"]
 size = Vector2(101, 49)
 
-[node name="InkCombat" type="Node2D"]
+[node name="InkCombatRound4" type="Node2D"]
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("1_i2xws")]
 stream = ExtResource("2_86uoi")

--- a/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_6.tscn
+++ b/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_6.tscn
@@ -57,7 +57,7 @@ script = ExtResource("28_ihx08")
 type = 1
 metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
-[node name="InkCombat" type="Node2D"]
+[node name="InkCombatRound6" type="Node2D"]
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("1_7y6db")]
 stream = ExtResource("2_ck7cp")


### PR DESCRIPTION
This PR implements the agreed-upon naming convention for root nodes, ensuring that the main node of every `.tscn` scene matches the file name in PascalCase format.

resolves #1539 