### PR TITLE
linux: Remove sandbox hole for org.freedesktop.ScreenSaver

### DIFF
--- a/linux/org.endlessaccess.threadbare.yml
+++ b/linux/org.endlessaccess.threadbare.yml
@@ -13,7 +13,6 @@ finish-args:
 - --socket=fallback-x11
 - --socket=pulseaudio
 - --device=all
-- --talk-name=org.freedesktop.ScreenSaver
 modules:
 - name: threadbare
   buildsystem: simple


### PR DESCRIPTION
I added inhibit portal support upstream in Godot 4.6.
