### PR TITLE
Void quest: Do not capitalize "the" in "Moss the Monk"

### DIFF
--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/collected.dialogue
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/collected.dialogue
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-Moss The Monk: Take the story I told you, this Memory, to LinenVille! Hurry! Help them!
+Moss the Monk: Take the story I told you, this Memory, to LinenVille! Hurry! Help them!
 => END

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.tscn
@@ -15,7 +15,7 @@ size = Vector2(52, 50)
 [node name="Monk" type="CharacterBody2D" unique_id=2026075861]
 motion_mode = 1
 script = ExtResource("1_et70a")
-npc_name = "Moss The Monk"
+npc_name = "Moss the Monk"
 look_at_side = 0
 sprite_frames = ExtResource("2_8g08d")
 

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/intro_start.dialogue
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/intro_start.dialogue
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-Moss The Monk: This thread of Memory will teleport you to the town.
+Moss the Monk: This thread of Memory will teleport you to the town.
 do animation_player.play(&"eat_floor")
 do animation_player.animation_finished
-Moss The Monk: Oh, look! The Void is blooming fast here.
-Moss The Monk: You’ll need a [b]grappling hook[/b] to get to LinenVille. Take mine.
+Moss the Monk: Oh, look! The Void is blooming fast here.
+Moss the Monk: You’ll need a [b]grappling hook[/b] to get to LinenVille. Take mine.
 do animation_player.play(&"show_input_hints")
 => END

--- a/scenes/quests/lore_quests/quest_002/3_void_grappling/components/void_grappling.dialogue
+++ b/scenes/quests/lore_quests/quest_002/3_void_grappling/components/void_grappling.dialogue
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-Moss The Monk: The town is near, but I sense that the Void is somehow more powerful…
-Moss The Monk: I fear that it will chase you again. Run and hook as fast as you can!
+Moss the Monk: The town is near, but I sense that the Void is somehow more powerful…
+Moss the Monk: I fear that it will chase you again. Run and hook as fast as you can!
 => END


### PR DESCRIPTION
Void quest: Do not capitalize "the" in "Moss the Monk"

Resolves https://github.com/endlessm/threadbare/issues/1850
