### PR TITLE
Stealth: Fix size of input hint

### DIFF
--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -985,8 +985,8 @@ debug_color = Color(0, 0, 0, 0.42)
 anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
-offset_top = -100.0
-offset_right = 140.0
+offset_top = -64.0
+offset_right = 104.0
 grow_vertical = 0
 
 [node name="HUD" parent="." instance=ExtResource("10_idy4y")]


### PR DESCRIPTION
Stealth: Fix size of input hint

Previously the offsets were set strangely, causing the icons to be
squashed.

I cleared and reset the anchoring, and it fixed the issue. This is the
resulting diff.
