### PR TITLE
grappling_hook_powerup: Fix shadowing warning

### DIFF
--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/grappling_hook_powerup.gd
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/grappling_hook_powerup.gd
@@ -15,7 +15,6 @@ func _ready() -> void:
 
 
 func _on_button_item_collected() -> void:
-	var player: Player = get_tree().get_first_node_in_group("player")
 	LongerHook.grant_longer_hook(player)
 
 	# Zoom out the camera when collecting the powerup, because now the player


### PR DESCRIPTION
grappling_hook_powerup: Fix shadowing warning

Playing this scene would issue this warning from line 18:

> The local variable "player" is shadowing an already-declared variable
> at line 9 in the current class.

There is a member variable `player` holding a reference to `%Player`, so
there is no need to look up the player again in the "collected"
callback.
