### PR TITLE
Fix player can be moved after completing Sokoban puzzle

### DIFF
--- a/scenes/eternal_loom_sokoban/components/system/rules/rule_engine.gd
+++ b/scenes/eternal_loom_sokoban/components/system/rules/rule_engine.gd
@@ -178,7 +178,7 @@ func _check_goal() -> void:
 
 	if result:
 		goals_reached.emit()
-
+		directional_input.enabled = false
 		if next_scene:
 			SceneSwitcher.change_to_file_with_transition(next_scene)
 


### PR DESCRIPTION
In Sokoban Puzzles, fix being able to move the player during the small time of transition to the next scene.

Fixes: #1185 