### PR TITLE
Restored asset scale for pngs in Champ intro

### DIFF
--- a/scenes/quests/story_quests/champ/0_intro/champ_intro.tscn
+++ b/scenes/quests/story_quests/champ/0_intro/champ_intro.tscn
@@ -122,7 +122,6 @@ texture = ExtResource("4_m7ukv")
 
 [node name="Champ" type="Sprite2D" parent="TileMapLayers"]
 position = Vector2(871, 265)
-scale = Vector2(0.6510416, 0.5850695)
 texture = ExtResource("2_u4i0h")
 
 [node name="tapes" type="Node2D" parent="TileMapLayers"]

--- a/scenes/quests/story_quests/champ/0_intro/intro_components/champ_intro_image.png
+++ b/scenes/quests/story_quests/champ/0_intro/intro_components/champ_intro_image.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3135b6964d0eff604425d69c61fe85796f45f20171f24a07ddfa18b51994429
-size 3434
+oid sha256:2f33a4dddfefeabcba01304a39f1b2dd93deca8ed23bbfc5a2db02f8ed088219
+size 3812


### PR DESCRIPTION
Restored the scale to 1.0 for the assets in the Champ intro scene. This was inspired by #1835, trying to get ahead of issues where learners don't know the appropriate pixel size for creating art. 

When creating this scene, I wasn't thinking specifically about asset ratios and pixel sizes. My poster assets are 125 x 170. Is this sufficient for learners? I know this is not a standard size.

On the other hand, the "Replace Image" asset is not set to a 1x scale, as the original asset was not the same aspect ratio as my images. Will this pose a problem?