### PR TITLE
Don't set Create StoryQuest dialog as exclusive

### DIFF
--- a/addons/storyquest_bootstrap/new_storyquest_dialog.tscn
+++ b/addons/storyquest_bootstrap/new_storyquest_dialog.tscn
@@ -11,7 +11,6 @@ title = "Create StoryQuest"
 initial_position = 1
 size = Vector2i(600, 400)
 transient = true
-exclusive = true
 script = ExtResource("1_1ir5d")
 
 [node name="Panel" type="Panel" parent="." unique_id=693475436]


### PR DESCRIPTION
commit 1ad24df997af7d38d227328a8853244c50bf831e caused Godot to crash the next time you save the project after running the StoryQuest bootstrap tool. I believe the underlying bug is the one described in this upstream issue: https://github.com/godotengine/godot/issues/108003

Resolves https://github.com/endlessm/threadbare/issues/1894
