### PR TITLE
pause: Refer to title scene by path, not as a PackedScene

### DIFF
--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 extends CanvasLayer
 
-const TITLE_SCENE: PackedScene = preload("uid://stdqc6ttomff")
-const FRAYS_END := "uid://cufkthb25mpxy"
+@export_file("*.tscn") var title_scene: String
+@export_file("*.tscn") var frays_end: String
 
 @onready var pause_menu: Control = %PauseMenu
 @onready var resume_button: Button = %ResumeButton
@@ -36,7 +36,7 @@ func _on_abandon_quest_pressed() -> void:
 	toggle_pause()
 	GameState.abandon_quest()
 	SceneSwitcher.change_to_file_with_transition(
-		FRAYS_END, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+		frays_end, ^"", Transition.Effect.FADE, Transition.Effect.FADE
 	)
 
 
@@ -55,6 +55,6 @@ func _on_resume_button_pressed() -> void:
 
 func _on_title_screen_button_pressed() -> void:
 	toggle_pause()
-	SceneSwitcher.change_to_packed_with_transition(
-		TITLE_SCENE, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+	SceneSwitcher.change_to_file_with_transition(
+		title_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE
 	)

--- a/scenes/globals/pause/pause_overlay.tscn
+++ b/scenes/globals/pause/pause_overlay.tscn
@@ -11,6 +11,8 @@
 process_mode = 3
 layer = 2
 script = ExtResource("1_lf64b")
+title_scene = "uid://stdqc6ttomff"
+frays_end = "uid://cufkthb25mpxy"
 
 [node name="FabricBackground" type="NinePatchRect" parent="."]
 modulate = Color(1, 1, 1, 0.498039)


### PR DESCRIPTION
The pause overlay is an autoload so it is initialised early in the
project setup.

Previously pause_overlay.gd referenced the title screen as a
PackedScene. The title screen transitively refers to credits lists
imported from CSV with the threadbare_credits plugin. This means that
before all scripts can be parsed and the class database initialised, the
import plugin must be able to import the CSV. However the import plugin
previously referred to the CreditsTeam and CreditsTeamRoster resource
subclasses by name, which requires the class database to be initialised:
a circular dependency. This is apparently broken by Godot failing to
load the import plugin, which causes the CSV files to instead be
imported as translation files using the built in CSV translation
importer, breaking the project.

The problem goes away once the project has been imported once because
.godot/global_script_class_cache.cfg has been initialised, so the
resource types can be found by name. This is why I didn't hit it when
writing the plugin.

Refer to the title screen as a string path, not PackedScene. Move these
definitions to the scene file so that the real path can be seen in the
editor.

I debugged this with Claude (but wrote this fix myself). What's annoying
is that I have previously debugged and fixed an equivalent bug by hand:
this is the same change as made in commit
8d10acde47544dcc7b160438bafc9db0ed592977 to the title and splash
screens, for the same reason, just a different import plugin.

Claude initially fixed the bug by changing
threadbare_credit/import_plugin.gd to refer to CreditsTeam and
CreditsTeamRoster via `preload()`, but making that change - with or
without this one - sometimes causes Godot to segfault during first
import; sometimes does not fix the problem; and sometimes works. I
cannot understand why and now need to move on.

Resolves https://github.com/endlessm/threadbare/issues/1832