### PR TITLE
storyquest_bootstrap: Free scenes after duplicating them

### DIFF
--- a/addons/storyquest_bootstrap/copier.gd
+++ b/addons/storyquest_bootstrap/copier.gd
@@ -108,6 +108,8 @@ func copy_packed_scene(packed_scene: PackedScene, copy_path: String) -> Resource
 	result = ResourceSaver.save(copied)
 	assert(result == OK, error_string(result))
 
+	scene.free()
+
 	return copied
 
 


### PR DESCRIPTION
In order to duplicate a .tscn file, we load it as a PackedScene,
instantiate it, modify that instance, pack it, and save the new
PackedScene. Previously the instance was leaked. Free it.

This is not needed for any other types handled by this tool because
Resources are RefCounted; PackedScene is a Resource, but the instanced
scene is a Node which is not a RefCounted.
