### PR TITLE
RandomFrameSpriteBehavior: Randomize frame progress too

### DIFF
--- a/scenes/game_logic/sprite_behaviors/random_frame_sprite_behavior.gd
+++ b/scenes/game_logic/sprite_behaviors/random_frame_sprite_behavior.gd
@@ -10,10 +10,13 @@ extends BaseSpriteBehavior
 
 func _ready() -> void:
 	var frames_length: int = sprite.sprite_frames.get_frame_count(sprite.animation)
-	sprite.frame = randi_range(0, frames_length)
+	# TODO: weight the choice of frame by the relative lengths of frames.
+	# i.e. if an animation has one frame lasting 800ms, and four frames lasting 100ms each,
+	# we should be 8× more likely to pick the 800ms frame than each of the other 4.
+	sprite.set_frame_and_progress(randi_range(0, frames_length), randf())
 
 
 func _notification(what: int) -> void:
 	match what:
 		NOTIFICATION_EDITOR_PRE_SAVE:
-			sprite.frame_progress = 0
+			sprite.frame = 0


### PR DESCRIPTION
Previously this behaviour would randomize the starting frame of the
parent AnimatedSprite2D. But this can still lead to unwanted
synchronicity between instances of the sprite. For example, in Fray's
End we have a big field of barley. The barley animation has 2 frames
(actually it has 4 but it's 2 unique frames each duplicated once), and
so there are only 4 possible starting positions, leading the field to
have a quite visible lock-step sway.

As well as setting the `frame` property, also set `frame_progress`,
which is the position within the chosen frame (between 0.0 for the start
and 1.0 for the end).

In addition, reset both `frame` and `frame_progress` when saving the
containing scene. (Setting `AnimatedSprite2D.frame` implicitly sets
`AnimatedSprite2D.frame_progress` to `0.0`.) Previously we only cleared
`frame_progress` which means that, for instance, `cat.tscn` has a
particular `frame` saved.
