### PR TITLE
Template Elder: Fix quest directory

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/template_elder.tscn
+++ b/scenes/game_elements/characters/npcs/elder/template_elder.tscn
@@ -22,7 +22,7 @@ size = Vector2(67, 72)
 collision_layer = 2
 motion_mode = 1
 script = ExtResource("1_l4hfl")
-quest_directory = "res://scenes/quests/story_quests/"
+quest_directory = "res://scenes/quests/template_quests/"
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -320,7 +320,6 @@ eternal_loom = NodePath("../../EternalLoom")
 
 [node name="TemplateElder" parent="NPCs" node_paths=PackedStringArray("eternal_loom") instance=ExtResource("43_ppslc")]
 position = Vector2(1455, 493)
-quest_directory = "res://scenes/quests/template_quests/NO_EDIT"
 eternal_loom = NodePath("../../EternalLoom")
 
 [node name="Axeman" parent="NPCs" instance=ExtResource("17_0a1i7")]


### PR DESCRIPTION
Previously, the template elder's quest directory was overridden in
Fray's End. The overridden value was
res://scenes/quests/template_quests/NO_EDIT/. This is not correct: the
directory is res://scenes/quests/template_quests/, and the one quest
within it is NO_EDIT.

But funnily enough this happened to work almost correctly! The Storybook
initialisation logic did almost nothing (no files matched
"${quest_directory}/*/quest.tres" so the rest was skipped); but the
default quest for the StorybookPage scene is the NO_EDIT quest, so this
was shown without a table of contents. This is why we did not notice the
problem.

Define the quest directory in the template_elder scene, not in
frays_end. Set the directory correctly.
