### PR TITLE
Add a debug menu to toggle quest completion state

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -22,6 +22,9 @@ signal lives_changed(new_lives: int)
 ## when darkness goes away so artificial lights should turn off.
 signal lights_changed(lights_on: bool, immediate: bool)
 
+## Emitted when a quest is added or removed from [member completed_quests].
+signal completed_quests_changed
+
 const GAME_STATE_PATH := "user://game_state.cfg"
 const INVENTORY_SECTION := "inventory"
 const INVENTORY_ITEMS_KEY := "items_collected"
@@ -200,11 +203,7 @@ func _clear_quest_state() -> void:
 ## and unset it. Also resets lives to maximum.
 func mark_quest_completed() -> void:
 	if current_quest:
-		var quest_name := current_quest.resource_path
-		if quest_name not in completed_quests:
-			completed_quests.append(quest_name)
-			_state.set_value(GLOBAL_SECTION, COMPLETED_QUESTS_KEY, completed_quests)
-
+		_do_set_quest_completed_state(current_quest, true)
 		current_quest = null
 		_clear_quest_state()
 		_save()
@@ -236,6 +235,26 @@ func abandon_quest() -> void:
 	_clear_quest_state()
 	current_quest = null
 	clear_inventory()
+
+
+## Updates [member completed_quests] to include [param quest] if [param
+## is_completed] is true, or remove [param quest] if [param is_completed] is
+## false.
+func set_quest_completed_state(quest: Quest, is_completed: bool) -> void:
+	_do_set_quest_completed_state(quest, is_completed)
+	_save()
+
+
+func _do_set_quest_completed_state(quest: Quest, is_completed: bool) -> void:
+	var quest_name := quest.resource_path
+	if is_completed:
+		if quest_name not in completed_quests:
+			completed_quests.append(quest_name)
+			completed_quests_changed.emit()
+	else:
+		while quest_name in completed_quests:
+			completed_quests.erase(quest_name)
+			completed_quests_changed.emit()
 
 
 ## Remove all [InventoryItem] from the [member inventory].
@@ -355,6 +374,7 @@ func restore() -> Dictionary:
 func _save() -> void:
 	if not persist_progress:
 		return
+	_state.set_value(GLOBAL_SECTION, COMPLETED_QUESTS_KEY, completed_quests)
 	var err := _state.save(GAME_STATE_PATH)
 	if err != OK:
 		push_error("Failed to save settings to %s: %s" % [GAME_STATE_PATH, err])

--- a/scenes/globals/pause/pause_overlay.tscn
+++ b/scenes/globals/pause/pause_overlay.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Texture2D" uid="uid://lg5dl13njsg3" path="res://assets/first_party/tiles/Grass_And_Sand_Tiles.png" id="2_1tcw0"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="2_sd5t1"]
 [ext_resource type="PackedScene" uid="uid://dkeb0yjgcfi86" path="res://scenes/menus/options/options.tscn" id="3_sd5t1"]
+[ext_resource type="PackedScene" uid="uid://56ja3m4283wa" path="res://scenes/menus/debug/debug_settings.tscn" id="5_ai8ue"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_1tcw0"]
 
@@ -81,6 +82,13 @@ size_flags_horizontal = 4
 theme_type_variation = &"FlatButton"
 text = "Options"
 
+[node name="DebugButton" type="Button" parent="TabContainer/PauseMenu/VBoxContainer" unique_id=75453807]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Debug Settings"
+
 [node name="TitleScreenButton" type="Button" parent="TabContainer/PauseMenu/VBoxContainer" unique_id=830702640]
 unique_name_in_owner = true
 layout_mode = 2
@@ -94,8 +102,15 @@ process_mode = 2
 visible = false
 layout_mode = 2
 
+[node name="DebugSettings" parent="TabContainer" unique_id=1197092088 instance=ExtResource("5_ai8ue")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 2
+
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/ResumeButton" to="." method="_on_resume_button_pressed"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/AbandonQuestButton" to="." method="_on_abandon_quest_pressed"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/OptionsButton" to="." method="_on_options_button_pressed"]
+[connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/DebugButton" to="TabContainer/DebugSettings" method="show"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/TitleScreenButton" to="." method="_on_title_screen_button_pressed"]
 [connection signal="back" from="TabContainer/Options" to="." method="_on_options_back"]
+[connection signal="back" from="TabContainer/DebugSettings" to="." method="_on_options_back"]

--- a/scenes/menus/debug/debug_completed_quest_list.gd
+++ b/scenes/menus/debug/debug_completed_quest_list.gd
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends VBoxContainer
+
+const QUEST_ROOT := "res://scenes/quests"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	visibility_changed.connect(_on_visibility_changed)
+	rebuild()
+
+
+func _on_visibility_changed() -> void:
+	if visible:
+		rebuild()
+
+
+func rebuild() -> void:
+	for child: Node in get_children():
+		remove_child(child)
+		child.queue_free()
+
+	for dir: String in DirAccess.get_directories_at(QUEST_ROOT):
+		for quest in Quest.enumerate(QUEST_ROOT.path_join(dir)):
+			var bits: Array[String]
+			if quest.title:
+				bits.append(quest.title)
+			bits.append(quest.resource_path.get_base_dir().substr(QUEST_ROOT.length() + 1))
+			var button := CheckButton.new()
+			button.text = " · ".join(bits)
+			button.button_pressed = GameState.completed_quests.has(quest.resource_path)
+			button.toggled.connect(_on_button_toggled.bind(quest))
+			add_child(button)
+
+
+func _on_button_toggled(toggled_on: bool, quest: Quest) -> void:
+	GameState.set_quest_completed_state(quest, toggled_on)

--- a/scenes/menus/debug/debug_completed_quest_list.gd.uid
+++ b/scenes/menus/debug/debug_completed_quest_list.gd.uid
@@ -1,0 +1,1 @@
+uid://d3s58aw5loxqd

--- a/scenes/menus/debug/debug_completed_quest_list.tscn
+++ b/scenes/menus/debug/debug_completed_quest_list.tscn
@@ -1,0 +1,24 @@
+[gd_scene format=3 uid="uid://cie2w455avmwm"]
+
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_1g3i8"]
+[ext_resource type="Script" uid="uid://d3s58aw5loxqd" path="res://scenes/menus/debug/debug_completed_quest_list.gd" id="1_68hah"]
+
+[node name="DebugCompletedQuestList" type="VBoxContainer" unique_id=1279772854]
+theme = ExtResource("1_1g3i8")
+theme_override_constants/separation = 0
+script = ExtResource("1_68hah")
+
+[node name="Sample1" type="CheckButton" parent="." unique_id=69004526]
+editor_description = "These sample nodes are deleted at runtime; they are only here to help edit this scene, and scenes that use it."
+layout_mode = 2
+text = "The Musician's Quest · lore_quests/quest_001"
+
+[node name="Sample2" type="CheckButton" parent="." unique_id=1811931812]
+editor_description = "These sample nodes are deleted at runtime; they are only here to help edit this scene, and scenes that use it."
+layout_mode = 2
+text = "After The Tremor · story_quests/after_the_tremor"
+
+[node name="Sample3" type="CheckButton" parent="." unique_id=1488387126]
+editor_description = "These sample nodes are deleted at runtime; they are only here to help edit this scene, and scenes that use it."
+layout_mode = 2
+text = "template_quests/NO_EDIT"

--- a/scenes/menus/debug/debug_settings.tscn
+++ b/scenes/menus/debug/debug_settings.tscn
@@ -1,0 +1,44 @@
+[gd_scene format=3 uid="uid://56ja3m4283wa"]
+
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_w7kol"]
+[ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="2_46px3"]
+[ext_resource type="PackedScene" uid="uid://cie2w455avmwm" path="res://scenes/menus/debug/debug_completed_quest_list.tscn" id="2_k06h7"]
+[ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="3_46px3"]
+
+[node name="DebugSettings" type="PanelContainer" unique_id=35497477 node_paths=PackedStringArray("back_button")]
+custom_minimum_size = Vector2(800, 600)
+offset_right = 675.0
+offset_bottom = 255.0
+theme = ExtResource("1_w7kol")
+script = ExtResource("2_46px3")
+back_button = NodePath("VBoxContainer/BackButton")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1670771472]
+layout_mode = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer" unique_id=587878740]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_type_variation = &"PlayerRibbon"
+
+[node name="Label" type="Label" parent="VBoxContainer/PanelContainer" unique_id=1690979224]
+layout_mode = 2
+text = "Completed Quests"
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer" unique_id=1508593035]
+layout_mode = 2
+size_flags_vertical = 3
+follow_focus = true
+horizontal_scroll_mode = 0
+
+[node name="DebugCompletedQuestList" parent="VBoxContainer/ScrollContainer" unique_id=1279772854 instance=ExtResource("2_k06h7")]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="BackButton" type="Button" parent="VBoxContainer" unique_id=751568689]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Back"
+icon = ExtResource("3_46px3")
+flat = true

--- a/scenes/menus/options/components/options.gd
+++ b/scenes/menus/options/components/options.gd
@@ -1,14 +1,17 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
-extends CenterContainer
+extends Control
 
 signal back
 
-@onready var back_button: Button = %BackButton
+@export var back_button: Button
 
 
 func _ready() -> void:
+	visibility_changed.connect(_on_visibility_changed)
 	_on_visibility_changed()
+
+	back_button.pressed.connect(_on_back_button_pressed)
 
 
 func _on_visibility_changed() -> void:

--- a/scenes/menus/options/options.tscn
+++ b/scenes/menus/options/options.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://tahf2q1d3e74" path="res://scenes/menus/options/components/video_settings.tscn" id="4_cw13b"]
 [ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="5_qdq3g"]
 
-[node name="Options" type="CenterContainer" unique_id=2066163370]
+[node name="Options" type="CenterContainer" unique_id=2066163370 node_paths=PackedStringArray("back_button")]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -14,6 +14,7 @@ grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_ptihp")
 script = ExtResource("2_cw13b")
+back_button = NodePath("PanelContainer/VBoxContainer/BackButton")
 metadata/_tab_index = 1
 
 [node name="PanelContainer" type="PanelContainer" parent="." unique_id=280848008]
@@ -37,6 +38,3 @@ theme_type_variation = &"FlatButton"
 text = "Back"
 icon = ExtResource("5_qdq3g")
 flat = true
-
-[connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
-[connection signal="pressed" from="PanelContainer/VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]

--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -15,6 +15,9 @@ enum Status {
 	BROKEN = 2,
 }
 
+## [Quest] resources must have this filename to be found by the game.
+const FILENAME := "quest.tres"
+
 ## The development status of this quest.
 @export var status: Status = Status.WORK_IN_PROGRESS
 
@@ -50,6 +53,23 @@ enum Status {
 
 ## The animation in [member sprite_frames] to display. This should typically be a looping animation.
 @export var animation_name: StringName = &""
+
+
+## Lists all quests in [param quest_directory]; which is to say, all [Quest]
+## resources named [const FILENAME] which are in an immediate subdirectory of
+## [param quest_directory].
+## [br][br]
+## In Bash terms, this is: [code]$quest_directory/*/quest.tres[/code]
+static func enumerate(quest_directory: String) -> Array[Quest]:
+	var quests: Array[Quest] = []
+
+	for dir in ResourceLoader.list_directory(quest_directory):
+		var quest_path := quest_directory.path_join(dir).path_join(FILENAME)
+		if ResourceLoader.exists(quest_path):
+			var quest: Quest = ResourceLoader.load(quest_path)
+			quests.append(quest)
+
+	return quests
 
 
 func _validate_property(property: Dictionary) -> void:

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -41,20 +41,10 @@ var _navigation_locked: bool = false
 
 
 func _enumerate_quests() -> Array[Quest]:
-	var has_template: bool = false
-	var quests: Array[Quest] = []
-
-	for dir in ResourceLoader.list_directory(quest_directory):
-		var quest_path := quest_directory.path_join(dir).path_join(QUEST_RESOURCE_NAME)
-		if ResourceLoader.exists(quest_path):
-			var quest: Quest = ResourceLoader.load(quest_path)
-			if quest == STORY_QUEST_TEMPLATE:
-				has_template = true
-			else:
-				quests.append(quest)
-
-	if has_template:
-		quests.append(TEMPLATE_QUEST_METADATA)
+	var quests: Array[Quest] = Quest.enumerate(quest_directory)
+	var template_index := quests.find(STORY_QUEST_TEMPLATE)
+	if template_index != -1:
+		quests[template_index] = TEMPLATE_QUEST_METADATA
 
 	return quests
 


### PR DESCRIPTION
We want to start making aspects of the game world react to which quests
have been completed, but currently the only ways to adjust which quests
are marked as having been completed are:

- Complete a quest (marking it as completed)
- Start a new game (marking all quests as not completed)
- Manually edit the save file

Add a menu to the pause screen which allows these to be toggled.
