### PR TITLE
Only fade background music when changing streams

### DIFF
--- a/scenes/game_elements/props/background_music/components/background_music.gd
+++ b/scenes/game_elements/props/background_music/components/background_music.gd
@@ -1,17 +1,22 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 @tool
+class_name BackgroundMusic
 extends Node
+## Specify the background music to play in a scene.
+##
+## This controls the singleton MusicPlayer node, which outlives every scene, so
+## that music can keep playing between scenes.
+##
+## There should be at most one BackgroundMusic component in a scene.
 
-@export_tool_button("Play") var play_button: Callable = _play
-@export_tool_button("Stop") var stop_button: Callable = _stop
-@export_tool_button("Pause/Resume") var pause_resume_button: Callable = _pause_resume
+@export_tool_button("Play") var play_button: Callable = play
+@export_tool_button("Stop") var stop_button: Callable = stop
+
 @export var stream: AudioStream:
 	set(new_value):
 		stream = new_value
 		update_configuration_warnings()
-
-@onready var audio_stream_player: AudioStreamPlayer = MusicPlayer.background_music_player
 
 
 func _get_configuration_warnings() -> PackedStringArray:
@@ -22,63 +27,29 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 
 func _ready() -> void:
-	if Engine.is_editor_hint():
-		return
-
-	if stream:
-		_fade_in()
-		_play()
-	else:
-		_stop()
-
-	Transitions.started.connect(self._fade_out)
-
-
-func _play() -> void:
-	if audio_stream_player.stream == stream and audio_stream_player.playing:
-		return
-
-	if stream:
-		audio_stream_player.stream = stream
-		audio_stream_player.play()
-
-
-func _stop() -> void:
-	audio_stream_player.stop()
-
-
-func _pause_resume() -> void:
-	if audio_stream_player.is_playing():
-		audio_stream_player.stream_paused = true
-	else:
-		audio_stream_player.stream_paused = false
-
-
-func _fade_in() -> void:
-	create_tween().tween_property(audio_stream_player, "volume_linear", 1.0, 1.0)
-
-
-func _fade_out() -> void:
-	create_tween().tween_property(audio_stream_player, "volume_linear", 0.0, 1.0)
+	if not Engine.is_editor_hint():
+		play()
 
 
 func _exit_tree() -> void:
-	## Without this, if you click the Play button and then close the scene
-	## in the editor, the music will keep playing.
 	if Engine.is_editor_hint():
-		_stop()
+		stop()
+	else:
+		MusicPlayer.scene_about_to_change()
 
 
-## If [member stream] is an [AudioStreamInteractive], and music is playing,
+## Start playing [member stream], if it is not already playing. Does nothing if
+## [member stream] is already playing.
+func play() -> void:
+	MusicPlayer.play_stream(stream)
+
+
+## Stop playing background music.
+func stop() -> void:
+	MusicPlayer.play_stream(null)
+
+
+## If [member stream] is an [AudioStreamInteractive], and is playing,
 ## switch to [param clip_name].
 func switch_to_clip(clip_name: StringName) -> void:
-	if not audio_stream_player.is_playing():
-		push_warning("Not currently playing")
-		return
-
-	if audio_stream_player.stream is not AudioStreamInteractive:
-		push_warning("Switching clips is only supported with AudioStreamInteractive")
-		return
-
-	var playback := audio_stream_player.get_stream_playback() as AudioStreamPlaybackInteractive
-	playback.switch_to_clip_by_name(clip_name)
+	MusicPlayer.switch_to_clip(clip_name)

--- a/scenes/globals/music_player/music_player.gd
+++ b/scenes/globals/music_player/music_player.gd
@@ -2,5 +2,88 @@
 # SPDX-License-Identifier: MPL-2.0
 @tool
 extends Node
+## Global music player
+##
+## This singleton node handles playing background music. It is controlled by a
+## [BackgroundMusic] node in each scene, which specifies which stream to play in
+## that scene.
+##
+## When switching to a new scene, this node determines whether the music has
+## changed. If so, it fades out the old music (if any) before playing the new
+## music.
+
+## Time to fade out the previous music before playing a new stream. This should
+## be kept in sync with the Transitions visual fade duration.
+const FADE_DURATION_SECONDS := 1.0
+
+# If true, the previous BackgroundMusic node has left the tree, and we are
+# expecting a call to play_stream() from a BackgroundMusic in the new scene. If
+# no such call arrives, we will fade out the current music anyway.
+var _pending_new_stream: bool = false
+
+var _tween: Tween
 
 @onready var background_music_player: AudioStreamPlayer = %BackgroundMusicPlayer
+
+
+func _ready() -> void:
+	get_tree().scene_changed.connect(_on_scene_changed)
+
+
+func _on_scene_changed() -> void:
+	if _pending_new_stream:
+		# No background music in the new scene.
+		background_music_player.stop()
+		background_music_player.stream = null
+		_pending_new_stream = false
+
+
+## Called to indicate that the scene is about to change. If no corresponding
+## call to [member play_stream] arrives before [signal SceneTree.scene_changed]
+## is emitted, the current music will fade out.
+func scene_about_to_change() -> void:
+	_pending_new_stream = true
+
+
+## Start playing [param stream], if it is not already playing, fading out any
+## other stream that was playing before.
+func play_stream(stream: AudioStream) -> void:
+	if _tween:
+		_tween.kill()
+		_tween = null
+
+	_pending_new_stream = false
+
+	if background_music_player.stream:
+		if background_music_player.stream == stream:
+			# No change needed
+			return
+
+		# Fade out previous music
+		_tween = create_tween()
+		_tween.tween_property(background_music_player, "volume_linear", 0.0, FADE_DURATION_SECONDS)
+		await _tween.finished
+		_tween = null
+	elif not Engine.is_editor_hint() and Transitions.is_running():
+		# When switching from a scene without music to a scene with music, still
+		# wait for the visual fade to finish before starting the new music.
+		await Transitions.finished
+
+	background_music_player.volume_linear = 1.0
+	background_music_player.stream = stream
+	background_music_player.play()
+
+
+## If the currently-playing stream is an [AudioStreamInteractive], and music is
+## playing, switch to [param clip_name].
+func switch_to_clip(clip_name: StringName) -> void:
+	if not background_music_player.is_playing():
+		push_warning("Not currently playing")
+		return
+
+	if background_music_player.stream is not AudioStreamInteractive:
+		push_warning("Switching clips is only supported with AudioStreamInteractive")
+		return
+
+	var playback := background_music_player.get_stream_playback() as AudioStreamPlaybackInteractive
+	playback.switch_to_clip_by_name(clip_name)

--- a/scenes/quests/lore_quests/quest_001/4_closing_transition/closing_transition.tscn
+++ b/scenes/quests/lore_quests/quest_001/4_closing_transition/closing_transition.tscn
@@ -134,6 +134,20 @@ tracks/2/keys = {
 "update": 0,
 "values": [Vector2(450, 63), Vector2(725, 63)]
 }
+tracks/3/type = "method"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("../BackgroundMusic")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(1),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"stop"
+}]
+}
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_gyhjf"]
 _data = {


### PR DESCRIPTION
Previously, the background music always faded out during the scene-exit
transition, then faded in during the scene-enter transition. This had:
two negative consequences:

1. It sounds bad when the successive scenes have the same music (e.g.
   the three waves of ink combat);
2. It means the opening chord of each new piece of music is guaranteed
   to be inaudible since the 1-second fade-in is still ongoing.

Instead:

- Do not fade the music when the scene fades out;
- When the new scene arrives, with a BackgroundMusic node:
  - If the stream is the same, do nothing (fixing point 1 above);
  - Else, fade out the old stream for 1 second, then start playing the
    new stream at full volume (fixing point 2 above).

To do this, move most of the logic from BackgroundMusic to MusicPlayer.
Remove the ability to pause/resume BackgroundMusic in the editor for
simplicity, leaving only Play/Stop.

Improve documentation of the two cooperating scripts.

Resolves https://github.com/endlessm/threadbare/issues/637

