### PR TITLE
GameState: Don't assume current_scene is defined

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -67,8 +67,9 @@ var _state := ConfigFile.new()
 
 
 func _ready() -> void:
-	var initial_scene_uid := ResourceLoader.get_resource_uid(
-		get_tree().current_scene.scene_file_path
+	var current_scene := get_tree().current_scene
+	var initial_scene_uid := (
+		ResourceLoader.get_resource_uid(current_scene.scene_file_path) if current_scene else -1
 	)
 	var main_scene_uid := ResourceLoader.get_resource_uid(
 		ProjectSettings.get_setting("application/run/main_scene")


### PR DESCRIPTION
When running a `--script` from the command line, autoloads are still
loaded, but SceneTree.current_scene is null. Handle this case similarly
to when running a specific scene which is not the main scene: disable
persisting progress.
