### PR TITLE
Elder NPCs: Vary their animation randomly

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/lore_quest_elder.tscn
+++ b/scenes/game_elements/characters/npcs/elder/lore_quest_elder.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://dedhjloxblho6" path="res://scenes/game_elements/characters/npcs/elder/components/elder.gd" id="1_jlpjw"]
 [ext_resource type="Resource" uid="uid://c1baepfbbcd4s" path="res://scenes/game_elements/characters/npcs/elder/components/lore_quest_starter.dialogue" id="2_4dt43"]
+[ext_resource type="Script" uid="uid://cms2wqtbxjl1h" path="res://scenes/game_logic/sprite_behaviors/random_frame_sprite_behavior.gd" id="3_4dt43"]
 [ext_resource type="SpriteFrames" uid="uid://bpfnbr7ig4s5g" path="res://scenes/game_elements/characters/components/sprite_frames/elder.tres" id="3_ak236"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/components/interact_area.gd" id="4_81yrg"]
 [ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="5_ak236"]
@@ -30,6 +31,11 @@ position = Vector2(0, -40)
 sprite_frames = ExtResource("3_ak236")
 animation = &"idle"
 autoplay = "idle"
+
+[node name="RandomFrameSpriteBehavior" type="Node2D" parent="AnimatedSprite2D" unique_id=1766169897 node_paths=PackedStringArray("sprite")]
+script = ExtResource("3_4dt43")
+sprite = NodePath("..")
+metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
 
 [node name="BodyShape" type="CollisionShape2D" parent="." unique_id=156281937]
 position = Vector2(1, 0)

--- a/scenes/game_elements/characters/npcs/elder/story_quest_elder.tscn
+++ b/scenes/game_elements/characters/npcs/elder/story_quest_elder.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://dedhjloxblho6" path="res://scenes/game_elements/characters/npcs/elder/components/elder.gd" id="1_rah8h"]
 [ext_resource type="Resource" uid="uid://ykdgo73x62wa" path="res://scenes/game_elements/characters/npcs/elder/components/story_quest_starter.dialogue" id="2_dyfur"]
+[ext_resource type="Script" uid="uid://cms2wqtbxjl1h" path="res://scenes/game_logic/sprite_behaviors/random_frame_sprite_behavior.gd" id="3_dyfur"]
 [ext_resource type="SpriteFrames" uid="uid://cqe47tmqq3mu4" path="res://scenes/game_elements/characters/components/sprite_frames/elder2.tres" id="3_rah8h"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/components/interact_area.gd" id="4_v03uk"]
 [ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="5_bi5h8"]
@@ -30,7 +31,11 @@ position = Vector2(0, -40)
 sprite_frames = ExtResource("3_rah8h")
 animation = &"idle"
 autoplay = "idle"
-frame = 5
+
+[node name="RandomFrameSpriteBehavior" type="Node2D" parent="AnimatedSprite2D" unique_id=807199844 node_paths=PackedStringArray("sprite")]
+script = ExtResource("3_dyfur")
+sprite = NodePath("..")
+metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
 
 [node name="BodyShape" type="CollisionShape2D" parent="." unique_id=1964287603]
 position = Vector2(-1, 0)

--- a/scenes/game_elements/characters/npcs/elder/template_elder.tscn
+++ b/scenes/game_elements/characters/npcs/elder/template_elder.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://dedhjloxblho6" path="res://scenes/game_elements/characters/npcs/elder/components/elder.gd" id="1_l4hfl"]
 [ext_resource type="SpriteFrames" uid="uid://cqe47tmqq3mu4" path="res://scenes/game_elements/characters/components/sprite_frames/elder2.tres" id="2_ewone"]
+[ext_resource type="Script" uid="uid://cms2wqtbxjl1h" path="res://scenes/game_logic/sprite_behaviors/random_frame_sprite_behavior.gd" id="3_ewone"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/components/interact_area.gd" id="3_ftke6"]
 [ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="4_m4ftv"]
 [ext_resource type="Resource" uid="uid://dg0fe4uwdjlbd" path="res://scenes/game_elements/characters/npcs/elder/components/template_quest_starter.dialogue" id="5_l4hfl"]
@@ -30,7 +31,11 @@ position = Vector2(0, -40)
 sprite_frames = ExtResource("2_ewone")
 animation = &"idle"
 autoplay = "idle"
-frame = 5
+
+[node name="RandomFrameSpriteBehavior" type="Node2D" parent="AnimatedSprite2D" unique_id=2080141430 node_paths=PackedStringArray("sprite")]
+script = ExtResource("3_ewone")
+sprite = NodePath("..")
+metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
 
 [node name="BodyShape" type="CollisionShape2D" parent="." unique_id=901172117]
 position = Vector2(-1, 0)


### PR DESCRIPTION
By adding a RandomFrameSpriteBehavior on each of them.

Before this, the Template Elder and the StoryQuest Elder were playing their animations at the same time.