### PR TITLE
StoryQuestProgress: Don't warn if GameState.current_quest is unset

### DIFF
--- a/scenes/ui_elements/story_quest_progress/components/story_quest_progress.gd
+++ b/scenes/ui_elements/story_quest_progress/components/story_quest_progress.gd
@@ -9,7 +9,6 @@ const ITEM_SLOT: PackedScene = preload("uid://1mjm4atk2j6e")
 
 func _ready() -> void:
 	if not GameState.current_quest:
-		push_warning("No current quest")
 		return
 
 	if GameState.current_quest.threads_to_collect == 0:


### PR DESCRIPTION
StoryQuestProgress: Don't warn if GameState.current_quest is unset

This is expected when you are in Fray's End between quests.
