### PR TITLE
throwing_enemy: Fix property grouping

### DIFF
--- a/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
+++ b/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
@@ -27,8 +27,9 @@ const WALK_TARGET_SKIP_ANGLE: float = PI / 4.
 ## circle is this proportion of the [member walking_range].
 const WALK_TARGET_SKIP_RANGE: float = 0.25
 
-## The projectile scene to instantiate when spawning a projectile.
-@export var projectile_scene: PackedScene = preload("uid://j8mqjkg0rvai")
+## The projectile will be instantiated at this distance from the [member projectile_marker] node,
+## in the direction of the player.
+@export_range(0., 100., 1., "or_greater", "suffix:m") var distance: float = 20.0
 
 ## The period of time between throwing projectiles.
 ## Note: Currently this is limited by the length of the AnimationPlayer animation "attack".
@@ -64,9 +65,8 @@ const WALK_TARGET_SKIP_RANGE: float = 0.25
 
 @export_group("Projectile", "projectile")
 
-## The projectile will be instantiated at this distance from the [member projectile_marker] node,
-## in the direction of the player.
-@export_range(0., 100., 1., "or_greater", "suffix:m") var distance: float = 20.0
+## The projectile scene to instantiate when spawning a projectile.
+@export var projectile_scene: PackedScene = preload("uid://j8mqjkg0rvai")
 
 ## The speed of the projectile initial impulse and the projectile bouncing impulse.
 @export_range(10., 100., 5., "or_greater", "or_less", "suffix:m/s")


### PR DESCRIPTION

The intention is for all projectile_ properties to be grouped together
in a "Projectile" group via:

```gdscript
@export_group("Projectile", "projectile")
```

The second argument is a prefix to strip from properties in the group,
so `projectile_follows_player` becomes "Follows Player". However, per its documentation:

> The grouping will break on the first property that doesn't have a
> prefix.

In commit 117e713d7220f7fc629c567623bfe2e9e19c309a, `var distance` was
added right below this `@export_group`. `distance` does not have the
prefix, so the group ends.

Move the `distance` property out of the group section of the file. Move
the `projectile_scene` property into that group.
