### PR TITLE
background music: Tween volume_linear not volume_db

### DIFF
--- a/scenes/game_elements/props/background_music/components/background_music.gd
+++ b/scenes/game_elements/props/background_music/components/background_music.gd
@@ -55,13 +55,11 @@ func _pause_resume() -> void:
 
 
 func _fade_in() -> void:
-	create_tween().tween_property(audio_stream_player, "volume_db", linear_to_db(1.0), 1.0)
+	create_tween().tween_property(audio_stream_player, "volume_linear", 1.0, 1.0)
 
 
 func _fade_out() -> void:
-	# If we use linear_to_db(0.0) as final value, the audio stream player
-	# is muted instantly because it goes from 0.0db to -infdb.
-	create_tween().tween_property(audio_stream_player, "volume_db", linear_to_db(0.00001), 1.0)
+	create_tween().tween_property(audio_stream_player, "volume_linear", 0.0, 1.0)
 
 
 func _exit_tree() -> void:


### PR DESCRIPTION
Previously we tweened the `volume_db` property between
`linear_to_db(0.00001)` and `linear_to_db(1.0)`. The reason for the strange
lower bound was given in a comment but to expand on it:
`linear_to_db(0.0)` is `-inf`. `linear_to_db` maps the (logarithmic) decibel
scale between -inf and 0.0 onto a linear scale between 0.0 and 1.0. Here
is a table of some sample values that I found helpful, rounded to 1dp:

| x       | linear_to_db(x) |
| ------- | --------------- |
| 0.0     | -inf            |
| 0.00001 | -100.0          |
| 0.05    |  -26.0          |
| 0.1     |  -20.0          |
| 0.25    |  -12.0          |
| 0.5     |   -6.0          |
| 0.75    |   -2.5          |
| 1.0     |    0.0          |

It's not meaningful to tween a value between 0.0 and -inf: there's no
such thing as "halfway between 0.0 and -inf".

`AudioStreamPlayer` has a `volume_linear` property. Setting it just sets
`volume_db` to the result of `linear_to_db()` on its input. By tweening this
property instead, then we can actually tween between the two bounds that
we want.

It also sounds better to my ears than what we were doing before, which
was tweening between 0.0 dB and -100 dB. The human ear perceives a
reduction of 10 dB as a halving of volume. Previously, halfway through
the fade-out (between -0.0 dB and -100 dB) the volume would be -50 dB,
which is a five-fold reduction in volume and means that the sound is
essentially inaudible. With this change, the fade-out is smoother.
