### PR TITLE
Grappling hook powerup: Remove confusing signs

### DIFF
--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_powerup.tscn
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_powerup.tscn
@@ -253,23 +253,8 @@ position = Vector2(971, -388)
 [node name="HookableNeedle3" parent="OnTheGround/NeedlesPinsB" instance=ExtResource("4_7gbyj")]
 position = Vector2(837, -280)
 
-[node name="Signs" type="Node2D" parent="OnTheGround"]
-y_sort_enabled = true
-
-[node name="Sign" parent="OnTheGround/Signs" instance=ExtResource("8_g2ubw")]
-position = Vector2(-686, 1615)
-text = "Go!"
-
-[node name="Sign2" parent="OnTheGround/Signs" instance=ExtResource("8_g2ubw")]
+[node name="Sign" parent="OnTheGround" instance=ExtResource("8_g2ubw")]
 position = Vector2(-1581, 1616)
-text = "Go!"
-
-[node name="Sign3" parent="OnTheGround/Signs" instance=ExtResource("8_g2ubw")]
-position = Vector2(-371, 1615)
-text = "Go!"
-
-[node name="Sign4" parent="OnTheGround/Signs" instance=ExtResource("8_g2ubw")]
-position = Vector2(-998, 1615)
 text = "Go!"
 
 [node name="LongerStringPowerUp" parent="OnTheGround" instance=ExtResource("7_rlnni")]


### PR DESCRIPTION
The signs are misleading, pointing to the exit when the player has to do some exploration first.

Remove the 3 misleading signs. Leave only the sign that is on the other unreachable side. Rename it to "Sign" (was Sign2 in the group).

Remove the Node2D that was grouping and Y-sorting the signs.

Helps https://github.com/endlessm/threadbare/issues/1504