### PR TITLE
Hide mouse pointer after no movement is registered

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -33,6 +33,7 @@ CameraShake="*res://scenes/globals/camera_shaker/camera_shake.tscn"
 InputHelper="*res://addons/input_helper/input_helper.gd"
 AspectRatioDebugger="*res://scenes/globals/aspect_ratio_debugger/aspect_ratio_debugger.tscn"
 InputGlobal="*res://scenes/game_elements/props/hint/input_key/InputHintManager.gd"
+MouseManager="*res://scenes/globals/mouse_manager/mouse_manager.tscn"
 
 [debug]
 

--- a/scenes/globals/mouse_manager/mouse_manager.gd
+++ b/scenes/globals/mouse_manager/mouse_manager.gd
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Node
+
+@onready var hide_timer: Timer = %HideTimer
+
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventMouseMotion:
+		Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
+		hide_timer.start(3)
+
+
+func _on_hide_timer_timeout() -> void:
+	Input.mouse_mode = Input.MOUSE_MODE_HIDDEN

--- a/scenes/globals/mouse_manager/mouse_manager.gd.uid
+++ b/scenes/globals/mouse_manager/mouse_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://rw3yh3185lpn

--- a/scenes/globals/mouse_manager/mouse_manager.tscn
+++ b/scenes/globals/mouse_manager/mouse_manager.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=3 uid="uid://cnihu6fwcogid"]
+
+[ext_resource type="Script" uid="uid://rw3yh3185lpn" path="res://scenes/globals/mouse_manager/mouse_manager.gd" id="1_u8i10"]
+
+[node name="MouseManager" type="Node"]
+script = ExtResource("1_u8i10")
+
+[node name="HideTimer" type="Timer" parent="."]
+unique_name_in_owner = true
+wait_time = 3.0
+one_shot = true
+autostart = true
+
+[connection signal="timeout" from="HideTimer" to="." method="_on_hide_timer_timeout"]


### PR DESCRIPTION
Add a new global that, whenever the mouse is moved, restarts a 3 seconds one-shot timer. Upon timeout, hide the mouse.

This makes the mouse visible only when using it. Assuming that people is used to move the mouse in order to find its position on screen.

Note: This is not implementing the feature proposal in https://github.com/endlessm/threadbare/issues/807 . So is up for discussion. I think is better for now to hide the mouse most of the time, after seeing many gameplays yesterday in which they are playing dark levels with the bright mouse pointer in the middle of the screen.

Helps https://github.com/endlessm/threadbare/issues/807