### PR TITLE
Champ: exporting speed var for outro animation

### DIFF
--- a/scenes/quests/story_quests/champ/4_outro/champ_animation.gd
+++ b/scenes/quests/story_quests/champ/4_outro/champ_animation.gd
@@ -4,7 +4,7 @@ extends CharacterBody2D
 
 @onready var champ_animation: AnimatedSprite2D = $"Champ Animation"
 
-var swim_speed: int = 100
+@export var swim_speed: int = 100
 
 func _ready() -> void:
 	# Give champ a starting swim speed


### PR DESCRIPTION
Super quick fix, exporting the speed variable so learners can change how fast the Champ animation moves from the inspector.