### PR TITLE
Input Helper: Add singleton in _enable_plugin not _enter_tree

### DIFF
--- a/addons/input_helper/plugin.gd
+++ b/addons/input_helper/plugin.gd
@@ -12,9 +12,11 @@ var http_request: HTTPRequest = HTTPRequest.new()
 var next_version: String = ""
 
 
-func _enter_tree():
+func _enable_plugin():
 	add_autoload_singleton("InputHelper", "res://addons/input_helper/input_helper.gd")
 
+
+func _enter_tree():
 	# Configure settings
 	InputHelperSettings.prepare()
 
@@ -24,9 +26,11 @@ func _enter_tree():
 	http_request.request(REMOTE_RELEASES_URL)
 
 
-func _exit_tree():
+func _disable_plugin():
 	remove_autoload_singleton("InputHelper")
 
+
+func _exit_tree():
 	if next_version != "":
 		remove_tool_menu_item("Update Input Helper to v%s" % next_version)
 


### PR DESCRIPTION
This fixes an issue where, every time the project is opened in the
editor, the editor shows it as having unsaved changes.

Fixes https://github.com/endlessm/threadbare/issues/1827
