### PR TITLE
Solve musician sprite in music puzzle

### DIFF
--- a/scenes/game_elements/characters/components/assets/musician_idle.png
+++ b/scenes/game_elements/characters/components/assets/musician_idle.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6abe0349bb7abef16c2b63c0e54a72059fe25df4247e817703b772fb0cd7d340
-size 6305
+oid sha256:ef8e74d7467bc1bb9ac18c06e8d8cae61cdfaf54af81d1e8a0ac37585313c895
+size 6954

--- a/scenes/game_elements/characters/components/assets/musician_playing.png
+++ b/scenes/game_elements/characters/components/assets/musician_playing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd73db8d3fa6b7c1c2dee654498553a002b1080c040e064afd35a1ed66e3ab0a
-size 9452
+oid sha256:900b029140e1cee0ed2288ef04359c5e07007b711b0e32317a29450c130b4607
+size 10427

--- a/scenes/game_elements/characters/components/sprite_frames/musician.tres
+++ b/scenes/game_elements/characters/components/sprite_frames/musician.tres
@@ -2,36 +2,36 @@
 
 [ext_resource type="Texture2D" uid="uid://d0dej4i54rq5d" path="res://scenes/game_elements/characters/components/assets/musician_idle.png" id="1_t81g1"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_dcatg"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_jg2qk"]
 atlas = ExtResource("1_t81g1")
-region = Rect2(0, 0, 128, 128)
+region = Rect2(0, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_wkraa"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_xlx7c"]
 atlas = ExtResource("1_t81g1")
-region = Rect2(128, 0, 128, 128)
+region = Rect2(192, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_a5jv3"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_vsd8u"]
 atlas = ExtResource("1_t81g1")
-region = Rect2(256, 0, 128, 128)
+region = Rect2(384, 0, 192, 192)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_suc5d"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_7p71y"]
 atlas = ExtResource("1_t81g1")
-region = Rect2(384, 0, 128, 128)
+region = Rect2(576, 0, 192, 192)
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_dcatg")
+"texture": SubResource("AtlasTexture_jg2qk")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_wkraa")
+"texture": SubResource("AtlasTexture_xlx7c")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_a5jv3")
+"texture": SubResource("AtlasTexture_vsd8u")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_suc5d")
+"texture": SubResource("AtlasTexture_7p71y")
 }],
 "loop": true,
 "name": &"idle",


### PR DESCRIPTION
I found a solution without affecting the main branch, because that would affect other Sequence Puzzles. The Threadbare sprites should be in a 192x192 aspect ratio, as shown in the visual guide, and centered. This way, it's best to center the musician to avoid conflicts with other branches. This would be reflected in the scene. 
<img width="737" height="695" alt="image" src="https://github.com/user-attachments/assets/75bab5c9-4c5a-45e5-8d9f-e1bafee18e3d" />
Fixes: #1590 