### PR TITLE
Play musician's "playing" animation when puzzle is solved

### DIFF
--- a/scenes/game_elements/characters/components/sprite_frames/musician.tres
+++ b/scenes/game_elements/characters/components/sprite_frames/musician.tres
@@ -1,6 +1,7 @@
-[gd_resource type="SpriteFrames" load_steps=6 format=3 uid="uid://clx8sssi4tw8q"]
+[gd_resource type="SpriteFrames" load_steps=14 format=3 uid="uid://clx8sssi4tw8q"]
 
 [ext_resource type="Texture2D" uid="uid://d0dej4i54rq5d" path="res://scenes/game_elements/characters/components/assets/musician_idle.png" id="1_t81g1"]
+[ext_resource type="Texture2D" uid="uid://dl6jap006wm6b" path="res://scenes/game_elements/characters/components/assets/musician_playing.png" id="2_xlx7c"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_jg2qk"]
 atlas = ExtResource("1_t81g1")
@@ -17,6 +18,34 @@ region = Rect2(384, 0, 192, 192)
 [sub_resource type="AtlasTexture" id="AtlasTexture_7p71y"]
 atlas = ExtResource("1_t81g1")
 region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_v87sq"]
+atlas = ExtResource("2_xlx7c")
+region = Rect2(0, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_p1u7s"]
+atlas = ExtResource("2_xlx7c")
+region = Rect2(192, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_84cav"]
+atlas = ExtResource("2_xlx7c")
+region = Rect2(384, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_oou6h"]
+atlas = ExtResource("2_xlx7c")
+region = Rect2(576, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_cds1k"]
+atlas = ExtResource("2_xlx7c")
+region = Rect2(768, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_cuel3"]
+atlas = ExtResource("2_xlx7c")
+region = Rect2(960, 0, 192, 192)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_kxpat"]
+atlas = ExtResource("2_xlx7c")
+region = Rect2(1152, 0, 192, 192)
 
 [resource]
 animations = [{
@@ -35,5 +64,31 @@ animations = [{
 }],
 "loop": true,
 "name": &"idle",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_v87sq")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_p1u7s")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_84cav")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_oou6h")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_cds1k")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_cuel3")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_kxpat")
+}],
+"loop": true,
+"name": &"solved",
 "speed": 10.0
 }]

--- a/scenes/game_elements/characters/npcs/sequence_puzzle_assistant/components/sequence_puzzle_assistant.gd
+++ b/scenes/game_elements/characters/npcs/sequence_puzzle_assistant/components/sequence_puzzle_assistant.gd
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ## An NPC who can assist the player with a sequence puzzle.
+##
+## If the [member NPC.sprite_frames] has a [code]solved[/code] animation, this will be played
+## continuously once [member puzzle] is solved.
 @tool
 class_name SequencePuzzleAssistant
 extends Talker
@@ -15,6 +18,14 @@ extends Talker
 ## The [member Talker.dialogue] configured on this node can check and modify this property to play
 ## different dialogue for the player's first interaction with this NPC, if desired.
 var first_conversation: bool = true
+
+
+func _ready() -> void:
+	super._ready()
+	if Engine.is_editor_hint():
+		return
+
+	puzzle.solved.connect(_on_puzzle_solved)
 
 
 ## Call this method from dialogue to record that the player has been offered one more hint for the
@@ -38,3 +49,8 @@ func _get_configuration_warnings() -> PackedStringArray:
 		warnings.append("No puzzle assigned")
 
 	return warnings
+
+
+func _on_puzzle_solved() -> void:
+	if sprite_frames.has_animation(&"solved"):
+		animated_sprite_2d.play(&"solved")


### PR DESCRIPTION
@Omar071201 drew a really fun animation where the musician is playing his instrument, but it was so far not used in the game.

Teach `sequence_puzzle_assistant.gd` to start playing an optional `solved` animation when the puzzle is solved. Define that animation in the musician's SpriteFrames.
