### PR TITLE
Verso combat: Override less of throwing_enemy.gd

### DIFF
--- a/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/ThrowingEnemyHealth.tscn
+++ b/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/ThrowingEnemyHealth.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://dcoas3imo10p5"]
 
 [ext_resource type="Script" uid="uid://djmphyxuypgn1" path="res://scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/throwing_enemy_health.gd" id="1_88n2w"]
+[ext_resource type="PackedScene" uid="uid://gonywq78u3xd" path="res://scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/verso_projectile.tscn" id="2_1njs3"]
 [ext_resource type="SpriteFrames" uid="uid://deosvk5k4su5f" path="res://scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat_components/NO_EDIT_throwing_enemy.tres" id="2_88n2w"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_3vyb7"]
@@ -240,6 +241,8 @@ _data = {
 
 [node name="ThrowingEnemyHealth" type="CharacterBody2D" unique_id=2096096720 groups=["throwing_enemy"]]
 script = ExtResource("1_88n2w")
+distance = 75.0
+projectile_scene = ExtResource("2_1njs3")
 metadata/_custom_type_script = "uid://dfj3625owet5p"
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="." unique_id=23722739]

--- a/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/throwing_enemy_health.gd
+++ b/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/throwing_enemy_health.gd
@@ -4,34 +4,6 @@
 extends ThrowingEnemy
 
 signal Defeated
-
-func shoot_projectile() -> void:
-	var player: Player = get_tree().get_first_node_in_group("player")
-	if not is_instance_valid(player):
-		return
-	if not allowed_labels:
-		_is_attacking = false
-		return
-	var projectile: Projectile = projectile_scene.instantiate()
-	projectile.direction = projectile_marker.global_position.direction_to(player.global_position)
-	scale.x = 1 if projectile.direction.x < 0 else -1
-	projectile.label = allowed_labels.pick_random()
-	if projectile.label in color_per_label:
-		projectile.color = color_per_label[projectile.label]
-	projectile.global_position = (projectile_marker.global_position + (projectile.direction * 75.))
-	if projectile_follows_player:
-		projectile.node_to_follow = player
-	projectile.sprite_frames = projectile_sprite_frames
-	projectile.hit_sound_stream = projectile_hit_sound_stream
-	projectile.small_fx_scene = projectile_small_fx_scene
-	projectile.big_fx_scene = projectile_big_fx_scene
-	projectile.trail_fx_scene = projectile_trail_fx_scene
-	projectile.speed = projectile_speed
-	projectile.duration = projectile_duration
-	projectile.can_hit_enemy = true
-	get_tree().current_scene.add_child(projectile)
-	_set_target_position()
-	_is_attacking = false
 	
 func _on_got_hit(body: Node2D) -> void:
 	super(body)

--- a/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/verso_projectile.tscn
+++ b/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/verso_projectile.tscn
@@ -1,0 +1,50 @@
+[gd_scene format=3 uid="uid://cwfsydjtknnsn"]
+
+[ext_resource type="Script" uid="uid://bofv3bcwj3rx2" path="res://scenes/game_elements/props/projectile/components/projectile.gd" id="1_j2yfe"]
+[ext_resource type="SpriteFrames" uid="uid://b00dcfe4dtvkh" path="res://scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat_components/NO_EDIT_projectile_spriteframes.tres" id="2_j7fua"]
+
+[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_tbgi4"]
+friction = 0.0
+bounce = 1.0
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_o6xl0"]
+size = Vector2(44, 44)
+
+[node name="VersoProjectile" type="RigidBody2D" unique_id=1611529190 groups=["projectiles"]]
+collision_layer = 256
+collision_mask = 80
+mass = 0.3
+physics_material_override = SubResource("PhysicsMaterial_tbgi4")
+gravity_scale = 0.0
+lock_rotation = true
+continuous_cd = 2
+contact_monitor = true
+max_contacts_reported = 1
+script = ExtResource("1_j2yfe")
+can_hit_enemy = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1499726276]
+shape = SubResource("RectangleShape2D_o6xl0")
+
+[node name="VisibleThings" type="Node2D" parent="." unique_id=1129773837]
+unique_name_in_owner = true
+position = Vector2(-3, 0)
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="VisibleThings" unique_id=1816818143]
+unique_name_in_owner = true
+sprite_frames = ExtResource("2_j7fua")
+autoplay = "default"
+
+[node name="TrailFXMarker" type="Marker2D" parent="VisibleThings" unique_id=771420475]
+unique_name_in_owner = true
+position = Vector2(-40, 0)
+
+[node name="DurationTimer" type="Timer" parent="." unique_id=259732970]
+unique_name_in_owner = true
+
+[node name="HitSound" type="AudioStreamPlayer2D" parent="." unique_id=1862098516]
+unique_name_in_owner = true
+bus = &"SFX"
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]
+[connection signal="timeout" from="DurationTimer" to="." method="_on_duration_timer_timeout"]


### PR DESCRIPTION
Previously throwing_enemy_health.gd overrode shoot_projectile() with two changes:

1. It adjusts the distance from the enemy that the projectile spawns;
2. It sets can_hit_enemy = true on the projectile.

Since this scene was first written, it has become possible to adjust
both of these properties.

Make a copy of the projectile, verso_projectile.tscn, which sets
can_hit_enemy to true.

Adjust ThrowingEnemyHealth.tscn to use this copy of the projectile, and
to set the distance to 75.

Delete the shoot_projectile() override.

Resolves #1316 
