### PR TITLE
Music puzzle: Don't scale musician

### DIFF
--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1371,7 +1371,6 @@ editor_draw_limits = true
 
 [node name="SequencePuzzleAssistant" parent="OnTheGround" node_paths=PackedStringArray("puzzle") instance=ExtResource("20_jdge0")]
 position = Vector2(888, 865)
-scale = Vector2(1.00892, 0.871497)
 puzzle = NodePath("../SequencePuzzle")
 dialogue = ExtResource("6_l4i5r")
 look_at_side = 0


### PR DESCRIPTION
The musician sprite was scaled to this funny aspect ratio in commit
9d3368641bf289f2b4716d86dbc021dab4cded92. It makes the animation look really janky.

Eliminate the scale, making the musician 14% taller.
