### PR TITLE
Directional input hint: Fix inexisting action name

### DIFF
--- a/scenes/game_elements/props/hint/input_key/directional_input_hint.gd
+++ b/scenes/game_elements/props/hint/input_key/directional_input_hint.gd
@@ -74,7 +74,7 @@ func _physics_process(_delta: float) -> void:
 			visible = false
 
 	# Visual feedback when the actual action (e.g., move_up) is pressed
-	if Input.is_action_pressed(action_name):
+	if action_name != "move_unpressed" and Input.is_action_pressed(action_name):
 		# subtle pressed look
 		modulate = Color(0.994, 0.99, 0.992, 1.0)
 	else:


### PR DESCRIPTION
The string "move_unpressed" is used by this script, but is not an actual input action of the game. So checking for
Input.is_action_pressed("move_unpressed") produces an error in every physics process step.

Fix https://github.com/endlessm/threadbare/issues/1584