### PR TITLE
storyquest_bootstrap: Improve dialog size, position, and keyboard behaviour

### DIFF
--- a/addons/storyquest_bootstrap/new_storyquest_dialog.gd
+++ b/addons/storyquest_bootstrap/new_storyquest_dialog.gd
@@ -14,6 +14,7 @@ var _title: String
 var _description: String
 var _filename: String
 var _invalid_char_regex: RegEx
+var _valid := false
 
 @onready var create_button: Button = %CreateButton
 @onready var panel: Panel = %Panel
@@ -39,7 +40,16 @@ func _ready() -> void:
 	assert(error == OK, error_string(error))
 
 
-func _on_create_button_pressed() -> void:
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed(&"ui_cancel"):
+		close_requested.emit()
+		set_input_as_handled()
+
+
+func submit() -> void:
+	if not _valid:
+		return
+
 	title_edit.editable = false
 	description_edit.editable = false
 	create_button.disabled = true
@@ -107,4 +117,5 @@ func _revalidate() -> void:
 			errors.append('⚠ Title cannot include "story" and "quest" words')
 
 	errors_label.text = "\n".join(errors)
-	create_button.disabled = errors.size() > 0
+	_valid = errors.size() == 0
+	create_button.disabled = not _valid

--- a/addons/storyquest_bootstrap/new_storyquest_dialog.tscn
+++ b/addons/storyquest_bootstrap/new_storyquest_dialog.tscn
@@ -11,6 +11,7 @@ title = "Create StoryQuest"
 initial_position = 1
 size = Vector2i(600, 400)
 transient = true
+exclusive = true
 script = ExtResource("1_1ir5d")
 
 [node name="Panel" type="Panel" parent="."]
@@ -103,6 +104,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 placeholder_text = "This quest is about..."
 wrap_mode = 1
+tab_input_mode = false
 
 [node name="ProgressBar" type="ProgressBar" parent="PanelContainer/VBoxContainer"]
 unique_name_in_owner = true
@@ -124,6 +126,8 @@ text = "Create"
 
 [connection signal="close_requested" from="." to="." method="_on_close_requested"]
 [connection signal="text_changed" from="PanelContainer/VBoxContainer/GridContainer/TitleEdit" to="." method="_on_title_edit_text_changed"]
+[connection signal="text_submitted" from="PanelContainer/VBoxContainer/GridContainer/TitleEdit" to="." method="submit" unbinds=1]
 [connection signal="text_changed" from="PanelContainer/VBoxContainer/GridContainer/FolderEdit" to="." method="_on_folder_edit_text_changed"]
-[connection signal="text_changed" from="PanelContainer/VBoxContainer/DescriptionEdit" to="." method="_on_description_edit_text_changed"]
-[connection signal="pressed" from="PanelContainer/VBoxContainer/MarginContainer2/CreateButton" to="." method="_on_create_button_pressed"]
+[connection signal="text_submitted" from="PanelContainer/VBoxContainer/GridContainer/FolderEdit" to="." method="submit" unbinds=1]
+[connection signal="gui_input" from="PanelContainer/VBoxContainer/DescriptionEdit" to="." method="_on_description_edit_gui_input"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/MarginContainer2/CreateButton" to="." method="submit"]

--- a/addons/storyquest_bootstrap/plugin.gd
+++ b/addons/storyquest_bootstrap/plugin.gd
@@ -35,7 +35,8 @@ func _open_new_storyquest_dialog() -> void:
 	_new_storyquest_dialog.validate_filename = validate_filename
 	_new_storyquest_dialog.create_storyquest.connect(_on_create_storyquest)
 	_new_storyquest_dialog.cancel.connect(_close_dialog)
-	EditorInterface.popup_dialog(_new_storyquest_dialog)
+	_new_storyquest_dialog.size *= EditorInterface.get_editor_scale()
+	EditorInterface.popup_dialog_centered(_new_storyquest_dialog)
 
 
 func _close_dialog() -> void:


### PR DESCRIPTION
Previously the dialog was not centred on the editor. Make it so by using
EditorInterface.popup_dialog_centered().

Previously, if the editor scale was not 100%, the dialog would not be
the correct size. For example, if the scale was 200%, the dialog would
be tiny and the Create button would not be visible until you resize the
dialog. In the editor, you have to manually scale everything according
to the current scale factor! Do so before popping up the dialog.

Previously you could still interact with the editor even when the dialog was
open. This is inconsistent with other tools like the Project Settings dialog.
Set exclusive to true to prevent this.

Previously, hitting Tab in the description field would insert a tab character.
We do not want tab characters in the description! Set tab_input_mode to false,
which allows pressing Tab to move focus to the Create button.

Make hitting Ctrl+Enter in either of the single-line text fields submit the
form.

Make hitting Esc in the dialog close it unless the copy process is running, just
as if you pressed the (X) in the titlebar.
