### PR TITLE
Update quest images

### DIFF
--- a/scenes/menus/storybook/components/storybook_page.tscn
+++ b/scenes/menus/storybook/components/storybook_page.tscn
@@ -248,7 +248,7 @@ grow_vertical = 2
 size_flags_horizontal = 3
 theme = SubResource("Theme_rf3dg")
 theme_override_constants/margin_left = 0
-theme_override_constants/margin_top = 0
+theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 0
 theme_override_constants/margin_bottom = 0
 script = ExtResource("1_jl23h")
@@ -304,6 +304,7 @@ autowrap_mode = 2
 [node name="VBoxContainer2" type="VBoxContainer" parent="HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_constants/separation = 15
 
 [node name="ScrollContainer" type="ScrollContainer" parent="HBoxContainer/VBoxContainer2"]
 custom_minimum_size = Vector2(360, 430)
@@ -324,7 +325,7 @@ autowrap_mode = 3
 [node name="PlayButton" type="Button" parent="HBoxContainer/VBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_vertical = 8
+size_flags_vertical = 4
 focus_neighbor_top = NodePath(".")
 focus_neighbor_bottom = NodePath(".")
 focus_previous = NodePath("../../../LeftPage/VBoxContainer/BackButton")

--- a/scenes/quests/lore_quests/quest_001/Musician.png
+++ b/scenes/quests/lore_quests/quest_001/Musician.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6a5328d14bf3ed1d85a502fe5fd0a58a6e201171fb1c258861d7e26846cd8c7
-size 1338018
+oid sha256:b6225c69dd90ddf094acf78fad99325a0ca18e53aceda753150fe16480b76caa
+size 390487

--- a/scenes/quests/lore_quests/quest_002/Void.png
+++ b/scenes/quests/lore_quests/quest_002/Void.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94699a433904180a688619d6e7edf520e01a7fbfffc37a7c1a5abc8f1c1ceef4
-size 1718800
+oid sha256:a07b77e897e218cc923eb7ba137582f6e6440b9d2b4b09bd971dc7651cc66dd0
+size 625897


### PR DESCRIPTION
I have re-drawn the sketches for **The Musicians Quest** and **The Void** storybook.  
Previously, the images exceeded 720p quality, which caused excessive compression and loss of detail.  

- **The Void** now features a clearer, more comprehensible image that better matches the level.  
- The **layout’s top margin** has been slightly adjusted, as it previously appeared too close to the book’s edges.
<img width="730" height="799" alt="image" src="https://github.com/user-attachments/assets/2555e565-da54-47f4-ae9b-e110cfaa6b18" />
<img width="619" height="760" alt="image" src="https://github.com/user-attachments/assets/5a96a88a-3144-4fb1-afbb-29e072077ba5" />
