### PR TITLE
El Ojo Revelador: Add third-party asset licensing information

### DIFF
--- a/scenes/quests/story_quests/el_ojo_revelador/0_intro/intro_components/dungeon10.png.license
+++ b/scenes/quests/story_quests/el_ojo_revelador/0_intro/intro_components/dungeon10.png.license
@@ -1,0 +1,5 @@
+https://opengameart.org/content/lpc-dungeon-elements
+
+SPDX-FileCopyrightText: Lanea Zimmerman (Sharm)
+SPDX-FileCopyrightText: William Thompson (William.Thompsonj)
+SPDX-License-Identifier: CC-BY-4.0

--- a/scenes/quests/story_quests/el_ojo_revelador/0_intro/intro_components/dungeonex.png.license
+++ b/scenes/quests/story_quests/el_ojo_revelador/0_intro/intro_components/dungeonex.png.license
@@ -1,0 +1,5 @@
+https://opengameart.org/content/lpc-dungeon-elements
+
+SPDX-FileCopyrightText: Lanea Zimmerman (Sharm)
+SPDX-FileCopyrightText: William Thompson (William.Thompsonj)
+SPDX-License-Identifier: CC-BY-4.0

--- a/scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/Ambiente1_03.ogg.license
+++ b/scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/Ambiente1_03.ogg.license
@@ -1,0 +1,6 @@
+SPDX-License-Identifier: CC-BY-4.0
+SPDX-FileCopyrightText: 2020 Alexandr Zhelanov
+
+https://www.youtube.com/channel/UCxmng6_DMIayDwkiWGVzVRQ?view_as=subscriber totalnomus@gmail.com
+
+https://opengameart.org/content/ancient-temple

--- a/scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/Ambiente2_01.ogg.license
+++ b/scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/Ambiente2_01.ogg.license
@@ -1,0 +1,4 @@
+SPDX-License-Identifier: CC0-1.0
+SPDX-FileCopyrightText: controllerhead (Random Battle)
+
+https://opengameart.org/content/random-battle

--- a/scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/Suspenso.wav.license
+++ b/scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/Suspenso.wav.license
@@ -1,0 +1,4 @@
+SPDX-License-Identifier: CC-BY-4.0
+SPDX-FileCopyrightText: F.M.Audio
+
+Horror Stinger 12.wav by F.M.Audio -- https://freesound.org/s/614717/ -- License: Attribution 4.0

--- a/scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/outro.mp3.license
+++ b/scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/outro.mp3.license
@@ -1,0 +1,4 @@
+SPDX-License-Identifier: CC-BY-4.0
+SPDX-FileCopyrightText: Bogart VGM
+
+https://opengameart.org/content/military-march


### PR DESCRIPTION
Several of these assets require attribution; we need to have this information to hand so that we can generate/write the credits. The information is in commit acccaf86cbf4d04f72faab32df7eb1aff78d1748 but it is useful to have it in the repo proper.

(The submitter of lpc-dungeon-elements is named "William Thompson", and their username is "William.Thompsonj". My name is also William J. Thompson but I am no relation.)
