### PR TITLE
MouseManager: Set process_mode to ALWAYS

### DIFF
--- a/scenes/globals/mouse_manager/mouse_manager.tscn
+++ b/scenes/globals/mouse_manager/mouse_manager.tscn
@@ -3,6 +3,8 @@
 [ext_resource type="Script" uid="uid://rw3yh3185lpn" path="res://scenes/globals/mouse_manager/mouse_manager.gd" id="1_u8i10"]
 
 [node name="MouseManager" type="Node" unique_id=1563614058]
+process_mode = 3
+editor_description = "Process Mode: Always - so that the mouse pointer appears when moved in the pause menu."
 script = ExtResource("1_u8i10")
 
 [node name="HideTimer" type="Timer" parent="." unique_id=2136803454]


### PR DESCRIPTION
This allows the mouse to be reliably used when the game is paused.
