### PR TITLE
Reset per-scene lights-on state

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -325,7 +325,7 @@ func change_lights(new_lights_on: bool, immediate: bool = false) -> void:
 
 
 ## Clear the per-scene state.
-func clear_per_scane_state() -> void:
+func clear_per_scene_state() -> void:
 	lights_on = false
 
 

--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -141,7 +141,7 @@ func change_to_file(scene_path: String, spawn_point: NodePath = ^"") -> void:
 
 
 func change_to_packed(scene: PackedScene, spawn_point: NodePath = ^"") -> void:
-	GameState.clear_per_scane_state()
+	GameState.clear_per_scene_state()
 
 	if get_tree().change_scene_to_packed(scene) == OK:
 		_set_hash(scene.resource_path)


### PR DESCRIPTION
This state is supposed to be transient, per scene. A Light2D dynamically added to the scene tree could check if the current scene needs the lights on. So it needs to be resetted to its default when switching scenes.

Resolve https://github.com/endlessm/threadbare/issues/2005