### PR TITLE
mothsache: Don't make player fall when defeated

### DIFF
--- a/scenes/game_elements/characters/enemies/mothsache/mothsache.gd
+++ b/scenes/game_elements/characters/enemies/mothsache/mothsache.gd
@@ -339,7 +339,7 @@ func _on_attack_radius_body_entered(body: Node2D) -> void:
 
 		if body.has_method("defeat"):
 			var player: Node2D = body
-			player.defeat(true)
+			player.defeat()
 
 
 ## Called when the attack animation finishes.


### PR DESCRIPTION
Passing `true` to `defeat()` causes the player sprite to be scaled
gradually towards 0 during the unravel animation. This is meant to be
used when the player falls into the void. It didn't look right here.
