### PR TITLE
Don't shatter non-existent string when defeated

### DIFF
--- a/scenes/game_elements/characters/player/components/player_hook.gd
+++ b/scenes/game_elements/characters/player/components/player_hook.gd
@@ -106,7 +106,8 @@ func _set_character(new_character: CharacterBody2D) -> void:
 
 func _on_player_mode_changed(mode: Player.Mode) -> void:
 	if mode == Player.Mode.DEFEATED:
-		shatter_string()
+		if hook_string:
+			shatter_string()
 
 
 func _get_configuration_warnings() -> PackedStringArray:


### PR DESCRIPTION
Since 494fec1eb6afaaf769dff17e2e86864653e82369 ("Player Hook: Shatter string when player is defeated"), the player's mode changing to DEFEATED causes a call to PlayerHook.shatter_string(). If the player was not currently throwing a string - for example, if they were caught by a guard or by the void while not grappling - this would crash:

    SCRIPT ERROR: Invalid access to property or key 'points' on a base object of type 'Nil'.
          at: PlayerHook.tessellate_string (res://scenes/game_elements/characters/player/components/player_hook.gd:213)
          GDScript backtrace (most recent call first):
              [0] tessellate_string (res://scenes/game_elements/characters/player/components/player_hook.gd:213)
              [1] shatter_string (res://scenes/game_elements/characters/player/components/player_hook.gd:220)
              [2] _on_player_mode_changed (res://scenes/game_elements/characters/player/components/player_hook.gd:109)
              [3] _set_mode (res://scenes/game_elements/characters/player/components/player.gd:111)
              [4] defeat (res://scenes/game_elements/characters/player/components/player.gd:242)
              [5] _on_player_detected (res://scenes/game_logic/stealth_game_logic.gd:16)
              [6] _update_player_awareness (res://scenes/game_elements/characters/enemies/guard/components/guard.gd:204)
              [7] _process (res://scenes/game_elements/characters/enemies/guard/components/guard.gd:165)

Add a check in the mode_changed callback: only call shatter_string() if there is a string to shatter.

Fixes https://github.com/endlessm/threadbare/issues/1798
