### PR TITLE
credits: Fix reference to keyboard_arrows_none.png

### DIFF
--- a/scenes/menus/title/components/credits.tscn
+++ b/scenes/menus/title/components/credits.tscn
@@ -11,7 +11,7 @@
 [ext_resource type="Texture2D" uid="uid://b400qoqe8k15f" path="res://scenes/menus/title/components/logos/godot.png" id="8_ytlm2"]
 [ext_resource type="Texture2D" uid="uid://c0exirlcfw8ds" path="res://scenes/menus/title/components/logos/fannypack_logo.png" id="10_rcvat"]
 [ext_resource type="Texture2D" uid="uid://u8rdutan7bln" path="res://scenes/menus/title/components/logos/Endless Access Horizontal.png" id="12_3srqy"]
-[ext_resource type="Texture2D" uid="uid://cexenripopr1m" path="res://assets/third_party/inputs/kenney_input-prompts_1.4/Keyboard & Mouse/Default/keyboard_arrows_none.png" id="19_m3so8"]
+[ext_resource type="Texture2D" uid="uid://bc8ffgelnq2nn" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_arrows_none.tres" id="19_m3so8"]
 [ext_resource type="Script" uid="uid://bcx7jadxu27en" path="res://scenes/game_elements/props/hint/input_key/directional_input_hint.gd" id="20_5ojsv"]
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_3srqy"]


### PR DESCRIPTION
The individual input hint assets were removed in commit
745893a32588d42b34294fb9b51e4f7a494c8891, which was developed in parallel with
the scrolling credits scene.

    WARNING: res://scenes/menus/title/components/credits.tscn:14 - ext_resource,
             invalid UID: uid://cexenripopr1m - using text path instead:
             res://assets/third_party/inputs/kenney_input-prompts_1.4/Keyboard & Mouse/Default/keyboard_arrows_none.png
         at: load (scene/resources/resource_format_text.cpp:444)
    ERROR: Failed loading resource:
           res://assets/third_party/inputs/kenney_input-prompts_1.4/Keyboard & Mouse/Default/keyboard_arrows_none.png.
       at: _load (core/io/resource_loader.cpp:343)

Replace the dangling reference to that individual asset with the replacement
AtlasTexture resource.
