### PR TITLE
Grappling needles level: Trigger loop puzzle award once

### DIFF
--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_needles.tscn
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_needles.tscn
@@ -412,4 +412,4 @@ shape = SubResource("RectangleShape2D_m6xvq")
 [node name="HUD" parent="." instance=ExtResource("14_bxmjx")]
 visible = false
 
-[connection signal="all_hooked" from="OnTheGround/AllHooked" to="." method="_on_all_hooked_all_hooked"]
+[connection signal="all_hooked" from="OnTheGround/AllHooked" to="." method="_on_all_hooked_all_hooked" flags=6]


### PR DESCRIPTION
Use the "one shot" flag on the signal connection. So the puzzle award is called once. This fixes a bug of the door sound playing when the door is already open.

Fix https://github.com/endlessm/threadbare/issues/1506