### PR TITLE
ci: Export with Godot 4.6.1

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Export web build
         uses: endlessm/godot-export-action@v1
         with:
-          godot_version: "4.6"
+          godot_version: "4.6.1"
 
       # PCK files are the same across export presets/platforms; prep the one
       # just exported for web to be used separately, i.e. for Flatpak builds


### PR DESCRIPTION
This maintenance release contains miscellaneous fixes on top of 4.6.
Nothing that looks essential, but also no reason not to.

https://godotengine.org/article/maintenance-release-godot-4-6-1/
