### PR TITLE
Fix regression added in 0f6dbece

### DIFF
--- a/scenes/quests/lore_quests/quest_002/3_void_grappling/void_grappling.tscn
+++ b/scenes/quests/lore_quests/quest_002/3_void_grappling/void_grappling.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=38 format=4 uid="uid://b4fmobosi6qvx"]
+[gd_scene load_steps=38 format=4 uid="uid://ce7nk8qmi64d2"]
 
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="1_5a8rg"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="1_grfk2"]


### PR DESCRIPTION
While updating the foam tileset in the scene void_grappling.tscn I was doing something else, and the editor changed the scene UID. This broke the Void quest. Revert to the original UID.