### PR TITLE
SceneSwitcher: Set challenge start scene to deep link scene

### DIFF
--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -66,6 +66,7 @@ func _restore_from_hash() -> void:
 				GameState.persist_progress = false
 				GameState.clear()
 				GameState.guess_quest(path)
+				GameState.set_challenge_start_scene(path)
 
 			# In theory, we might like to avoid switching scene if the specified
 			# scene is the default scene. In practice, that will not happen, and


### PR DESCRIPTION
SceneSwitcher: Set challenge start scene to deep link scene

Previously, if you deep-linked to (say) the second ink combat in the
first quest, then if you die 3 times you will respawn at the start of
the music puzzle. This is because we don't set the field that records
the start of the current challenge when deep-linking.

It would be most correct in this case to set it to the *first* round of
ink combat, because that is the start of that challenge. However this is
hard to do, and this is a debug feature so you probably don't want to be
kicked back to a previous scene if you are trying to test a specific
scene.
