### PR TITLE
ci: Cache .godot directory

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -95,6 +95,16 @@ jobs:
           # templates here instead of in ~/.local/share/godot/
           touch ._sc_
 
+      - name: Restore Godot import cache
+        uses: actions/cache/restore@v4
+        if: ${{ github.event_name != 'release' }}
+        with:
+          path: |
+            .godot
+          key: ${{ runner.os }}-dotgodot-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-dotgodot
+
       - name: Export web release
         run: |
           mkdir -v -p build/web && cd build
@@ -122,6 +132,13 @@ jobs:
         with:
           name: pck
           path: build/${{ env.PCK_NAME }}.pck
+
+      - name: Save Godot import cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            .godot
+          key: ${{ runner.os }}-dotgodot-${{ github.sha }}
 
   flatpak:
     name: Build Flatpak


### PR DESCRIPTION
When Godot loads the project, all resources must be imported into
.godot/imported. For example, if you have `res://assets/foo.png` plus
`res://assets/foo.png.import`, then Godot creates
`res://.godot/imported/foo.png-HASH.ctex` according to the settings (and indeed
the path!) in the `.import` file. It also writes
`.godot/imported/foo.png-HASH.ctex.md5` containing the md5sums of the source
file and the imported resource.

Importing a file can involve decompressing the source file and recompressing it
in a different format, so it involves some computation.

Godot knows how to reimport files if either the `.import` or the file itself
have changed relative to what is in `.godot/imported`; and to skip reimporting
if neither have changed. So, we can cache this directory in CI, and save
reimporting all these files each time.

As far as I can tell, when an imported file is *removed* from the project Godot
does not evict it from .godot/imported; and I can't find any built-in way to
prune the import directory. I also have a lingering concern that if Godot's
import cache invalidation logic is buggy, we could have issues where e.g. we
change the import settings for an asset, but this change is ignored in CI due to
the previous import being cached. So: don't restore the cache when making a
release. This will ensure the release is a fresh build; and caching the
resulting freshly-created .godot directory will effectively prune the cache.
