### PR TITLE
Add Champ Intro/Outro Dialogue

### DIFF
--- a/scenes/quests/story_quests/champ/0_intro/intro_components/champ_intro.dialogue
+++ b/scenes/quests/story_quests/champ/0_intro/intro_components/champ_intro.dialogue
@@ -4,11 +4,11 @@
 ~ start
 do animation_player.play(&"walk_on")
 do animation_player.animation_finished
-Welcome to the StoryQuest template, where you'll learn how to mod elements of each scene and create your own StoryQuest! Let's start with the intro.
-In the Godot FileSystem, find the intro folder and double-click on the intro dialogue file to edit the text.
-Press enter to add a new line. Each line becomes a new dialogue box in-game.
-Select Cinematic node; drag your StoryQuest dialogue to the "Dialogue" field in the Inspector.
-Set the next scene using the "Next Scene" field in the Inspector.
+Evan has always been fascinated by elusive creatures known only by legends.
+He appreciates that there are many versions of how big they are, how sinister or perhaps friendly, and what they look like. 
+No matter what, each account of a brave adventurer's journey offers insight into their creativity and imagination. 
+He's heard many tales of a green, scaly, lake monster who swims the waters of Lake Champlain in Vermont. Champ.
+While Evan can roughly picture Champ in his mind, he can't help but feel the pull of Lake Champlain and the desire to confirm his theories...
 do animation_player.play(&"walk_off")
-Explore other elements to mod, like the placeholder image, tile map, and animation options for this scene!
+He can't resist! He finds his old hiking boots and decides that first thing in the morning, he will set out on a quest to find Champ.
 => END

--- a/scenes/quests/story_quests/champ/4_outro/outro_components/champ_outro.dialogue
+++ b/scenes/quests/story_quests/champ/4_outro/outro_components/champ_outro.dialogue
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-You've made it to the closing scene!
-This is where you will tie up the loose ends of your story.
-Let's go back to Fray's End so you can return these threads to the Eternal Loom...
+Evan couldn't believe it, but there was Champ! Swimming lazily about 30 yards offshore. 
+Regretting that he forgot his camera, Evan takes a moment to capture a mental picture of the scene before him.
+The beauty of the lake, the mountainous landscape behind it, and Champ slipping above and below the surface of the water.
+Satisfied with his discovery, he heads back home to work on a sketch and the story of how he found the lake monster of Lake Champlain.
 => END


### PR DESCRIPTION
Adding the motivations behind Evan's fascination with legendary creatures, and how exciting it was to finally lay eyes on Champ! The missing asset from the intro, and the gray sprite for Champ in the outro represent assets that the learners can modify/replace for their work.

Game Design:
Narrative & Storytelling by @felixwalberg