### PR TITLE
stella: Improve starfish collision shape & let it spin

### DIFF
--- a/scenes/quests/story_quests/stella/2_stella_combat/stella_combat_components/stella_projectile_starfish.tscn
+++ b/scenes/quests/story_quests/stella/2_stella_combat/stella_combat_components/stella_projectile_starfish.tscn
@@ -7,27 +7,19 @@
 friction = 0.0
 bounce = 1.0
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_o6xl0"]
-size = Vector2(44, 44)
-
 [node name="StellaProjectileStarfish" type="RigidBody2D" unique_id=1611529190 groups=["projectiles"]]
 collision_layer = 256
 collision_mask = 80
 mass = 0.3
 physics_material_override = SubResource("PhysicsMaterial_tbgi4")
 gravity_scale = 0.0
-lock_rotation = true
 continuous_cd = 2
 contact_monitor = true
 max_contacts_reported = 1
 script = ExtResource("1_uhkiy")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1499726276]
-shape = SubResource("RectangleShape2D_o6xl0")
-
 [node name="VisibleThings" type="Node2D" parent="." unique_id=1129773837]
 unique_name_in_owner = true
-position = Vector2(-3, 0)
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="VisibleThings" unique_id=1816818143]
 unique_name_in_owner = true
@@ -37,6 +29,10 @@ autoplay = "default"
 [node name="TrailFXMarker" type="Marker2D" parent="VisibleThings" unique_id=771420475]
 unique_name_in_owner = true
 position = Vector2(-40, 0)
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="." unique_id=173284507]
+position = Vector2(3, 0)
+polygon = PackedVector2Array(19, -9, 2, -6, -3, -21, -7, -6, -25, -9, -12, 4, -19, 21, -3, 11, 14, 21, 8, 5)
 
 [node name="DurationTimer" type="Timer" parent="." unique_id=259732970]
 unique_name_in_owner = true


### PR DESCRIPTION
stella: Improve starfish collision shape & let it spin

Previously the starfish projectile sprite was offset slightly from the
centre, and the collision shape was inherited from the generic
projectile.

Zero the positions. Give it a star-shaped collision polygon. Unset
lock_rotation so that it can spin when ricocheting off obstacles.

I made this change while demonstrating to Justin why the new approach of
having separate projectile scenes is worth the trade-off of having more
copies of very similar scenes, then decided it is actually worth pushing.
