### PR TITLE
Remove obsolete properties from PlayStation button texture resource

### DIFF
--- a/scenes/game_elements/props/hint/resources/playstation.tres
+++ b/scenes/game_elements/props/hint/resources/playstation.tres
@@ -33,11 +33,6 @@ metadata/_custom_type_script = "uid://dhgm1dl0ohox5"
 
 [resource]
 script = ExtResource("1_omqst")
-move_unpressed = ExtResource("4_dgptc")
-move_up = ExtResource("5_oi6ek")
-move_down = ExtResource("1_v2nbk")
-move_left = ExtResource("2_w33ub")
-move_right = ExtResource("3_vbn2r")
 move = SubResource("Resource_kkpem")
 aim = SubResource("Resource_emb5i")
 metadata/_custom_type_script = "uid://c0haweg5svww1"


### PR DESCRIPTION
Remove obsolete properties from PlayStation button texture resource

These `move_up` etc. properties were removed from `JoypadButtonTextures`
in commit cef922098728a8ee6895582f405480434dd870a1, in favour of a
sub-resource for `move` and another for `aim` which each have `up` etc.
properties.

The fact that I committed this resource with both sets of properties
reveals my development process: I added the new sub-resources, made the
scripts `@tool` scripts that set the new `move` sub-resource from the
old `move_up` etc. properties, and resaved all these resource files.
Then I removed the old fields, removed `@tool`, and opened and saved
each resource again. Evidently I missed one!
