### PR TITLE
Add museum with size of characters and props

### DIFF
--- a/scenes/game_elements/components/elements_scale_museum.tscn
+++ b/scenes/game_elements/components/elements_scale_museum.tscn
@@ -1,0 +1,117 @@
+[gd_scene load_steps=10 format=3 uid="uid://cm88m1ynn3mp0"]
+
+[ext_resource type="Texture2D" uid="uid://caajyl18koevp" path="res://scenes/game_elements/props/decoration/hiding_mushroom/components/Mushroom_Idle.png" id="2_gqoln"]
+[ext_resource type="Texture2D" uid="uid://b65dg7i548oip" path="res://scenes/game_elements/props/decoration/books/components/Books_1.png" id="2_jwcoy"]
+[ext_resource type="Texture2D" uid="uid://dqvj0682oytop" path="res://scenes/game_elements/props/decoration/bush/components/Bush_Green_Large.png" id="3_wcpm3"]
+[ext_resource type="Texture2D" uid="uid://dcolxb7p4oyob" path="res://scenes/game_elements/characters/player/components/storyweaver_red_idle.png" id="4_gqoln"]
+[ext_resource type="Texture2D" uid="uid://c1oq5t3ql24cn" path="res://scenes/game_elements/characters/enemies/guard/components/storyvore_idle_blue.png" id="5_gi7q7"]
+[ext_resource type="Texture2D" uid="uid://dqqpdpbahw71l" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/inkdrinker_idle_purple.png" id="6_fmc7b"]
+[ext_resource type="Texture2D" uid="uid://wp4gcho1a4bn" path="res://scenes/game_elements/characters/components/assets/elder_idle.png" id="7_1jyb6"]
+[ext_resource type="Texture2D" uid="uid://dyf1kgdf0ovtj" path="res://scenes/game_elements/props/buildings/house/components/House_Patch_Blue_01.png" id="8_f4mxb"]
+[ext_resource type="Texture2D" uid="uid://dc4nuj702f442" path="res://scenes/game_elements/props/tree/components/Tree_Patches_Green.png" id="9_hjmsw"]
+
+[node name="ElementsScaleMuseum" type="Node2D"]
+metadata/_edit_horizontal_guides_ = [-43.0, -46.0, -56.0, -81.0, -86.0, -99.0, -129.0, -187.0]
+
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2(394, -106)
+
+[node name="Lines" type="Node2D" parent="."]
+
+[node name="Line2D9" type="Line2D" parent="Lines"]
+position = Vector2(0, -186.5)
+points = PackedVector2Array(0, 0, 750, 0)
+width = 1.0
+default_color = Color(0.2509804, 0.627451, 0.44313726, 1)
+
+[node name="Line2D8" type="Line2D" parent="Lines"]
+position = Vector2(0, -128.5)
+points = PackedVector2Array(0, 0, 601, 0)
+width = 1.0
+default_color = Color(0.28627452, 0.654902, 0.7490196, 1)
+
+[node name="Line2D7" type="Line2D" parent="Lines"]
+position = Vector2(0, -128.5)
+points = PackedVector2Array(0, 0, 515, 0)
+width = 1.0
+default_color = Color(0.87058824, 0.34509805, 0.4745098, 1)
+
+[node name="Line2D6" type="Line2D" parent="Lines"]
+position = Vector2(0, -98.5)
+points = PackedVector2Array(0, 0, 399, 0)
+width = 1.0
+default_color = Color(0.49411765, 0.4392157, 0.73333335, 1)
+
+[node name="Line2D5" type="Line2D" parent="Lines"]
+position = Vector2(0, -85.5)
+points = PackedVector2Array(0, 0, 336, 0)
+width = 1.0
+default_color = Color(0.19607843, 0.43137255, 0.4745098, 1)
+
+[node name="Line2D4" type="Line2D" parent="Lines"]
+position = Vector2(0, -80.5)
+points = PackedVector2Array(0, 0, 249, 0)
+width = 1.0
+default_color = Color(0.90588236, 0.38039216, 0.38039216, 1)
+
+[node name="Line2D3" type="Line2D" parent="Lines"]
+position = Vector2(0, -55.5)
+points = PackedVector2Array(0, 0, 174, 0)
+width = 1.0
+default_color = Color(0.2509804, 0.627451, 0.44313726, 1)
+
+[node name="Line2D2" type="Line2D" parent="Lines"]
+position = Vector2(0, -45.5)
+points = PackedVector2Array(0, 0, 126, 0)
+width = 1.0
+default_color = Color(0.87058824, 0.34509805, 0.4745098, 1)
+
+[node name="Line2D" type="Line2D" parent="Lines"]
+position = Vector2(0, -42.5)
+points = PackedVector2Array(0, 0, 71, 0)
+width = 1.0
+default_color = Color(0.827451, 0.28627452, 0.28627452, 1)
+
+[node name="Assets" type="Node2D" parent="."]
+
+[node name="MushroomIdle" type="Sprite2D" parent="Assets"]
+position = Vector2(70, -23)
+texture = ExtResource("2_gqoln")
+
+[node name="Books1" type="Sprite2D" parent="Assets"]
+position = Vector2(125, -27)
+texture = ExtResource("2_jwcoy")
+
+[node name="BushGreenLarge" type="Sprite2D" parent="Assets"]
+position = Vector2(186, -29)
+texture = ExtResource("3_wcpm3")
+hframes = 4
+
+[node name="StoryweaverRedIdle" type="Sprite2D" parent="Assets"]
+position = Vector2(253, -28)
+texture = ExtResource("4_gqoln")
+hframes = 10
+
+[node name="StoryvoreIdleBlue" type="Sprite2D" parent="Assets"]
+position = Vector2(336, -38)
+texture = ExtResource("5_gi7q7")
+hframes = 11
+
+[node name="InkdrinkerIdlePurple" type="Sprite2D" parent="Assets"]
+position = Vector2(412, -41)
+texture = ExtResource("6_fmc7b")
+hframes = 8
+
+[node name="ElderIdle" type="Sprite2D" parent="Assets"]
+position = Vector2(476, -57)
+texture = ExtResource("7_1jyb6")
+hframes = 18
+
+[node name="HousePatchBlue01" type="Sprite2D" parent="Assets"]
+position = Vector2(612, -82)
+texture = ExtResource("8_f4mxb")
+
+[node name="TreePatchesGreen" type="Sprite2D" parent="Assets"]
+position = Vector2(746, -95)
+texture = ExtResource("9_hjmsw")
+hframes = 6


### PR DESCRIPTION
Add a scene to document the size and proportions of representative game elements.

Basically the section [Size of Characters and Props](https://github.com/endlessm/threadbare/wiki/Visual-Style-Guide#size-of-characters-and-props) of the visual style guide, but is better to have it inside the project itself, where the actual assets live.

Influenced by the talk [Gyms, Zoos, and Museums: Your documentation should be in-game](https://godotfest.com/talks/gyms-zoos-and-museums-your-documentation-should-be-in-game/) from GodotFest 2025.
