### PR TITLE
TalkBehavior: Allow passing extra context to dialogue

### DIFF
--- a/scenes/game_logic/talk_behavior.gd
+++ b/scenes/game_logic/talk_behavior.gd
@@ -22,6 +22,12 @@ extends Node
 @export var interact_area: InteractArea:
 	set = _set_interact_area
 
+## Other nodes in the scene tree to make available in [member dialogue], in addition to
+## properties defined on the parent node and on the [Player] scene.
+## Each node in this list can be accessed by its [member Node.name].
+## Having multiple nodes in this list with the same name is not advised.
+@export var extra_context: Array[Node]
+
 var before_dialogue: Callable
 
 
@@ -50,6 +56,9 @@ func _ready() -> void:
 func _on_interaction_started(player: Player, _from_right: bool) -> void:
 	if before_dialogue:
 		await before_dialogue.call()
-	DialogueManager.show_dialogue_balloon(dialogue, title, [get_parent(), player])
+	var extra: Dictionary[String, Node]
+	for node: Node in extra_context:
+		extra[node.name] = node
+	DialogueManager.show_dialogue_balloon(dialogue, title, [get_parent(), player, extra])
 	await DialogueManager.dialogue_ended
 	interact_area.end_interaction()


### PR DESCRIPTION
I would like to make a townie's dialogue vary based on whether a pathway
has been unlocked. The dialogue could directly access the GameState but
I have a new node with the same API as lever.gd, except rather than
being triggered by an interaction, it is updated by changes to the list
of completed quests. I would prefer to not open-code the "condition
satisfied?" check in two places, so I want to access that node from the
townie's dialogue.

If the townie's TalkBehavior was in a separate scene, this field would
not help: I would need to use editable children (yuck) or add a new
field to the townie's root node, which would make this field unnecessary
because we already pass the TalkBehavior's parent as context so
fields of the townie can be accessed from dialogue. (This is how the
musician queries the state of the sequence puzzle: there is a
SequencePuzzle field on the sequence_puzzle_helper.gd script.)

I am not sure either of these approaches are great. I think we probably
want the generic npc.gd script to have the ability to talk (eliminating
talker.gd) if it has a TalkBehavior, and add another exported field to
pass extra stuff to dialogue (eliminating sequence_puzzle_assistant.gd).
I think in practice people always expect to be able to talk to every
NPC. But that is one for another day.
