### PR TITLE
Void runner: Add forest collider

### DIFF
--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -80,6 +80,7 @@ func reveal() -> void:
 	revealed = true
 	appear_sound.play()
 	animation_player.play("reveal")
+	await animation_player.animation_finished
 
 
 ## When interacted with, the collectible will display a brief animation

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.gd
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.gd
@@ -7,6 +7,7 @@ extends NPC
 @export var camera: Camera2D
 @export var void_layer: TileMapCover
 @export var enemy: CharacterBody2D
+@export var collectible_thread: CollectibleItem
 
 var _repelled := false
 
@@ -19,6 +20,8 @@ func repel_void() -> void:
 	tween.tween_property(camera, "zoom", original_zoom / 3.0, 1.0).set_ease(Tween.EASE_IN_OUT)
 	await tween.finished
 	await void_layer.uncover_all(3.0)
+
+	await collectible_thread.reveal()
 
 	tween = create_tween()
 	tween.tween_property(camera, "zoom", original_zoom, 1.0).set_ease(Tween.EASE_IN_OUT)

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
@@ -849,15 +849,17 @@ polygon = PackedVector2Array(-221.5, 55.5, -226.5, 102.5, -174.5, 105.5, -158.5,
 
 [node name="CollectibleItem" parent="OnTheGround" instance=ExtResource("22_auh5r")]
 position = Vector2(474, 1058)
+revealed = false
 next_scene = "uid://b8mfigsd8y5qs"
 item = SubResource("Resource_8l6e1")
 collected_dialogue = ExtResource("27_g2rto")
 
-[node name="Monk" parent="OnTheGround" node_paths=PackedStringArray("camera", "void_layer", "enemy") instance=ExtResource("23_swnl7")]
+[node name="Monk" parent="OnTheGround" node_paths=PackedStringArray("camera", "void_layer", "enemy", "collectible_thread") instance=ExtResource("23_swnl7")]
 position = Vector2(3842, 1882)
 camera = NodePath("../Player/Camera2D")
 void_layer = NodePath("../../TileMapLayers/Void")
 enemy = NodePath("../VoidSpreadingEnemy")
+collectible_thread = NodePath("../CollectibleItem")
 
 [node name="UnreachableIsland1" type="Node2D" parent="OnTheGround"]
 y_sort_enabled = true


### PR DESCRIPTION
Please note that we can't do the same for the "SouthCopse" area because the player has to traverse it. Do it only for the thick forest.

Resolve https://github.com/endlessm/threadbare/issues/1753