### PR TITLE
ci: Use reusable export action

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -19,7 +19,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 env:
-  GODOT_VERSION: "4.5.1"
   PCK_NAME: threadbare
 
 jobs:
@@ -64,55 +63,10 @@ jobs:
               - 'linux/**'
               - .github/workflows/export.yml
 
-      - name: Cache Godot Engine downloads
-        id: cache-godot
-        uses: actions/cache@v5
+      - name: Export web build
+        uses: endlessm/godot-export-action@v1
         with:
-          path: |
-            build/godot
-            build/._sc_
-            build/editor_data/export_templates/${{ env.GODOT_VERSION }}.stable
-          key: godot-${{ env.GODOT_VERSION }}
-
-      - name: Download Godot Engine from GitHub release
-        id: download
-        if: steps.cache-godot.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p build && cd build
-
-          # Download Godot Engine itself
-          wget --progress=dot:giga https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
-          unzip Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip && \
-          mv Godot_v${GODOT_VERSION}-stable_linux.x86_64 godot
-
-          # Download export templates
-          mkdir -p editor_data/export_templates
-          wget --progress=dot:giga https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
-          unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz && \
-          mv templates editor_data/export_templates/${GODOT_VERSION}.stable
-
-          # Tell Godot Engine to run in "self-contained" mode so it looks for
-          # templates here instead of in ~/.local/share/godot/
-          touch ._sc_
-
-      - name: Restore Godot import cache
-        uses: actions/cache/restore@v5
-        if: ${{ github.event_name != 'release' }}
-        with:
-          path: |
-            .godot
-          key: ${{ runner.os }}-dotgodot-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-dotgodot
-
-      - name: Export web release
-        run: |
-          mkdir -v -p build/web && cd build
-
-          # Note that the export path can be confusing; it's relative to the
-          # Godot project path, NOT necessarily the current directory or Godot
-          # binary location
-          ./godot --headless --verbose --path ../ --export-release "Web" ./build/web/index.html
+          godot_version: 4.5.1
 
       # PCK files are the same across export presets/platforms; prep the one
       # just exported for web to be used separately, i.e. for Flatpak builds
@@ -132,13 +86,6 @@ jobs:
         with:
           name: pck
           path: build/${{ env.PCK_NAME }}.pck
-
-      - name: Save Godot import cache
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            .godot
-          key: ${{ runner.os }}-dotgodot-${{ github.sha }}
 
   flatpak:
     name: Build Flatpak


### PR DESCRIPTION
I have factored out the GitHub Actions steps we copy-paste between many
different projects into a reusable composite action.

