### PR TITLE
Eternal Loom: Fix crash after jumping into the middle of a quest

### DIFF
--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
@@ -31,8 +31,17 @@ func _ready() -> void:
 		if Transitions.is_running():
 			await Transitions.finished
 
-		var elder := _find_elder(GameState.current_quest)
-		await elder.congratulate_player()
+		var elder: Elder
+		if GameState.current_quest:
+			elder = _find_elder(GameState.current_quest)
+		elif elders:
+			# If the game was started from a specific scene (in the editor or
+			# via the #fragment in the web build), rather than by picking a
+			# quest from an elder, GameState.current_quest will be null.
+			# Pick any elder.
+			elder = elders[0]
+		if elder:
+			await elder.congratulate_player()
 
 		GameState.set_incorporating_threads(false)
 		GameState.mark_quest_completed()

--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -65,6 +65,7 @@ func _restore_from_hash() -> void:
 				# for testing or debugging.
 				GameState.persist_progress = false
 				GameState.clear()
+				# TODO: Try to look up the quest that the scene corresponds to
 
 			# In theory, we might like to avoid switching scene if the specified
 			# scene is the default scene. In practice, that will not happen, and


### PR DESCRIPTION
In the editor, I used "Play Scene" on
res://scenes/quests/lore_quests/quest_003/1_stealth_sequence_combo/stealth_sequence_combo.tscn,
then proceeded all the way through the Sokoban puzzle and back to Fray's
End. On reaching Fray's End the game crashed:

    E 0:11:53:679   EternalLoom._find_elder: Invalid access to property or key 'resource_path' on a base object of type 'Nil'.
      <GDScript Source>eternal_loom.gd:43 @ EternalLoom._find_elder()
      <Stack Trace> eternal_loom.gd:43 @ _find_elder()
                    eternal_loom.gd:34 @ _ready()
                    transitions.gd:95 @ do_transition()
                    transitions.gd:81 @ _introduce_scene()
                    transitions.gd:63 @ _do_tween()

The issue is that when you jump into the game at a particular scene
(either in the editor, or via the URL hash on the web),
GameState.current_quest is null. But because I had collected 3 threads,
I was able to enter the loom anyway (it doesn't check current_quest).

Then when we get back to Fray's End, we try to find which Elder issued
us with the current quest; which crashes if GameState.current_quest is
null.

Handle this case: if current_quest is null, just pick the first elder.
If there are no elders (shouldn't happen), don't show the dialogue.
