### PR TITLE
Make volume sliders control volume_linear

### DIFF
--- a/scenes/menus/options/components/volume_slider.gd
+++ b/scenes/menus/options/components/volume_slider.gd
@@ -11,7 +11,6 @@ extends HSlider
 
 
 func _ready() -> void:
-	min_value = Settings.MIN_VOLUME
 	_refresh()
 
 

--- a/scenes/menus/options/components/volume_slider.tscn
+++ b/scenes/menus/options/components/volume_slider.tscn
@@ -5,8 +5,11 @@
 [node name="VolumeSlider" type="HSlider" unique_id=1987500278]
 size_flags_horizontal = 3
 size_flags_vertical = 4
-min_value = -30.0
-max_value = 0.0
+max_value = 1.0
+step = 0.1
+tick_count = 11
+ticks_on_borders = true
+ticks_position = 3
 script = ExtResource("1_o184v")
 
 [connection signal="value_changed" from="." to="." method="_on_value_changed"]


### PR DESCRIPTION
Previously the volume sliders adjusted volume_db linearly in the range
-30 dB to 0 dB, with a special case to mute the audio at -30 dB. The dB
scale is logarithmic, not linear.

Godot provides linear_to_db() and db_to_linear(), which map linear
values in the range 0.0 to 1.0 to/from the logarithmic range -inf dB
(silence) to 0 dB, exactly to implement volume sliders. AudioServer
provides convenience methods to set and get linear volume, implemented
in terms of linear_to_db() and db_to_linear().

Connect the volume sliders to adjust the linear volume. Adjust the range
to 0.0 to 1.0 to match. Remove the mute special case: setting the linear
volume to 0.0 is the same as setting the decibel volume to -inf.

Since players will have out of range values saved if they have ever
adjusted the volumes, add versioning to the settings file, and discard
any previous settings. This will reset the volume levels to the
defaults. There are no other settings stored in the file at present.

While we're here: add ticks to the volume sliders.
