### PR TITLE
void runner: Fix forest barrier collision layers

### DIFF
--- a/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
@@ -411,6 +411,8 @@ sprite_frames = ExtResource("13_b5w51")
 
 [node name="Forest" type="StaticBody2D" parent="OnTheGround" unique_id=1750666820]
 y_sort_enabled = true
+collision_layer = 512
+collision_mask = 0
 
 [node name="AreaFiller" type="Node" parent="OnTheGround/Forest" unique_id=820523385]
 script = ExtResource("9_kgem8")
@@ -975,9 +977,11 @@ texture = ExtResource("18_rrp37")
 position = Vector2(609, 914)
 texture = ExtResource("19_j6nb3")
 
-[node name="SanctuaryWoods" type="Node2D" parent="OnTheGround" unique_id=1808409558]
+[node name="SanctuaryWoods" type="StaticBody2D" parent="OnTheGround" unique_id=677929103]
 y_sort_enabled = true
 position = Vector2(315, 24)
+collision_layer = 512
+collision_mask = 0
 
 [node name="Tree" parent="OnTheGround/SanctuaryWoods" unique_id=267693094 instance=ExtResource("10_epkxq")]
 position = Vector2(3710.01, 1638.94)
@@ -1044,11 +1048,8 @@ position = Vector2(3505.48, 1740.11)
 scale = Vector2(0.937681, 1.0068)
 sprite_frames = ExtResource("21_xqo3t")
 
-[node name="StaticBody2D" type="StaticBody2D" parent="OnTheGround/SanctuaryWoods" unique_id=30265943]
-position = Vector2(3551, 1666)
-
-[node name="CollisionShape2D" type="CollisionPolygon2D" parent="OnTheGround/SanctuaryWoods/StaticBody2D" unique_id=655034154]
-position = Vector2(5, -60)
+[node name="CollisionShape2D" type="CollisionPolygon2D" parent="OnTheGround/SanctuaryWoods" unique_id=655034154]
+position = Vector2(3556, 1606)
 polygon = PackedVector2Array(-221.5, 55.5, -226.5, 102.5, -174.5, 105.5, -158.5, 99.5, -139.5, 127.5, -90.5, 134.5, -71.5, 153.5, -44.5, 157.5, -12.5, 148.5, 2.5, 148.5, 13.5, 153.5, 33.5, 157.5, 51.5, 152.5, 69.5, 144.5, 105.5, 145.5, 125.5, 161.5, 147.5, 168.5, 171.5, 167.5, 186.5, 162.5, 202.5, 163.5, 225.5, 166.5, 237.5, 156.5, 231.5, 80.5, 210.5, 20.5, 208.5, -27.5, 178.5, -94.5, 133.5, -134.5, 38.5, -132.5, -96.5, -117.5, -178.5, -59.5, -228.5, -14.5)
 
 [node name="CollectibleItem" parent="OnTheGround" unique_id=1898669578 instance=ExtResource("22_auh5r")]


### PR DESCRIPTION
The dense forests are now StaticBody2D nodes with a collision shape that
prevents the player from trying to walk between the trees at all, even
if the geometry of the trees would let them.

However the collision layer & mask were left at the default values:
layer 1, i.e. the "player" physics layer.

Also weirdly, SanctuaryWoods was a bare Node2D with the trees and a
StaticBody2D as a child. I looked back through the git history and it
was always a Node2D. I think what happened is: I planted the trees with
an Area2D + AreaFiller, then for some reason I removed those. Then we
later added the barrier.

Make the SanctuaryWoods be the StaticBody2D, rather than the trees being
siblings of the StaticBody2D.

Update this and another forest to use the correct collision layer:
non_walkable_floor. (There is an argument that they are in fact walls
but non_walkable_floor is what the other barriers in this specific level
e.)
