### PR TITLE
Grant the player effectively infinite lives

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -29,7 +29,7 @@ const GLOBAL_SECTION := "global"
 const GLOBAL_INCORPORATING_THREADS_KEY := "incorporating_threads"
 const COMPLETED_QUESTS_KEY := "completed_quests"
 const LIVES_KEY := "current_lives"
-const MAX_LIVES := 3
+const MAX_LIVES := 0x7fffffffffffffff
 const DEBUG_LIVES := false
 
 ## Scenes to skip from saving.


### PR DESCRIPTION
We currently have a partial implementation of lives in the game. The player starts with 3 lives; they lose a life each time they are defeated; and when they run out of lives, they are kicked back to the start of the current challenge.

However, we have no visible indication of the number of lives the player has remaining. As a result, the game feels broken when the player unexpectedly loses their progress after being defeated.

In addition, some recent playtesters felt that the game-over behaviour is unfair, even if it were visible.

For now, set the number of lives to be effectively infinite (the largest positive integer that Godot can represent), to effectively disable the feature. This hexadecimal number is 9,223,372,036,854,775,807 in decimal: 9 quintillion in the short scale.

Helps https://github.com/endlessm/threadbare/issues/1957
