### PR TITLE
El ojo revelador: fix combat scene

### DIFF
--- a/scenes/quests/story_quests/el_ojo_revelador/2_combat/el_ojo_revelador_combat.tscn
+++ b/scenes/quests/story_quests/el_ojo_revelador/2_combat/el_ojo_revelador_combat.tscn
@@ -33,6 +33,7 @@ color = Color(0.47397625, 0.47397554, 0.47397572, 1)
 [node name="FillGameLogic" type="Node" parent="." unique_id=688937184]
 script = ExtResource("1_gcfas")
 barrels_to_win = 6
+autostart = true
 metadata/_custom_type_script = "uid://cp54mgi54nywo"
 
 [node name="TileMapLayers" type="Node2D" parent="." unique_id=787427396]
@@ -56,6 +57,7 @@ tile_set = ExtResource("3_gcfas")
 [node name="Player" parent="." unique_id=2140286703 instance=ExtResource("4_3otej")]
 position = Vector2(293, 262)
 scale = Vector2(1.5, 1.5)
+mode = 1
 sprite_frames = ExtResource("5_t1ovd")
 
 [node name="Camera2D" type="Camera2D" parent="Player" unique_id=990651902]


### PR DESCRIPTION
This was broken by commit 975c06a269472f1ad4ddb68fa427bf783b8c1457:
fill_game_logic.gd no longer autostarts the game by default, and does
not change the player mode. This change was made in parallel to the
development of the storyquest.

Set autostart = true on the FillGameLogic node, and change the player
mode to Fighting.
