### PR TITLE
Switch background music when ink combat completed

### DIFF
--- a/scenes/game_elements/props/background_music/components/background_music.gd
+++ b/scenes/game_elements/props/background_music/components/background_music.gd
@@ -69,3 +69,18 @@ func _exit_tree() -> void:
 	## in the editor, the music will keep playing.
 	if Engine.is_editor_hint():
 		_stop()
+
+
+## If [member stream] is an [AudioStreamInteractive], and music is playing,
+## switch to [param clip_name].
+func switch_to_clip(clip_name: StringName) -> void:
+	if not audio_stream_player.is_playing():
+		push_warning("Not currently playing")
+		return
+
+	if audio_stream_player.stream is not AudioStreamInteractive:
+		push_warning("Switching clips is only supported with AudioStreamInteractive")
+		return
+
+	var playback := audio_stream_player.get_stream_playback() as AudioStreamPlaybackInteractive
+	playback.switch_to_clip_by_name(clip_name)

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres
@@ -1,0 +1,21 @@
+[gd_resource type="AudioStreamInteractive" load_steps=3 format=3 uid="uid://dkgtyb0x1i0m2"]
+
+[ext_resource type="AudioStream" uid="uid://dgwihwibc8ah6" path="res://assets/first_party/music/Threadbare_Combat.ogg" id="1_okerr"]
+[ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="2_7ytc0"]
+
+[resource]
+clip_count = 2
+clip_0/name = &"combat"
+clip_0/stream = ExtResource("1_okerr")
+clip_0/auto_advance = 0
+clip_1/name = &"cozy"
+clip_1/stream = ExtResource("2_7ytc0")
+clip_1/auto_advance = 0
+_transitions = {
+Vector2i(0, 1): {
+"fade_beats": 2.0,
+"fade_mode": 3,
+"from_time": 0,
+"to_time": 1
+}
+}

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_1.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_1.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=31 format=4 uid="uid://c764br4tplkb2"]
 
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="1_33khf"]
+[ext_resource type="AudioStream" uid="uid://dkgtyb0x1i0m2" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres" id="2_3npeg"]
 [ext_resource type="Resource" uid="uid://cmhcuoms2kh1a" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/dialogues/ink_well.dialogue" id="2_o41k0"]
 [ext_resource type="Script" uid="uid://cp54mgi54nywo" path="res://scenes/game_logic/fill_game_logic.gd" id="3_0b2ty"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="3_nlryc"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="3_v7ikp"]
-[ext_resource type="AudioStream" uid="uid://dgwihwibc8ah6" path="res://assets/first_party/music/Threadbare_Combat.ogg" id="4_hlahk"]
 [ext_resource type="PackedScene" uid="uid://lgu7aeqa7o3r" path="res://scenes/game_elements/props/door/door.tscn" id="5_bxnsu"]
 [ext_resource type="PackedScene" uid="uid://b82nsrh332syj" path="res://scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn" id="5_h0i4r"]
 [ext_resource type="Script" uid="uid://hqdquinbimce" path="res://scenes/game_elements/props/teleporter/teleporter/components/teleporter.gd" id="5_lmnu5"]
@@ -57,7 +57,7 @@ size = Vector2(101, 49)
 y_sort_enabled = true
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("3_nlryc")]
-stream = ExtResource("4_hlahk")
+stream = ExtResource("2_3npeg")
 
 [node name="Cinematic" type="Node2D" parent="."]
 script = ExtResource("1_33khf")

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_2.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_2.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=28 format=4 uid="uid://cgemeabsewy1f"]
 
+[ext_resource type="AudioStream" uid="uid://dkgtyb0x1i0m2" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres" id="2_4q3i8"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="2_wqron"]
-[ext_resource type="AudioStream" uid="uid://dgwihwibc8ah6" path="res://assets/first_party/music/Threadbare_Combat.ogg" id="3_0kd4s"]
 [ext_resource type="Script" uid="uid://cp54mgi54nywo" path="res://scenes/game_logic/fill_game_logic.gd" id="3_wqron"]
 [ext_resource type="TileSet" uid="uid://oynx002hv8tl" path="res://tiles/water.tres" id="4_4q3i8"]
 [ext_resource type="PackedScene" uid="uid://crqjcicx0vdu" path="res://scenes/game_elements/props/decoration/bush/bush.tscn" id="4_4r6cg"]
@@ -53,7 +53,7 @@ size = Vector2(101, 49)
 [node name="InkCombatRound2" type="Node2D"]
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("2_wqron")]
-stream = ExtResource("3_0kd4s")
+stream = ExtResource("2_4q3i8")
 
 [node name="FillGameLogic" type="Node" parent="."]
 script = ExtResource("3_wqron")

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
@@ -2,8 +2,8 @@
 
 [ext_resource type="Resource" uid="uid://cmhcuoms2kh1a" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/dialogues/ink_well.dialogue" id="2_fgs83"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="2_je2ou"]
+[ext_resource type="AudioStream" uid="uid://dkgtyb0x1i0m2" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres" id="2_t7m4v"]
 [ext_resource type="Script" uid="uid://cp54mgi54nywo" path="res://scenes/game_logic/fill_game_logic.gd" id="3_4iw8v"]
-[ext_resource type="AudioStream" uid="uid://dgwihwibc8ah6" path="res://assets/first_party/music/Threadbare_Combat.ogg" id="3_je2ou"]
 [ext_resource type="PackedScene" uid="uid://lgu7aeqa7o3r" path="res://scenes/game_elements/props/door/door.tscn" id="4_fgs83"]
 [ext_resource type="TileSet" uid="uid://oynx002hv8tl" path="res://tiles/water.tres" id="4_t7m4v"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="5_k5uk8"]
@@ -56,7 +56,7 @@ metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 [node name="InkCombatRound3" type="Node2D"]
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("2_je2ou")]
-stream = ExtResource("3_je2ou")
+stream = ExtResource("2_t7m4v")
 
 [node name="FillGameLogic" type="Node" parent="."]
 script = ExtResource("3_4iw8v")
@@ -196,4 +196,5 @@ limit_bottom = 2048
 position_smoothing_enabled = true
 editor_draw_limits = true
 
+[connection signal="goal_reached" from="FillGameLogic" to="BackgroundMusic" method="switch_to_clip" binds= [&"cozy"]]
 [connection signal="goal_reached" from="FillGameLogic" to="FillGameLogic/LevelCompletedAnimation" method="play" binds= ["goal_completed"]]

--- a/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_4.tscn
+++ b/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_4.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=32 format=4 uid="uid://dgt78lsdstjrl"]
 
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="1_i2xws"]
-[ext_resource type="AudioStream" uid="uid://dgwihwibc8ah6" path="res://assets/first_party/music/Threadbare_Combat.ogg" id="2_86uoi"]
+[ext_resource type="AudioStream" uid="uid://dkgtyb0x1i0m2" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres" id="2_ah6ns"]
 [ext_resource type="Script" uid="uid://cp54mgi54nywo" path="res://scenes/game_logic/fill_game_logic.gd" id="3_ajc71"]
 [ext_resource type="TileSet" uid="uid://oynx002hv8tl" path="res://tiles/water.tres" id="4_gteq2"]
 [ext_resource type="TileSet" uid="uid://yducoif83sia" path="res://tiles/foam.tres" id="5_h8ejn"]
@@ -57,7 +57,7 @@ size = Vector2(101, 49)
 [node name="InkCombatRound4" type="Node2D"]
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("1_i2xws")]
-stream = ExtResource("2_86uoi")
+stream = ExtResource("2_ah6ns")
 
 [node name="FillGameLogic" type="Node" parent="."]
 script = ExtResource("3_ajc71")

--- a/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_5.tscn
+++ b/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_5.tscn
@@ -2,8 +2,8 @@
 
 [ext_resource type="TileSet" uid="uid://oynx002hv8tl" path="res://tiles/water.tres" id="1_6g6ab"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="1_u63rw"]
-[ext_resource type="AudioStream" uid="uid://dgwihwibc8ah6" path="res://assets/first_party/music/Threadbare_Combat.ogg" id="2_4jp3l"]
 [ext_resource type="TileSet" uid="uid://yducoif83sia" path="res://tiles/foam.tres" id="2_7t80u"]
+[ext_resource type="AudioStream" uid="uid://dkgtyb0x1i0m2" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres" id="2_djbws"]
 [ext_resource type="Script" uid="uid://cp54mgi54nywo" path="res://scenes/game_logic/fill_game_logic.gd" id="3_4cqf2"]
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="3_4wnvp"]
 [ext_resource type="TileSet" uid="uid://dfp36ffpanjq2" path="res://tiles/elevation.tres" id="4_7t80u"]
@@ -57,7 +57,7 @@ size = Vector2(101, 49)
 [node name="InkCombatRound5" type="Node2D"]
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("1_u63rw")]
-stream = ExtResource("2_4jp3l")
+stream = ExtResource("2_djbws")
 
 [node name="FillGameLogic" type="Node" parent="."]
 script = ExtResource("3_4cqf2")

--- a/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_6.tscn
+++ b/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_6.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="1_7y6db"]
 [ext_resource type="TileSet" uid="uid://oynx002hv8tl" path="res://tiles/water.tres" id="1_16xyg"]
 [ext_resource type="TileSet" uid="uid://yducoif83sia" path="res://tiles/foam.tres" id="1_rmat6"]
-[ext_resource type="AudioStream" uid="uid://dgwihwibc8ah6" path="res://assets/first_party/music/Threadbare_Combat.ogg" id="2_ck7cp"]
+[ext_resource type="AudioStream" uid="uid://dkgtyb0x1i0m2" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres" id="2_1a5yo"]
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="2_g1en3"]
 [ext_resource type="TileSet" uid="uid://dfp36ffpanjq2" path="res://tiles/elevation.tres" id="2_s2t2y"]
 [ext_resource type="Script" uid="uid://cp54mgi54nywo" path="res://scenes/game_logic/fill_game_logic.gd" id="3_1a5yo"]
@@ -60,7 +60,7 @@ metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 [node name="InkCombatRound6" type="Node2D"]
 
 [node name="BackgroundMusic" parent="." instance=ExtResource("1_7y6db")]
-stream = ExtResource("2_ck7cp")
+stream = ExtResource("2_1a5yo")
 
 [node name="FillGameLogic" type="Node" parent="."]
 script = ExtResource("3_1a5yo")
@@ -253,4 +253,5 @@ editor_draw_limits = true
 
 [node name="HUD" parent="." instance=ExtResource("27_7y6db")]
 
+[connection signal="goal_reached" from="FillGameLogic" to="BackgroundMusic" method="switch_to_clip" binds= [&"cozy"]]
 [connection signal="goal_reached" from="FillGameLogic" to="FillGameLogic/LevelCompletedAnimation" method="play" binds= ["goal_completed"]]


### PR DESCRIPTION
Previously, the intense combat music would continue to play even after
the final round had been completed and the collectible revealed.

Define an AudioStreamInteractive with 2 clips, the combat music and the
bed used in Fray's End. Set this as the background music stream on all 6
ink combat scenes, rather than setting the combat music directly: this
ensures that the music doesn't restart at the beginning between rounds 1
and 2 of combat.

Then, add a method to background_music.gd to switch to a different clip.
Connect to the goal_reached signal and, in addition to playing the
animation that reveals the collectible, also switch the music to the
the "cozy" clip.

This doesn't work quite right when switching between
quest_003/2_ink_drinker_levels/ink_combat_round_6.tscn and
frays_end.tscn. frays_end.tscn uses the less-dramatic bed music directly;
ink_combat_round_6.tscn uses a AudioStreamInteractive. background_music.gd
treats these as different streams and so restarts the music when switching to
frays_end.

But it sounds OK and I think the trade-off is worth it. I think this could be
improved in future by going further down this path: put *all* the background
music into an AudioStreamInteractive, with appropriate fades; or even have our
background music logic build an AudioStreamInteractive dynamically.

