### PR TITLE
Rename “A Void” to “The Void”

### DIFF
--- a/scenes/quests/lore_quests/quest_002/quest.tres
+++ b/scenes/quests/lore_quests/quest_002/quest.tres
@@ -16,7 +16,7 @@ animations = [{
 
 [resource]
 script = ExtResource("1_dlhxi")
-title = "A Void"
+title = "The Void"
 description = "StoryWeaver runs away from a growing emptiness that spreads across the land, smothering and swallowing everything it covers."
 first_scene = "uid://bm4ewr8p48x0i"
 sprite_frames = SubResource("SpriteFrames_l1xe8")


### PR DESCRIPTION
I called this quest “A Void” not “The Void” as a reference to the
English translation of a novel by Georges Perec (original French title:
« La Disparition »). This novel (which I have never read) is notably
written without using the letter ‘e’: a difficult task considering it is
the most frequently-used letter in both French and English.

My original description for the quest followed the same constraint:

> Our protagonist bolts from a growing blank that rolls across this
> land, stifling and consuming all that it cloaks.

In commit 67fe109efe45e9950944973baec3ab59656d7ded the description was
rewritten to be more legible & less awkward-sounding – a good change!
Change the title to the less-awkward “The Void” to match.

https://en.wikipedia.org/wiki/A_Void
