### PR TITLE
SequencePuzzleObject: Extend Node2D not StaticBody2D

### DIFF
--- a/scenes/game_elements/props/sequence_puzzle_object/components/sequence_puzzle_object.gd
+++ b/scenes/game_elements/props/sequence_puzzle_object/components/sequence_puzzle_object.gd
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 @tool
 class_name SequencePuzzleObject
-extends StaticBody2D
+extends Node2D
 
 ## Emitted when the object is kicked by the player.
 signal kicked

--- a/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise_shell_gem.tscn
+++ b/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise_shell_gem.tscn
@@ -4,12 +4,8 @@
 [ext_resource type="SpriteFrames" uid="uid://cwd3k4451bn6i" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_gem1.tres" id="2_dwqaf"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/components/interact_area.gd" id="3_wah4k"]
 
-[node name="StellaTortoiseShellGem" type="StaticBody2D" groups=["sequence_object"]]
-editor_description = "It is intentional that this node does not have a collision shape: the main body of the tortoise blocks the player from walking through it.
-
-The main tortoise scene should instantiate this scene once for each segment of the shell; enable editable children; and configure the InteractArea as appropriate.
-
-Ideally SequencePuzzleObject would extend Node2D not StaticBody2D, and then Godot would not show a warning about the gems not having collision shapes."
+[node name="StellaTortoiseShellGem" type="Node2D" groups=["sequence_object"]]
+editor_description = "The main tortoise scene should instantiate this scene once for each segment of the shell; enable editable children; and configure the InteractArea as appropriate."
 script = ExtResource("1_elj1l")
 sprite_frames = ExtResource("2_dwqaf")
 


### PR DESCRIPTION
I previously believed that scripts could only be attached to nodes that exactly
match the type that the script extends. In fact, if a script extends type B, it
can be attached to any type A that is a supertype of B.

None of the code that uses SequencePuzzleObject uses any of the API provided by
StaticBody2D.

Change the base type of sequence_puzzle_object.gd from StaticBody2D to Node2D.
Modify the Stella Tortoise to use plain Node2D for the nodes this script is
attached to: this removes a warning about the segments not having any collision
shapes. Remove the note about this from the editor description.
