### PR TITLE
Fray's End: Lock editing the clouds shadow overlay

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -1116,6 +1116,7 @@ metadata/_custom_type_script = "uid://edcifob4jc4s"
 position = Vector2(62, 1747)
 
 [node name="CloudsShadow" parent="." unique_id=1515275591 instance=ExtResource("54_ns5r3")]
+metadata/_edit_lock_ = true
 
 [connection signal="interaction_ended" from="NPCs/Farmer/InteractArea" to="NPCs/Farmer" method="_on_interact_area_interaction_ended"]
 [connection signal="interaction_started" from="NPCs/Farmer/InteractArea" to="NPCs/Farmer" method="_on_interact_area_interaction_started"]


### PR DESCRIPTION
Otherwise it's very hard to select nodes behind the overlay by clicking on the editor 2D viewport.