### PR TITLE
Prefix template scene root nodes with quest name

### DIFF
--- a/addons/storyquest_bootstrap/copier.gd
+++ b/addons/storyquest_bootstrap/copier.gd
@@ -5,6 +5,7 @@ extends RefCounted
 
 const STORYQUESTS_PATH := "res://scenes/quests/story_quests/"
 const TEMPLATE_PREFIX := "NO_EDIT"
+const TEMPLATE_ROOT_NODE_PREFIX := "NoEdit"
 const TEMPLATE_PATH := "res://scenes/quests/template_quests/" + TEMPLATE_PREFIX + "/"
 const QUEST_FILENAME := "quest.tres"
 const TILES_PATH := "res://tiles/"
@@ -99,6 +100,11 @@ func copy_packed_scene(packed_scene: PackedScene, copy_path: String) -> Resource
 		var node := scene.get_node(path)
 
 		await maybe_copy_properties(node, path)
+
+	if scene.name.begins_with(TEMPLATE_ROOT_NODE_PREFIX):
+		var suffix := scene.name.substr(TEMPLATE_ROOT_NODE_PREFIX.length())
+		var pascal_case_name := quest_name.capitalize().replace(" ", "")
+		scene.name = pascal_case_name + suffix
 
 	copied.resource_path = copy_path
 

--- a/scenes/quests/template_quests/NO_EDIT/0_NO_EDIT_intro/NO_EDIT_intro.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/0_NO_EDIT_intro/NO_EDIT_intro.tscn
@@ -97,7 +97,7 @@ _data = {
 &"walk_on": SubResource("Animation_blo5s")
 }
 
-[node name="Intro" type="Node2D" unique_id=2049284984]
+[node name="NoEditIntro" type="Node2D" unique_id=2049284984]
 
 [node name="TileMapLayers" type="Node2D" parent="." unique_id=591504591]
 

--- a/scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth.tscn
@@ -33,7 +33,7 @@ size = Vector2(168.25, 122)
 script = ExtResource("10_tbnoi")
 metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
-[node name="StealthTemplateLevel" type="Node2D" unique_id=528815133]
+[node name="NoEditStealth" type="Node2D" unique_id=528815133]
 y_sort_enabled = true
 
 [node name="StealthGameLogic" type="Node" parent="." unique_id=1734695953]

--- a/scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat.tscn
@@ -18,7 +18,7 @@ script = ExtResource("11_4lmqk")
 type = 1
 metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
-[node name="Combat" type="Node2D" unique_id=1610054737]
+[node name="NoEditCombat" type="Node2D" unique_id=1610054737]
 y_sort_enabled = true
 
 [node name="Cinematic" type="Node2D" parent="." unique_id=951341763]

--- a/scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat_components/NO_EDIT_projectile.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat_components/NO_EDIT_projectile.tscn
@@ -10,7 +10,7 @@ bounce = 1.0
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_o6xl0"]
 size = Vector2(44, 44)
 
-[node name="Projectile" type="RigidBody2D" unique_id=1611529190 groups=["projectiles"]]
+[node name="NoEditProjectile" type="RigidBody2D" unique_id=1611529190 groups=["projectiles"]]
 collision_layer = 256
 collision_mask = 80
 mass = 0.3

--- a/scenes/quests/template_quests/NO_EDIT/3_NO_EDIT_sequence_puzzle/NO_EDIT_sequence_puzzle.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/3_NO_EDIT_sequence_puzzle/NO_EDIT_sequence_puzzle.tscn
@@ -27,7 +27,7 @@ script = ExtResource("15_5fyey")
 type = 2
 metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
-[node name="SequencePuzzleTemplate" type="Node2D" unique_id=217609538]
+[node name="NoEditSequencePuzzle" type="Node2D" unique_id=217609538]
 
 [node name="TileMapLayers" type="Node2D" parent="." unique_id=2088852286]
 

--- a/scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="SpriteFrames" uid="uid://vwf8e1v8brdp" path="res://scenes/quests/template_quests/NO_EDIT/NO_EDIT_player_components/NO_EDIT_player.tres" id="2_ka28e"]
 [ext_resource type="Resource" uid="uid://qceybl5dvpcp" path="res://scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro_components/NO_EDIT_outro.dialogue" id="2_wgmu0"]
 
-[node name="Outro" type="Node2D" unique_id=1273842832]
+[node name="NoEditOutro" type="Node2D" unique_id=1273842832]
 
 [node name="HUD" parent="." unique_id=260989644 instance=ExtResource("1_fibdn")]
 


### PR DESCRIPTION
For all scenes in the NO_EDIT template, change the root node name to be NoEdit followed by the quest name, matching the filename.

When instantiating the template, rewrite the root node name to replace NoEdit with the PascalCase name of the quest, so that, again, the root node matches the filename.

Resolves https://github.com/endlessm/threadbare/issues/1911
