### PR TITLE
Video settings: Use text property of CheckButton

### DIFF
--- a/scenes/menus/options/components/video_settings.tscn
+++ b/scenes/menus/options/components/video_settings.tscn
@@ -23,13 +23,10 @@ text = "Video Settings"
 layout_mode = 2
 columns = 2
 
-[node name="MusicLabel" type="Label" parent="GridContainer" unique_id=353222812]
-layout_mode = 2
-text = "Fullscreen"
-horizontal_alignment = 2
-
 [node name="CheckButton" type="CheckButton" parent="GridContainer" unique_id=409098937]
 layout_mode = 2
+size_flags_horizontal = 3
+text = "Fullscreen"
 script = ExtResource("2_qb52c")
 
 [connection signal="toggled" from="GridContainer/CheckButton" to="." method="_on_check_button_toggled"]

--- a/scenes/ui_elements/components/theme.tres
+++ b/scenes/ui_elements/components/theme.tres
@@ -162,6 +162,7 @@ Button/styles/normal = SubResource("StyleBoxTexture_rcupm")
 Button/styles/pressed = SubResource("StyleBoxTexture_w6oc6")
 CheckButton/styles/focus = SubResource("StyleBoxFlat_lerkg")
 CheckButton/styles/hover = SubResource("StyleBoxFlat_lerkg")
+CheckButton/styles/hover_pressed = SubResource("StyleBoxFlat_lerkg")
 CheckButton/styles/normal = SubResource("StyleBoxEmpty_7k42u")
 CheckButton/styles/pressed = SubResource("StyleBoxEmpty_lerkg")
 FixedSizeLabel/base_type = &"Label"


### PR DESCRIPTION
Video settings: Use text property of CheckButton

Previously the "Fullscreen" label for the corresponding toggle was a
separate label. But CheckButton has a built-in text property. Using this
has the advantage that clicking the label toggles the button; and that
the focus rectangle covers the label as well as the button.

Also define the hover_pressed style for CheckButton: without it the
label alignment changes in the case where the button is both enabled,
and being hovered over.
