### PR TITLE
Void runner: Make forest visibly denser

### DIFF
--- a/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
@@ -418,7 +418,6 @@ y_sort_enabled = true
 [node name="AreaFiller" type="Node" parent="OnTheGround/Forest"]
 script = ExtResource("9_kgem8")
 scenes = Array[PackedScene]([ExtResource("10_epkxq")])
-minimum_separation = 96.0
 metadata/_custom_type_script = "uid://bdhjixygupit1"
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="OnTheGround/Forest"]
@@ -426,180 +425,388 @@ position = Vector2(16, 0)
 polygon = PackedVector2Array(826, 1258, 894, 1221, 1022, 1206, 1140, 1216, 1267, 1228, 1309, 1228, 1372, 1216, 1542, 1217, 1665, 1235, 1760, 1254, 1799, 1256, 1839, 1240, 1899, 1248, 1956, 1244, 1981, 1260, 1998, 1315, 1984, 1395, 1985, 1617, 2108, 1623, 2108, 1792, 1971, 1794, 1900, 1808, 1851, 1798, 1804, 1740, 1778, 1724, 1699, 1719, 1667, 1708, 1659, 1677, 1639, 1658, 1501, 1651, 1429, 1662, 1387, 1657, 1368, 1634, 1340, 1613, 1299, 1604, 1262, 1619, 1225, 1647, 1203, 1725, 1164, 1736, 1119, 1738, 1064, 1758, 1043, 1786, 1018, 1838, 979, 1858, 941, 1854, 919, 1819, 866, 1782, 796, 1782, 805, 1553, 954, 1556, 951, 1395, 803, 1392, 803, 1302)
 
 [node name="Tree" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1811, 1724.12)
-scale = Vector2(0.846915, 0.827143)
+position = Vector2(1382.2803, 1632.7102)
+scale = Vector2(1.1197947, 1.0927237)
 
 [node name="Tree2" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1681.77, 1606.21)
-scale = Vector2(0.830458, 0.900932)
+position = Vector2(1439.2523, 1535.7427)
+scale = Vector2(1.1545825, 1.0734576)
 
 [node name="Tree3" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1957.83, 1654.18)
-scale = Vector2(0.87869, 0.883181)
+position = Vector2(1499.7568, 1584.5983)
+scale = Vector2(0.8081981, 0.84724814)
 
 [node name="Tree4" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(2055.72, 1781.84)
-scale = Vector2(1.09884, 1.13927)
+position = Vector2(1338.5072, 1517.5109)
+scale = Vector2(0.8311395, 0.8401409)
 
 [node name="Tree5" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1779.98, 1445.47)
-scale = Vector2(0.992656, 0.974467)
+position = Vector2(1229.2612, 1454.2185)
+scale = Vector2(1.0159218, 1.0812622)
 
 [node name="Tree6" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1785.55, 1567.75)
-scale = Vector2(0.894894, 0.988238)
+position = Vector2(1473.6097, 1645.1073)
+scale = Vector2(1.0886108, 1.0375677)
 
 [node name="Tree7" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1901.38, 1567.4)
-scale = Vector2(1.19947, 1.0922)
+position = Vector2(1266.6842, 1607.5509)
+scale = Vector2(0.8914821, 0.85817194)
 
 [node name="Tree8" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1607.88, 1457.77)
-scale = Vector2(0.879363, 0.810158)
+position = Vector2(1179.0205, 1366.3142)
+scale = Vector2(0.8944967, 0.91631985)
 
 [node name="Tree9" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1983.16, 1428.75)
-scale = Vector2(1.12152, 1.10601)
+position = Vector2(1298.9545, 1459.4517)
+scale = Vector2(1.1256133, 1.1855239)
 
 [node name="Tree10" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1508.12, 1420.9)
-scale = Vector2(1.15326, 1.15938)
+position = Vector2(1316.8308, 1391.2092)
+scale = Vector2(0.73724496, 0.8010309)
 
 [node name="Tree11" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1695.26, 1506.43)
-scale = Vector2(0.787383, 0.854977)
+position = Vector2(1370.556, 1460.0537)
+scale = Vector2(0.9938972, 1.0348382)
 
 [node name="Tree12" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1889.7, 1795.86)
-scale = Vector2(1.14246, 1.14376)
+position = Vector2(1131.9017, 1466.5935)
+scale = Vector2(1.0856584, 1.15316)
 
 [node name="Tree13" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1510.1, 1534.14)
-scale = Vector2(1.27542, 1.17197)
+position = Vector2(1475.4697, 1462.2035)
+scale = Vector2(0.8118678, 0.8423178)
 
 [node name="Tree14" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1408.33, 1471.73)
-scale = Vector2(1.20699, 1.18171)
+position = Vector2(1192.4207, 1518.759)
+scale = Vector2(0.95010173, 1.0391423)
 
 [node name="Tree15" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1547.09, 1325.66)
-scale = Vector2(1.01313, 0.957408)
+position = Vector2(1098.1514, 1529.1129)
+scale = Vector2(1.1161276, 1.1024277)
 
 [node name="Tree16" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1728.26, 1311.54)
-scale = Vector2(0.844084, 0.876774)
+position = Vector2(1556.7687, 1534.022)
+scale = Vector2(0.9226619, 1.0112801)
 
 [node name="Tree17" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1451.3, 1307.21)
-scale = Vector2(0.770579, 0.83698)
+position = Vector2(1479.8704, 1376.401)
+scale = Vector2(1.0746322, 1.0935458)
 
 [node name="Tree18" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1633.12, 1275.22)
-scale = Vector2(0.974905, 1.00532)
+position = Vector2(1412.244, 1374.4698)
+scale = Vector2(0.8683167, 0.88467824)
 
 [node name="Tree19" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1338.12, 1598.7)
-scale = Vector2(0.894101, 0.885509)
+position = Vector2(1373.4396, 1301.5039)
+scale = Vector2(0.73638546, 0.80714494)
 
 [node name="Tree20" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1359.71, 1228.22)
-scale = Vector2(0.790464, 0.834493)
+position = Vector2(1544.4095, 1388.0481)
+scale = Vector2(1.0972718, 1.037543)
 
 [node name="Tree21" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1861.59, 1285.92)
-scale = Vector2(0.844719, 0.822585)
+position = Vector2(1154.2428, 1605.0518)
+scale = Vector2(0.8255535, 0.9046065)
 
 [node name="Tree22" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1881.45, 1401.7)
-scale = Vector2(1.12954, 1.09645)
+position = Vector2(1090.0228, 1386.5903)
+scale = Vector2(1.0727872, 1.023779)
 
 [node name="Tree23" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1578.41, 1644.6)
-scale = Vector2(1.10767, 1.06333)
+position = Vector2(1268.8053, 1536.9736)
+scale = Vector2(1.0403281, 1.1153651)
 
 [node name="Tree24" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1700.55, 1705.39)
-scale = Vector2(0.874387, 0.877377)
+position = Vector2(1539.3894, 1453.6614)
+scale = Vector2(1.0465368, 1.0148385)
 
 [node name="Tree25" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1224.74, 1344.25)
-scale = Vector2(0.926429, 1.00363)
+position = Vector2(1180.589, 1250.4479)
+scale = Vector2(1.0719167, 1.1775024)
 
 [node name="Tree26" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1376.18, 1367.28)
-scale = Vector2(0.944259, 0.889828)
+position = Vector2(1479.668, 1256.0282)
+scale = Vector2(0.9958691, 1.0463)
 
 [node name="Tree27" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1978.64, 1266.73)
-scale = Vector2(0.862681, 0.887265)
+position = Vector2(1204.2318, 1699.9573)
+scale = Vector2(0.93105567, 0.8932324)
 
 [node name="Tree28" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1255.65, 1455.05)
-scale = Vector2(1.05917, 1.03492)
+position = Vector2(1046.437, 1671.3105)
+scale = Vector2(0.83159924, 0.8182535)
 
 [node name="Tree29" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1424.6, 1650.51)
-scale = Vector2(1.17387, 1.14141)
+position = Vector2(1123.0001, 1719)
+scale = Vector2(0.9313087, 1.0185748)
 
 [node name="Tree30" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1239.19, 1620.75)
-scale = Vector2(1.02827, 1.08766)
+position = Vector2(1246.7137, 1355.6332)
+scale = Vector2(1.1676837, 1.0859045)
 
 [node name="Tree31" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1196.24, 1723.97)
-scale = Vector2(1.01937, 1.12154)
+position = Vector2(1597.069, 1239.7765)
+scale = Vector2(0.9155617, 1.0091922)
 
 [node name="Tree32" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1178.7, 1520.42)
-scale = Vector2(1.02744, 1.07115)
+position = Vector2(1282.4269, 1270.6112)
+scale = Vector2(0.86028904, 0.9402178)
 
 [node name="Tree33" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1185.69, 1241.21)
-scale = Vector2(1.11481, 1.07254)
+position = Vector2(1050.3037, 1596.7957)
+scale = Vector2(1.0202129, 1.0927548)
 
 [node name="Tree34" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1118.4, 1438.35)
-scale = Vector2(1.07402, 1.09229)
+position = Vector2(1590.7051, 1636.3253)
+scale = Vector2(1.0192347, 1.0230081)
 
 [node name="Tree35" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1086.25, 1574.53)
-scale = Vector2(1.27827, 1.1875)
+position = Vector2(1527.1809, 1304.9438)
+scale = Vector2(1.047085, 1.1126257)
 
 [node name="Tree36" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1073.09, 1336.59)
-scale = Vector2(1.18238, 1.0962)
+position = Vector2(1675, 1652)
+scale = Vector2(0.85028595, 0.92155725)
 
 [node name="Tree37" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(917.44, 1225.27)
-scale = Vector2(1.20012, 1.12251)
+position = Vector2(1009.5964, 1431.5969)
+scale = Vector2(0.782292, 0.85152185)
 
 [node name="Tree38" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1040.98, 1773.11)
-scale = Vector2(0.739452, 0.802872)
+position = Vector2(993, 1802.9999)
+scale = Vector2(1.2071556, 1.1176566)
 
 [node name="Tree39" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1037.4, 1223.94)
-scale = Vector2(0.949234, 0.897694)
+position = Vector2(1602.6526, 1419.7683)
+scale = Vector2(0.9678298, 0.917706)
 
 [node name="Tree40" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(929.968, 1344.57)
-scale = Vector2(1.12446, 1.09052)
+position = Vector2(889.7811, 1750.5507)
+scale = Vector2(0.8690569, 0.8294269)
+
+[node name="Tree41" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1040.5966, 1489.7772)
+scale = Vector2(0.9718871, 0.95170796)
 
 [node name="Tree42" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(970.265, 1631.29)
-scale = Vector2(1.15211, 1.05199)
+position = Vector2(1650.8684, 1541.958)
+scale = Vector2(0.97895765, 0.98483956)
+
+[node name="Tree43" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1410.6509, 1249.178)
+scale = Vector2(0.9899776, 0.9264882)
 
 [node name="Tree44" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(894.377, 1779.11)
-scale = Vector2(1.1119, 1.19307)
+position = Vector2(990.80347, 1545.6177)
+scale = Vector2(0.97183883, 0.93859094)
+
+[node name="Tree45" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(935.0925, 1639.4624)
+scale = Vector2(1.0152028, 0.98969924)
 
 [node name="Tree46" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(976.119, 1848.71)
-scale = Vector2(1.02937, 1.06714)
+position = Vector2(1665.4192, 1466.9213)
+scale = Vector2(1.1295528, 1.0355574)
 
 [node name="Tree47" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
-position = Vector2(1031.43, 1481.95)
-scale = Vector2(1.11164, 1.02479)
+position = Vector2(1722.2441, 1424.0964)
+scale = Vector2(1.0595424, 1.1607482)
+
+[node name="Tree48" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1707.8922, 1306.3306)
+scale = Vector2(0.8498588, 0.8781812)
+
+[node name="Tree49" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1826.9473, 1393.1573)
+scale = Vector2(1.223828, 1.1519468)
+
+[node name="Tree50" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1123.8313, 1315.4529)
+scale = Vector2(1.1870306, 1.196012)
+
+[node name="Tree51" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1744.1963, 1683.3217)
+scale = Vector2(1.1063309, 1.0284735)
+
+[node name="Tree52" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1106.9972, 1248.7522)
+scale = Vector2(0.85729957, 0.8809529)
+
+[node name="Tree53" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(846.5888, 1623.7191)
+scale = Vector2(0.81516606, 0.8555735)
+
+[node name="Tree54" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(999.6678, 1363.8228)
+scale = Vector2(0.82852626, 0.85419935)
+
+[node name="Tree55" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(927.3709, 1810.3118)
+scale = Vector2(0.9322097, 0.8972994)
+
+[node name="Tree56" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(885.3466, 1555.0334)
+scale = Vector2(1.1773112, 1.0742941)
+
+[node name="Tree57" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1769.7693, 1504.4237)
+scale = Vector2(0.8458208, 0.8891507)
+
+[node name="Tree58" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1045.9403, 1283.6843)
+scale = Vector2(0.7890331, 0.8357743)
+
+[node name="Tree59" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1749.1011, 1586.2134)
+scale = Vector2(1.0860735, 1.0254198)
+
+[node name="Tree60" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1596.7426, 1322.454)
+scale = Vector2(1.108142, 1.1073587)
+
+[node name="Tree61" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(941.2953, 1708.248)
+scale = Vector2(1.0720986, 1.1777524)
+
+[node name="Tree62" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1780.0176, 1325.9479)
+scale = Vector2(1.0357059, 0.9648799)
+
+[node name="Tree63" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(864, 1769)
+scale = Vector2(1.0263792, 0.98297966)
+
+[node name="Tree64" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(918.6816, 1268.6688)
+scale = Vector2(0.8013454, 0.82603645)
+
+[node name="Tree65" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1882.031, 1525.6462)
+scale = Vector2(0.9902654, 0.97818285)
+
+[node name="Tree66" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1812.6302, 1648.6566)
+scale = Vector2(1.1461896, 1.14065)
+
+[node name="Tree67" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1669.1079, 1357.7317)
+scale = Vector2(1.0296319, 1.1051259)
+
+[node name="Tree68" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1005.0204, 1231.966)
+scale = Vector2(0.97447777, 0.92545336)
+
+[node name="Tree69" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(875.3328, 1681.6644)
+scale = Vector2(1.0948707, 1.1662575)
+
+[node name="Tree70" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1046.295, 1793.9714)
+scale = Vector2(1.1155096, 1.157208)
+
+[node name="Tree71" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1852.2191, 1707.5422)
+scale = Vector2(1.0031024, 0.9338421)
+
+[node name="Tree72" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1660.2032, 1258.069)
+scale = Vector2(0.9671796, 0.9866082)
+
+[node name="Tree73" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1947.7041, 1584.8834)
+scale = Vector2(0.90071636, 0.8801319)
+
+[node name="Tree74" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1910.0331, 1645.7726)
+scale = Vector2(0.8010884, 0.8219216)
+
+[node name="Tree75" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1438.6105, 1309.3958)
+scale = Vector2(0.9357405, 0.9521544)
+
+[node name="Tree76" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1996.7192, 1627.9263)
+scale = Vector2(1.0424424, 0.96835965)
+
+[node name="Tree77" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(2025.9686, 1698.1967)
+scale = Vector2(0.8605907, 0.91910547)
+
+[node name="Tree78" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1812.7712, 1556.8185)
+scale = Vector2(1.1618592, 1.1937333)
+
+[node name="Tree79" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(886.6161, 1341.4774)
+scale = Vector2(0.9929149, 0.9137347)
+
+[node name="Tree80" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1937.8444, 1383.1107)
+scale = Vector2(1.009213, 0.93610966)
+
+[node name="Tree81" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(831.78284, 1304.4116)
+scale = Vector2(0.9675537, 0.9255946)
+
+[node name="Tree82" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1869.1691, 1442.4373)
+scale = Vector2(0.86214274, 0.9473536)
+
+[node name="Tree83" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1969.2081, 1792.0664)
+scale = Vector2(1.2070137, 1.1092234)
+
+[node name="Tree84" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(2082, 1779)
+scale = Vector2(0.78024036, 0.8099169)
+
+[node name="Tree85" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1874.578, 1339.3212)
+scale = Vector2(0.7970275, 0.83849144)
+
+[node name="Tree86" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(2036.9219, 1761.7117)
+scale = Vector2(1.1332889, 1.1089565)
+
+[node name="Tree87" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1926.3778, 1721.3035)
+scale = Vector2(1.2834059, 1.1757158)
+
+[node name="Tree88" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(2093.4111, 1647.4072)
+scale = Vector2(0.8342633, 0.88246477)
+
+[node name="Tree89" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1872.5354, 1775.7069)
+scale = Vector2(1.0760204, 1.1791236)
+
+[node name="Tree90" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1836.6652, 1273.1156)
+scale = Vector2(1.0549184, 1.0619782)
+
+[node name="Tree91" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1861.2736, 1602.5042)
+scale = Vector2(1.0392936, 1.1252381)
+
+[node name="Tree92" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1992.5063, 1451.2172)
+scale = Vector2(1.009256, 0.91869444)
+
+[node name="Tree93" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1959.4509, 1264.5375)
+scale = Vector2(0.773384, 0.8386402)
+
+[node name="Tree94" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(2001.1254, 1368.6533)
+scale = Vector2(1.0349631, 1.0178696)
+
+[node name="Tree95" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1941.0226, 1495.5227)
+scale = Vector2(1.1824474, 1.1041962)
+
+[node name="Tree96" parent="OnTheGround/Forest" instance=ExtResource("10_epkxq")]
+position = Vector2(1994.4492, 1540.0923)
+scale = Vector2(0.92704195, 0.8720147)
 
 [node name="ForestExtraTrees" type="Node2D" parent="OnTheGround"]
 y_sort_enabled = true


### PR DESCRIPTION
Follow up of https://github.com/endlessm/threadbare/pull/1764

Change the AreaFiller minimum separation to 64 (the default value). Play with the Refill button until satisfied with the result. Slightly reposition a few trees after that.