### PR TITLE
projectile: make generic scene really generic

### DIFF
--- a/scenes/game_elements/props/projectile/projectile.tscn
+++ b/scenes/game_elements/props/projectile/projectile.tscn
@@ -1,8 +1,7 @@
 [gd_scene format=3 uid="uid://j8mqjkg0rvai"]
 
 [ext_resource type="Script" uid="uid://bofv3bcwj3rx2" path="res://scenes/game_elements/props/projectile/components/projectile.gd" id="1_kxdg3"]
-[ext_resource type="SpriteFrames" uid="uid://bhamin2pby7tq" path="res://scenes/game_elements/props/projectile/components/inkblob_spriteframes.tres" id="2_8sng6"]
-[ext_resource type="AudioStream" uid="uid://7jlv4wqpihl7" path="res://scenes/game_elements/props/projectile/components/blob_hit.wav" id="4_q6q4o"]
+[ext_resource type="SpriteFrames" uid="uid://b00dcfe4dtvkh" path="res://scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat_components/NO_EDIT_projectile_spriteframes.tres" id="2_vv7xl"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_tbgi4"]
 friction = 0.0
@@ -32,7 +31,7 @@ position = Vector2(-3, 0)
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="VisibleThings" unique_id=1816818143]
 unique_name_in_owner = true
-sprite_frames = ExtResource("2_8sng6")
+sprite_frames = ExtResource("2_vv7xl")
 autoplay = "default"
 
 [node name="TrailFXMarker" type="Marker2D" parent="VisibleThings" unique_id=771420475]
@@ -44,7 +43,6 @@ unique_name_in_owner = true
 
 [node name="HitSound" type="AudioStreamPlayer2D" parent="." unique_id=1862098516]
 unique_name_in_owner = true
-stream = ExtResource("4_q6q4o")
 bus = &"SFX"
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]


### PR DESCRIPTION
Previously it had the NO_EDIT sprite frames assigned on the root node,
but the ink blob one on the AnimatedSprite2D. At runtime, the former
overwrote the latter. This is confusing. Set the same on both.

Previously, it had a sound effect assigned on the AudioStreamPlayer2D
but not on the root node, and again the root node's null stream would be
set on the AudioStreamPlayer2D at runtime. Clear it.