### PR TITLE
Aligned move hint to bottom of viewport in Fray's End

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -357,6 +357,7 @@ grow_vertical = 0
 
 [node name="MovementInputHints" parent="ScreenOverlay/HBoxContainer" instance=ExtResource("28_lftgk")]
 layout_mode = 2
+size_flags_vertical = 8
 
 [node name="Label" type="Label" parent="ScreenOverlay/HBoxContainer/MovementInputHints"]
 layout_mode = 2
@@ -367,6 +368,7 @@ text = "Move"
 
 [node name="Repel_hint" type="HBoxContainer" parent="ScreenOverlay/HBoxContainer"]
 layout_mode = 2
+size_flags_vertical = 8
 
 [node name="InteractionInputHints" type="CenterContainer" parent="ScreenOverlay/HBoxContainer/Repel_hint"]
 layout_mode = 2


### PR DESCRIPTION
Fixes #1479 

Quick fix by setting movement and interaction hints to shrink_end.
This aligns the hint containers to the bottom of their parent containers instead of expanding to fill available space.

<img width="585" height="536" alt="image" src="https://github.com/user-attachments/assets/c29b88be-966b-4702-8ede-b9b0685fe422" />
