### PR TITLE
Stella: Rebuild tortoise as separate scene(s)

### DIFF
--- a/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise.tscn
+++ b/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise.tscn
@@ -1,0 +1,141 @@
+[gd_scene load_steps=15 format=3 uid="uid://cml3bcuq3vmeh"]
+
+[ext_resource type="Texture2D" uid="uid://c6khhgic6yboq" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise.png" id="1_pw0mv"]
+[ext_resource type="PackedScene" uid="uid://gsuvqvotq3fj" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise_shell_gem.tscn" id="2_ohnjq"]
+[ext_resource type="AudioStream" uid="uid://cg57q82pb243w" path="res://assets/third_party/nepalese_hand_bells/handBells-c4.ogg" id="3_1ig7o"]
+[ext_resource type="SpriteFrames" uid="uid://b0ysjxo0i31wi" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem2.tres" id="4_c23wd"]
+[ext_resource type="AudioStream" uid="uid://b83x8h0ob5mpq" path="res://assets/third_party/nepalese_hand_bells/handBells-d4.ogg" id="5_2w8tf"]
+[ext_resource type="SpriteFrames" uid="uid://cgiqnvfiradwh" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem3.tres" id="6_0gbug"]
+[ext_resource type="AudioStream" uid="uid://cmtiwg2cylmts" path="res://assets/third_party/nepalese_hand_bells/handBells-e4.ogg" id="7_mmng5"]
+[ext_resource type="SpriteFrames" uid="uid://dkubrpyrqw68o" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem4.tres" id="8_4sftv"]
+[ext_resource type="AudioStream" uid="uid://8k1hyi4gjae4" path="res://assets/third_party/nepalese_hand_bells/handBells-f4.ogg" id="9_lsn5i"]
+[ext_resource type="SpriteFrames" uid="uid://buj276sg7jp0q" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem5.tres" id="10_lgrp6"]
+[ext_resource type="AudioStream" uid="uid://6oahn2ucxxjv" path="res://assets/third_party/nepalese_hand_bells/handBells-g4.ogg" id="11_21pp6"]
+[ext_resource type="SpriteFrames" uid="uid://bbspuljcecijr" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem6.tres" id="12_ejecx"]
+[ext_resource type="AudioStream" uid="uid://bdboi4ndapqec" path="res://assets/third_party/nepalese_hand_bells/handBells-a4.ogg" id="13_m5xp2"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_4sftv"]
+size = Vector2(58, 37)
+
+[node name="StellaTortoise" type="Node2D"]
+editor_description = "This tortoise contains six SequencePuzzleObject nodes. In the scene that uses it, these nodes are assigned to the SequencePuzzleStep nodes by temporarily enabling Editable Children on the tortoise; assigning the nodes to the SequencePuzzleSteps; then disabling Editable Children on the tortoise again."
+
+[node name="Body" type="StaticBody2D" parent="."]
+
+[node name="BodySprite" type="Sprite2D" parent="Body"]
+scale = Vector2(2, 2)
+texture = ExtResource("1_pw0mv")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Body"]
+polygon = PackedVector2Array(-47, -75, -76, -69, -71, -42, -59, -28, -72, 22, -63, 53, -74, 85, -38, 107, -23, 86, -12, 94, -10, 109, 0, 109, 9, 94, 16, 91, 30, 102, 45, 104, 72, 79, 55, 61, 66, 36, 69, 3, 53, -33, 65, -43, 65, -71, 37, -83, 16, -109, -10, -119, -22, -108)
+
+[node name="Gem 1" parent="." instance=ExtResource("2_ohnjq")]
+audio_stream = ExtResource("3_1ig7o")
+
+[node name="InteractArea" parent="Gem 1" index="1"]
+interact_label_position = Vector2(-50, -64)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 1/InteractArea" index="0"]
+position = Vector2(-60, -64.5)
+shape = SubResource("RectangleShape2D_4sftv")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="AudioStreamPlayer2D" parent="Gem 1" index="2"]
+stream = ExtResource("3_1ig7o")
+
+[node name="Gem 2" parent="." instance=ExtResource("2_ohnjq")]
+sprite_frames = ExtResource("4_c23wd")
+audio_stream = ExtResource("5_2w8tf")
+
+[node name="AnimatedSprite2D" parent="Gem 2" index="0"]
+sprite_frames = ExtResource("4_c23wd")
+
+[node name="InteractArea" parent="Gem 2" index="1"]
+interact_label_position = Vector2(50, -66)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 2/InteractArea" index="0"]
+position = Vector2(71, -65)
+shape = SubResource("RectangleShape2D_4sftv")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="AudioStreamPlayer2D" parent="Gem 2" index="2"]
+stream = ExtResource("5_2w8tf")
+
+[node name="Gem 3" parent="." instance=ExtResource("2_ohnjq")]
+sprite_frames = ExtResource("6_0gbug")
+audio_stream = ExtResource("7_mmng5")
+
+[node name="AnimatedSprite2D" parent="Gem 3" index="0"]
+sprite_frames = ExtResource("6_0gbug")
+
+[node name="InteractArea" parent="Gem 3" index="1"]
+interact_label_position = Vector2(67, -9)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 3/InteractArea" index="0"]
+position = Vector2(91, 17)
+shape = SubResource("RectangleShape2D_4sftv")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="AudioStreamPlayer2D" parent="Gem 3" index="2"]
+stream = ExtResource("7_mmng5")
+
+[node name="Gem 4" parent="." instance=ExtResource("2_ohnjq")]
+sprite_frames = ExtResource("8_4sftv")
+audio_stream = ExtResource("9_lsn5i")
+
+[node name="AnimatedSprite2D" parent="Gem 4" index="0"]
+sprite_frames = ExtResource("8_4sftv")
+
+[node name="InteractArea" parent="Gem 4" index="1"]
+interact_label_position = Vector2(52, 49)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 4/InteractArea" index="0"]
+position = Vector2(61, 90)
+shape = SubResource("RectangleShape2D_4sftv")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="AudioStreamPlayer2D" parent="Gem 4" index="2"]
+stream = ExtResource("9_lsn5i")
+
+[node name="Gem 5" parent="." instance=ExtResource("2_ohnjq")]
+sprite_frames = ExtResource("10_lgrp6")
+audio_stream = ExtResource("11_21pp6")
+
+[node name="AnimatedSprite2D" parent="Gem 5" index="0"]
+sprite_frames = ExtResource("10_lgrp6")
+
+[node name="InteractArea" parent="Gem 5" index="1"]
+interact_label_position = Vector2(-52, 51)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 5/InteractArea" index="0"]
+position = Vector2(-61, 91)
+shape = SubResource("RectangleShape2D_4sftv")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="AudioStreamPlayer2D" parent="Gem 5" index="2"]
+stream = ExtResource("11_21pp6")
+
+[node name="Gem 6" parent="." instance=ExtResource("2_ohnjq")]
+sprite_frames = ExtResource("12_ejecx")
+audio_stream = ExtResource("13_m5xp2")
+
+[node name="AnimatedSprite2D" parent="Gem 6" index="0"]
+sprite_frames = ExtResource("12_ejecx")
+
+[node name="InteractArea" parent="Gem 6" index="1"]
+interact_label_position = Vector2(-78, -9)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 6/InteractArea" index="0"]
+position = Vector2(-87, 16)
+shape = SubResource("RectangleShape2D_4sftv")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="AudioStreamPlayer2D" parent="Gem 6" index="2"]
+stream = ExtResource("13_m5xp2")
+
+[editable path="Gem 1"]
+[editable path="Gem 2"]
+[editable path="Gem 3"]
+[editable path="Gem 4"]
+[editable path="Gem 5"]
+[editable path="Gem 6"]

--- a/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise_shell_gem.tscn
+++ b/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise_shell_gem.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=4 format=3 uid="uid://gsuvqvotq3fj"]
+
+[ext_resource type="Script" uid="uid://bjl6cydoln71k" path="res://scenes/game_elements/props/sequence_puzzle_object/components/sequence_puzzle_object.gd" id="1_elj1l"]
+[ext_resource type="SpriteFrames" uid="uid://cwd3k4451bn6i" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem1.tres" id="2_dwqaf"]
+[ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/components/interact_area.gd" id="3_wah4k"]
+
+[node name="StellaTortoiseShellGem" type="StaticBody2D" groups=["sequence_object"]]
+editor_description = "It is intentional that this node does not have a collision shape: the main body of the tortoise blocks the player from walking through it.
+
+The main tortoise scene should instantiate this scene once for each segment of the shell; enable editable children; and configure the InteractArea as appropriate.
+
+Ideally SequencePuzzleObject would extend Node2D not StaticBody2D, and then Godot would not show a warning about the gems not having collision shapes."
+script = ExtResource("1_elj1l")
+sprite_frames = ExtResource("2_dwqaf")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+unique_name_in_owner = true
+scale = Vector2(2, 2)
+sprite_frames = ExtResource("2_dwqaf")
+
+[node name="InteractArea" type="Area2D" parent="."]
+unique_name_in_owner = true
+collision_layer = 32
+collision_mask = 0
+script = ExtResource("3_wah4k")
+action = "Tap"
+metadata/_custom_type_script = "uid://du8wfijr35r35"
+
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
+unique_name_in_owner = true
+bus = &"SFX"
+
+[connection signal="interaction_started" from="InteractArea" to="." method="_on_interaction_started"]

--- a/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_puzzle.tscn
@@ -1,74 +1,24 @@
-[gd_scene load_steps=39 format=4 uid="uid://b7j5em2h1m2j7"]
+[gd_scene load_steps=20 format=4 uid="uid://b7j5em2h1m2j7"]
 
 [ext_resource type="TileSet" uid="uid://oynx002hv8tl" path="res://tiles/water.tres" id="1_koksn"]
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="2_g4uwj"]
-[ext_resource type="Texture2D" uid="uid://c6khhgic6yboq" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise.png" id="2_iwkby"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="2_sl1lr"]
 [ext_resource type="Script" uid="uid://c68oh8dtr21ti" path="res://scenes/game_logic/sequence_puzzle.gd" id="3_an7xq"]
 [ext_resource type="SpriteFrames" uid="uid://dn0ivusgamrg3" path="res://scenes/quests/story_quests/stella/stella_player_components/stella_player.tres" id="3_r0gok"]
-[ext_resource type="PackedScene" uid="uid://b8sok264erfoc" path="res://scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn" id="4_0jvpl"]
-[ext_resource type="SpriteFrames" uid="uid://bbspuljcecijr" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem6.tres" id="7_tvr0v"]
-[ext_resource type="AudioStream" uid="uid://cg57q82pb243w" path="res://assets/third_party/nepalese_hand_bells/handBells-c4.ogg" id="8_6bjsy"]
-[ext_resource type="Texture2D" uid="uid://hcc8oxmyf6r3" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem1.png" id="9_r0gok"]
 [ext_resource type="PackedScene" uid="uid://be4o3ythda4cu" path="res://scenes/game_elements/props/sequence_puzzle_hint_sign/sequence_puzzle_hint_sign.tscn" id="11_c8urv"]
-[ext_resource type="AudioStream" uid="uid://b83x8h0ob5mpq" path="res://assets/third_party/nepalese_hand_bells/handBells-d4.ogg" id="11_iqidm"]
-[ext_resource type="SpriteFrames" uid="uid://b0ysjxo0i31wi" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem2.tres" id="11_iwkby"]
 [ext_resource type="Script" uid="uid://ccc78coj2b1li" path="res://scenes/game_logic/sequence_puzzle_step.gd" id="13_cyoxr"]
-[ext_resource type="SpriteFrames" uid="uid://cgiqnvfiradwh" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem3.tres" id="13_tvr0v"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="14_edmpl"]
-[ext_resource type="AudioStream" uid="uid://cmtiwg2cylmts" path="res://assets/third_party/nepalese_hand_bells/handBells-e4.ogg" id="14_ucakk"]
-[ext_resource type="SpriteFrames" uid="uid://dkubrpyrqw68o" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem4.tres" id="15_0m0kb"]
 [ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="15_2p35u"]
-[ext_resource type="SpriteFrames" uid="uid://buj276sg7jp0q" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem5.tres" id="15_7g0fx"]
-[ext_resource type="AudioStream" uid="uid://8k1hyi4gjae4" path="res://assets/third_party/nepalese_hand_bells/handBells-f4.ogg" id="17_j5jpl"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="18_w255e"]
 [ext_resource type="PackedScene" uid="uid://ipvcfv2g0oi1" path="res://scenes/game_elements/characters/npcs/talker/talker.tscn" id="19_iwkby"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="19_mt5a1"]
-[ext_resource type="AudioStream" uid="uid://6oahn2ucxxjv" path="res://assets/third_party/nepalese_hand_bells/handBells-g4.ogg" id="20_gjes6"]
 [ext_resource type="SpriteFrames" uid="uid://c8xb6t6eq3xn5" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_guardian.tres" id="20_tvr0v"]
 [ext_resource type="SpriteFrames" uid="uid://hc634wlsdm4p" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_hint_rock.tres" id="22_koksn"]
-[ext_resource type="AudioStream" uid="uid://bdboi4ndapqec" path="res://assets/third_party/nepalese_hand_bells/handBells-a4.ogg" id="23_mu33e"]
 [ext_resource type="Resource" uid="uid://chajuw8jt4mm8" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_guardian.dialogue" id="29_g4uwj"]
+[ext_resource type="PackedScene" uid="uid://cml3bcuq3vmeh" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise.tscn" id="31_g4uwj"]
 [ext_resource type="SpriteFrames" uid="uid://2ek86nvw6y28" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_yellow.tres" id="31_xd6u5"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="32_7w21t"]
 [ext_resource type="Resource" uid="uid://wpifv4dfofm2" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_sequence_puzzle.dialogue" id="33_g4uwj"]
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_jgt7i"]
-atlas = ExtResource("9_r0gok")
-region = Rect2(0, 0, 128, 128)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_4ef3h"]
-atlas = ExtResource("9_r0gok")
-region = Rect2(0, 0, 128, 128)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_txjrb"]
-atlas = ExtResource("9_r0gok")
-region = Rect2(0, 128, 128, 128)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_tvr0v"]
-animations = [{
-"frames": [{
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_jgt7i")
-}],
-"loop": true,
-"name": &"default",
-"speed": 10.0
-}, {
-"frames": [{
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_4ef3h")
-}, {
-"duration": 3.0,
-"texture": SubResource("AtlasTexture_txjrb")
-}],
-"loop": true,
-"name": &"struck",
-"speed": 5.0
-}]
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_tvr0v"]
-size = Vector2(17.5833, 14.3334)
 
 [sub_resource type="Resource" id="Resource_u8qfb"]
 script = ExtResource("15_2p35u")
@@ -97,11 +47,6 @@ tile_set = ExtResource("2_g4uwj")
 [node name="OnTheGround" type="Node2D" parent="."]
 y_sort_enabled = true
 
-[node name="Tortoise" type="Sprite2D" parent="OnTheGround"]
-position = Vector2(187.2, 383.2)
-scale = Vector2(1.8, 1.8)
-texture = ExtResource("2_iwkby")
-
 [node name="Player" parent="OnTheGround" instance=ExtResource("2_sl1lr")]
 position = Vector2(227, 75)
 sprite_frames = ExtResource("3_r0gok")
@@ -112,159 +57,8 @@ position = Vector2(-1, 0)
 script = ExtResource("3_an7xq")
 metadata/_custom_type_script = "uid://c68oh8dtr21ti"
 
-[node name="Objects" type="Node2D" parent="OnTheGround/SequencePuzzle"]
-y_sort_enabled = true
-position = Vector2(359.2, 478.2)
-
-[node name="Gem 1" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_0jvpl")]
-position = Vector2(-171, -95)
-scale = Vector2(3, 3)
-sprite_frames = SubResource("SpriteFrames_tvr0v")
-audio_stream = ExtResource("8_6bjsy")
-
-[node name="AnimatedSprite2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 1" index="0"]
-position = Vector2(0.666664, 0.33334)
-sprite_frames = SubResource("SpriteFrames_tvr0v")
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 1" index="1"]
-position = Vector2(-17, -16)
-rotation = -6.28319
-
-[node name="InteractArea" parent="OnTheGround/SequencePuzzle/Objects/Gem 1" index="2"]
-position = Vector2(-16, -16)
-interact_label_position = Vector2(0, 0)
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 1/InteractArea" index="0"]
-position = Vector2(0, -0.333333)
-shape = SubResource("RectangleShape2D_tvr0v")
-
-[node name="AudioStreamPlayer2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 1" index="3"]
-stream = ExtResource("8_6bjsy")
-
-[node name="Gem 2" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_0jvpl")]
-position = Vector2(-171, -95)
-scale = Vector2(3, 3)
-sprite_frames = ExtResource("11_iwkby")
-audio_stream = ExtResource("11_iqidm")
-
-[node name="AnimatedSprite2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 2" index="0"]
-position = Vector2(-0.333334, -3.57628e-07)
-sprite_frames = ExtResource("11_iwkby")
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 2" index="1"]
-position = Vector2(13.6667, -16.6667)
-rotation = -6.28319
-
-[node name="InteractArea" parent="OnTheGround/SequencePuzzle/Objects/Gem 2" index="2"]
-position = Vector2(15, -17.6667)
-interact_label_position = Vector2(0, 0)
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 2/InteractArea" index="0"]
-position = Vector2(0, 0)
-shape = SubResource("RectangleShape2D_tvr0v")
-
-[node name="AudioStreamPlayer2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 2" index="3"]
-stream = ExtResource("11_iqidm")
-
-[node name="Gem 3" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_0jvpl")]
-position = Vector2(-171, -95)
-scale = Vector2(3, 3)
-sprite_frames = ExtResource("13_tvr0v")
-audio_stream = ExtResource("14_ucakk")
-
-[node name="AnimatedSprite2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 3" index="0"]
-position = Vector2(-2, -0.666667)
-sprite_frames = ExtResource("13_tvr0v")
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 3" index="1"]
-position = Vector2(16.6667, 5)
-rotation = -6.28319
-
-[node name="InteractArea" parent="OnTheGround/SequencePuzzle/Objects/Gem 3" index="2"]
-position = Vector2(18.6667, 4.33333)
-interact_label_position = Vector2(0, 0)
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 3/InteractArea" index="0"]
-position = Vector2(0, 0)
-shape = SubResource("RectangleShape2D_tvr0v")
-
-[node name="AudioStreamPlayer2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 3" index="3"]
-stream = ExtResource("14_ucakk")
-
-[node name="Gem 4" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_0jvpl")]
-position = Vector2(-171, -95)
-scale = Vector2(3, 3)
-sprite_frames = ExtResource("15_0m0kb")
-audio_stream = ExtResource("17_j5jpl")
-
-[node name="AnimatedSprite2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 4" index="0"]
-position = Vector2(-0.666667, -2.66667)
-sprite_frames = ExtResource("15_0m0kb")
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 4" index="1"]
-position = Vector2(12.6667, 26)
-rotation = -6.28319
-
-[node name="InteractArea" parent="OnTheGround/SequencePuzzle/Objects/Gem 4" index="2"]
-position = Vector2(15, 27)
-interact_label_position = Vector2(0, 0)
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 4/InteractArea" index="0"]
-position = Vector2(0, 0)
-shape = SubResource("RectangleShape2D_tvr0v")
-
-[node name="AudioStreamPlayer2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 4" index="3"]
-stream = ExtResource("17_j5jpl")
-
-[node name="Gem 5" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_0jvpl")]
-position = Vector2(-171, -95)
-scale = Vector2(3, 3)
-sprite_frames = ExtResource("15_7g0fx")
-audio_stream = ExtResource("20_gjes6")
-
-[node name="AnimatedSprite2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 5" index="0"]
-position = Vector2(1.33333, -2.66667)
-sprite_frames = ExtResource("15_7g0fx")
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 5" index="1"]
-position = Vector2(-13.6667, 26)
-rotation = -6.28319
-
-[node name="InteractArea" parent="OnTheGround/SequencePuzzle/Objects/Gem 5" index="2"]
-position = Vector2(-16.6667, 27)
-interact_label_position = Vector2(0, 0)
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 5/InteractArea" index="0"]
-position = Vector2(0, 0)
-shape = SubResource("RectangleShape2D_tvr0v")
-
-[node name="AudioStreamPlayer2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 5" index="3"]
-stream = ExtResource("20_gjes6")
-
-[node name="Gem 6" parent="OnTheGround/SequencePuzzle/Objects" instance=ExtResource("4_0jvpl")]
-position = Vector2(-171, -95)
-scale = Vector2(3, 3)
-sprite_frames = ExtResource("7_tvr0v")
-audio_stream = ExtResource("23_mu33e")
-
-[node name="AnimatedSprite2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 6" index="0"]
-position = Vector2(2.33333, 0)
-sprite_frames = ExtResource("7_tvr0v")
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 6" index="1"]
-position = Vector2(-19, 5)
-rotation = -6.28319
-
-[node name="InteractArea" parent="OnTheGround/SequencePuzzle/Objects/Gem 6" index="2"]
-position = Vector2(-20.3333, 4.33334)
-interact_label_position = Vector2(0, 0)
-
-[node name="CollisionShape2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 6/InteractArea" index="0"]
-position = Vector2(0, 0)
-shape = SubResource("RectangleShape2D_tvr0v")
-
-[node name="AudioStreamPlayer2D" parent="OnTheGround/SequencePuzzle/Objects/Gem 6" index="3"]
-stream = ExtResource("23_mu33e")
+[node name="Tortoise" parent="OnTheGround/SequencePuzzle" instance=ExtResource("31_g4uwj")]
+position = Vector2(191, 379)
 
 [node name="Signs" type="Node2D" parent="OnTheGround/SequencePuzzle"]
 y_sort_enabled = true
@@ -285,17 +79,17 @@ sprite_frames = ExtResource("22_koksn")
 
 [node name="SequencePuzzleStep1" type="Node2D" parent="OnTheGround/SequencePuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
 script = ExtResource("13_cyoxr")
-sequence = [NodePath("../../Objects/Gem 2"), NodePath("../../Objects/Gem 4"), NodePath("../../Objects/Gem 6")]
+sequence = [NodePath("../../Tortoise/Gem 2"), NodePath("../../Tortoise/Gem 4"), NodePath("../../Tortoise/Gem 6")]
 hint_sign = NodePath("../../Signs/HintSign1")
 
 [node name="SequencePuzzleStep2" type="Node2D" parent="OnTheGround/SequencePuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
 script = ExtResource("13_cyoxr")
-sequence = [NodePath("../../Objects/Gem 2"), NodePath("../../Objects/Gem 4"), NodePath("../../Objects/Gem 6"), NodePath("../../Objects/Gem 5"), NodePath("../../Objects/Gem 3"), NodePath("../../Objects/Gem 1")]
+sequence = [NodePath("../../Tortoise/Gem 2"), NodePath("../../Tortoise/Gem 4"), NodePath("../../Tortoise/Gem 6"), NodePath("../../Tortoise/Gem 5"), NodePath("../../Tortoise/Gem 3"), NodePath("../../Tortoise/Gem 1")]
 hint_sign = NodePath("../../Signs/HintSign2")
 
 [node name="SequencePuzzleStep3" type="Node2D" parent="OnTheGround/SequencePuzzle/Steps" node_paths=PackedStringArray("sequence", "hint_sign")]
 script = ExtResource("13_cyoxr")
-sequence = [NodePath("../../Objects/Gem 2"), NodePath("../../Objects/Gem 4"), NodePath("../../Objects/Gem 6"), NodePath("../../Objects/Gem 5"), NodePath("../../Objects/Gem 3"), NodePath("../../Objects/Gem 1"), NodePath("../../Objects/Gem 2"), NodePath("../../Objects/Gem 2"), NodePath("../../Objects/Gem 1"), NodePath("../../Objects/Gem 2")]
+sequence = [NodePath("../../Tortoise/Gem 2"), NodePath("../../Tortoise/Gem 4"), NodePath("../../Tortoise/Gem 6"), NodePath("../../Tortoise/Gem 5"), NodePath("../../Tortoise/Gem 3"), NodePath("../../Tortoise/Gem 1"), NodePath("../../Tortoise/Gem 2"), NodePath("../../Tortoise/Gem 2"), NodePath("../../Tortoise/Gem 1"), NodePath("../../Tortoise/Gem 2")]
 hint_sign = NodePath("../../Signs/HintSign3")
 
 [node name="CollectibleItem" parent="OnTheGround" instance=ExtResource("14_edmpl")]
@@ -332,10 +126,3 @@ dialogue = ExtResource("33_g4uwj")
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [connection signal="solved" from="OnTheGround/SequencePuzzle" to="OnTheGround/CollectibleItem" method="reveal"]
-
-[editable path="OnTheGround/SequencePuzzle/Objects/Gem 1"]
-[editable path="OnTheGround/SequencePuzzle/Objects/Gem 2"]
-[editable path="OnTheGround/SequencePuzzle/Objects/Gem 3"]
-[editable path="OnTheGround/SequencePuzzle/Objects/Gem 4"]
-[editable path="OnTheGround/SequencePuzzle/Objects/Gem 5"]
-[editable path="OnTheGround/SequencePuzzle/Objects/Gem 6"]


### PR DESCRIPTION
Unlike all the other sequence puzzles in the game, where the objects to
kick/tap/etc. are visibly separate in the game, in this puzzle the objects are
all segments of the tortoise's shell. This makes it particularly awkward to use the
sequence_puzzle_object.tscn scene because the InteractArea collision shapes have
to be different for each segment; and the segments themselves shouldn't block
player movement (because the main body of the tortoise should do that).

It's made even harder by the fact that sequence_puzzle_object.tscn scales its
sprite by 0.7× (which I consider a bug), so the main body of the tortoise has to
be scaled to match. (And then the tortoise assets are half the desired size so
the whole thing needs to be scaled up 2× on top of that.)

Rebuild the tortoise as a pair of new scenes: one for the segments, which does
not have any collision shapes configured; and one for the tortoise as a whole,
which instantiates six of the segments, enables editable children, and applies
the necessary tweaks. Discard the 0.7× scaling and simply scale up all the
sprites by 2.

Back in the main scene for the challenge, instantiate the tortoise. Now this is
the tricky part: we can still refer to the SequencePuzzleObject nodes within the
Tortoise node on the Step nodes, even though they are not visible when Editable
Children is disabled. This is a bit obscure but it makes the main challenge
scene much more legible IMO so I think it's worth it.

Helps https://github.com/endlessm/threadbare/issues/679
