### PR TITLE
ci: Only build main and PRs

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -13,7 +13,7 @@ on:
       - published
   push:
     branches:
-      - '*'
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Previously, the "Build and Export Game" workflow would run whenever any
branch is pushed or updated; and whenever a PR is opened or updated.

This in practice means that every PR from a branch in the same repo gets
built twice each time it is updated; which in turn means the (expensive
in terms of data transferred & GitHub Pages rate limit consumption)
"Publish to GitHub Pages" job would also be run twice.

Building a branch and building a PR actually have slightly different
meanings: I believe that the PR build is for a temporary merge commit
between the branch and main. So there are cases where the PR cannot be
built (due to a merge conflict) but it would still be useful to build
the branch. In this case a build can be triggered manually.

Similarly you could imagine wanting to build a branch without having an
open PR for it. Again you can trigger a build manually, or open a draft
PR (which also gives a place to comment on the branch).
