### PR TITLE
pre-commit: Remove exclusion for git_describe addon

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,5 +58,4 @@ exclude: |
   (?x)^(
     addons/dialogue_manager/(.*)|
     addons/input_helper/(.*)|
-    addons/git_describe/(.*)
   )$


### PR DESCRIPTION
pre-commit: Remove exclusion for git_describe addon

I removed this addon in favour of a simpler one in
commit e6fab5b9cc1f33e4b4d1352fd41ec75e625e12a4.
