### PR TITLE
cat: Don't block player movement while miaowing

### DIFF
--- a/scenes/game_elements/characters/npcs/cat/cat.tscn
+++ b/scenes/game_elements/characters/npcs/cat/cat.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://cr65lmm5b0ueo"]
+[gd_scene load_steps=8 format=3 uid="uid://cr65lmm5b0ueo"]
 
 [ext_resource type="SpriteFrames" uid="uid://caou2u7vffhei" path="res://scenes/game_elements/characters/npcs/cat/components/cat.tres" id="3_qosq0"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/components/interact_area.gd" id="4_8kxh7"]
+[ext_resource type="Script" uid="uid://djeshbrs3vwnb" path="res://scenes/game_elements/characters/npcs/cat/components/pet_interaction.gd" id="4_t04tf"]
 [ext_resource type="AudioStream" uid="uid://di2b2rgca1udv" path="res://scenes/game_elements/characters/npcs/cat/components/412017__skymary__cat-meow-short.wav" id="5_t04tf"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_3vyb7"]
@@ -41,9 +42,11 @@ position = Vector2(5, -28)
 shape = SubResource("RectangleShape2D_t04tf")
 debug_color = Color(0.6290859, 0.52632225, 0.15803415, 0.41960785)
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
+[node name="PetInteraction" type="Node" parent="." node_paths=PackedStringArray("interact_area", "miaow_player")]
+script = ExtResource("4_t04tf")
+interact_area = NodePath("../InteractArea")
+miaow_player = NodePath("AudioStreamPlayer2D")
+
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="PetInteraction"]
 stream = SubResource("AudioStreamRandomizer_8kxh7")
 bus = &"SFX"
-
-[connection signal="interaction_started" from="InteractArea" to="AudioStreamPlayer2D" method="play" unbinds=2]
-[connection signal="finished" from="AudioStreamPlayer2D" to="InteractArea" method="end_interaction"]

--- a/scenes/game_elements/characters/npcs/cat/components/pet_interaction.gd
+++ b/scenes/game_elements/characters/npcs/cat/components/pet_interaction.gd
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Node
+
+@export var interact_area: InteractArea
+@export var miaow_player: AudioStreamPlayer2D
+
+
+func _ready() -> void:
+	interact_area.interaction_started.connect(_on_interact_area_interaction_started)
+
+
+func _on_interact_area_interaction_started(_player: Player, _from_right: bool) -> void:
+	interact_area.end_interaction()
+	interact_area.disabled = true
+	miaow_player.play()
+	await miaow_player.finished
+	interact_area.disabled = false

--- a/scenes/game_elements/characters/npcs/cat/components/pet_interaction.gd.uid
+++ b/scenes/game_elements/characters/npcs/cat/components/pet_interaction.gd.uid
@@ -1,0 +1,1 @@
+uid://djeshbrs3vwnb


### PR DESCRIPTION
Previously, when you interacted with the cat, you had to wait for the miaow to finish before you could move again.

Instead, mark the interaction as completed immediately, but disable further interactions with the cat until it has finished miaowing.

Also remove the npc.gd script from the cat's root node: none of that functionality is actually used.