### PR TITLE
Set default mouse cursor in code, not project.godot

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -57,7 +57,6 @@ window/size/viewport_height=720
 window/size/mode=4
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
-mouse_cursor/custom_image="uid://cee2juvnxco6c"
 mouse_cursor/tooltip_position_offset=Vector2(19, 29)
 window/size/mode.editor=0
 window/size/mode.web=0

--- a/scenes/globals/mouse_manager/mouse_manager.gd
+++ b/scenes/globals/mouse_manager/mouse_manager.gd
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: MPL-2.0
 extends Node
 
+const MOUSE_CURSOR_DEFAULT = preload("uid://cee2juvnxco6c")
 const MOUSE_CURSOR_CROSS = preload("uid://bx11wyx7unc4q")
 
 @onready var hide_timer: Timer = %HideTimer
 
 
 func _ready() -> void:
+	Input.set_custom_mouse_cursor(MOUSE_CURSOR_DEFAULT, Input.CURSOR_ARROW, Vector2(0, 0))
 	Input.set_custom_mouse_cursor(MOUSE_CURSOR_CROSS, Input.CURSOR_CROSS, Vector2(32, 32))
 
 


### PR DESCRIPTION
Set default mouse cursor in code, not project.godot

When I first set the default cursor in commit
8e736dbd424425ac2ac79e6e1675ef877b86e9cd ("Add custom mouse pointer"), I
wrote:

> Doing this in project.godot only overrides the default cursor shape;
> other shapes (I-beam, hand, etc.) must be done in code. I believe we
> don't use any other shapes in the game so let's use project.godot.

Since commit 4dc1272e3972f4999e85bd2fa943e9f1f3f8b3b9 ("Mouse manager:
Set custom cursor for cross shape") that last sentence is no longer
true. It is more consistent to specify all the custom cursors in one
place, in the code.

In addition, setting the cursor in code rather than in project.godot
works around a Godot bug where specifying the cursor in project.godot
causes an error when the project is first imported into the editor,
because the image is accessed before the project has been scanned so the
UID is unknown:

    ERROR: Unrecognized UID: "uid://cee2juvnxco6c".
        at: get_id_path (core/io/resource_uid.cpp:199)
    ERROR: Condition "local_path.is_empty()" is true. Returning: Ref<ResourceLoader::LoadToken>()
        at: _load_start (core/io/resource_loader.cpp:568)

The downside of doing it this way is that the OS default cursor will be
seen until the mouse_managers autoload is initialized. I don't think
this is a significant issue.

Resolves https://github.com/endlessm/threadbare/issues/1838
