### PR TITLE
Toggleable: Use @abstract

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
           )
 
   - repo: https://github.com/Scony/godot-gdscript-toolkit
-    rev: 4.3.4
+    rev: 4.5.0
     hooks:
       - id: gdformat
         exclude: |

--- a/scenes/game_elements/props/lever/components/toggleable.gd
+++ b/scenes/game_elements/props/lever/components/toggleable.gd
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
-class_name Toggleable
+@abstract class_name Toggleable
 extends Node2D
 
 
@@ -18,6 +18,4 @@ func initialize_with_value(value: bool) -> void:
 	set_toggled(value)
 
 
-func set_toggled(_value: bool) -> void:
-	# For subclasses to override (mandatory)
-	assert(false, "Subclasses must override this method")
+@abstract func set_toggled(value: bool) -> void


### PR DESCRIPTION
Toggleable: Use @abstract

When this class was written, GDScript did not support abstract classes &
methods. Now it does.

Mark the class, and its set_toggled() method, as @abstract. Update
godot-gdscript-toolkit to a version that supports this syntax.
