### PR TITLE
shjourney: Remove stray instance of directional_input_hint.gd

### DIFF
--- a/scenes/quests/story_quests/shjourney/4_Laberinto/Laberinto.tscn
+++ b/scenes/quests/story_quests/shjourney/4_Laberinto/Laberinto.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=90 format=4 uid="uid://dyx8toyemw2vx"]
+[gd_scene load_steps=89 format=4 uid="uid://dyx8toyemw2vx"]
 
 [ext_resource type="Script" uid="uid://bb15xji6f5syf" path="res://scenes/quests/story_quests/shjourney/4_Laberinto/ScripBase.gd" id="1_f2sr3"]
 [ext_resource type="Script" uid="uid://dnp0tjloec2d7" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_wjmvn"]
@@ -43,7 +43,6 @@
 [ext_resource type="AudioStream" uid="uid://p2k8tnga0rfd" path="res://scenes/quests/story_quests/shjourney/2_shjourney_intro/template_intro_components/EffectSounds/keys_dropped.wav" id="37_37sn7"]
 [ext_resource type="Texture2D" uid="uid://b8yn4tog2cnaw" path="res://scenes/quests/story_quests/shjourney/4_Laberinto/personajes/estructuras(decoracion)/llave 1.png" id="38_3ri7t"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="40_u1x3w"]
-[ext_resource type="Script" uid="uid://bcx7jadxu27en" path="res://scenes/game_elements/props/hint/input_key/directional_input_hint.gd" id="41_3ri7t"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_sdlc6"]
 texture = ExtResource("5_bw2w6")
@@ -2462,7 +2461,6 @@ offset_left = -142.0
 offset_top = 181.0
 offset_right = -19.0
 offset_bottom = 281.0
-script = ExtResource("41_3ri7t")
 
 [node name="Label" type="Label" parent="CamaraPuerta/InteractInput"]
 layout_mode = 0


### PR DESCRIPTION
shjourney: Remove stray instance of directional_input_hint.gd

This scene has a TextureRect with directional_input_hint.gd attached.
Its name is InteractInput which might lead one to suspect that the
script attached used to be different. And indeed before
commit 9d03c40de4863e665f3a07e526c545faa3d8530c and
commit 783701b70678719f77ae2b15415a459a5b06ceb6 the attached script was
input_key.gd which was as follows:

    # SPDX-FileCopyrightText: The Threadbare Authors
    # SPDX-License-Identifier: MPL-2.0
    extends TextureRect

    @export var action_name: StringName

    func _physics_process(_delta: float) -> void:
        if Input.is_action_pressed(action_name):
            modulate = Color.GRAY
        else:
            modulate = Color.WHITE

This relied on the scene designer setting the correct texture for the
corresponding button. The action_name property was set to "running" in the
scene.

Over the course of those two commits, this simple script morphed into the
directional_input_hint.gd script that we have today, and the action_name was
unset. As a result, when you run this scene, the following is printed on each
physics frame:

    ERROR: The InputMap action "" doesn't exist.
       at: is_action_pressed (core/input/input.cpp:376)
       GDScript backtrace (most recent call first):
           [0] _physics_process (res://scenes/game_elements/props/hint/input_key/directional_input_hint.gd:77)

However, having looked through the Git commit history for the original fork, the
TextureRect node that the script is attached to has never had a texture assigned
to it; so it has never had any visible effect. Its functional purpose is to be
the parent to a Label that reads "Puerta desbloqueada" (door unlocked), which is
hidden at the start of the scene, and temporarily made visible when the player
collects the final key.

Remove the script, leaving it as a bare, invisible TextureRect. (It's referenced
by path in a script.)
