### PR TITLE
Overlay effects: Rename randomize function

### DIFF
--- a/scenes/game_elements/fx/clouds_shadow/components/clouds_shadow.gd
+++ b/scenes/game_elements/fx/clouds_shadow/components/clouds_shadow.gd
@@ -3,7 +3,7 @@
 @tool
 extends Parallax2D
 
-@export_tool_button("Random Clouds") var randomize_button: Callable = randomize
+@export_tool_button("Random Clouds") var randomize_button: Callable = randomize_effect
 
 @export var _seed: int:
 	set = _set_seed
@@ -28,7 +28,7 @@ func _ready() -> void:
 	_set_seed(_seed)
 
 
-func randomize() -> void:
+func randomize_effect() -> void:
 	await _set_seed(randi())
 
 

--- a/scenes/game_elements/fx/fog/components/fog.gd
+++ b/scenes/game_elements/fx/fog/components/fog.gd
@@ -3,7 +3,7 @@
 @tool
 extends Parallax2D
 
-@export_tool_button("Random Fog") var randomize_button: Callable = randomize
+@export_tool_button("Random Fog") var randomize_button: Callable = randomize_effect
 
 @export var _seed: int:
 	set = _set_seed
@@ -28,7 +28,7 @@ func _ready() -> void:
 	_set_seed(_seed)
 
 
-func randomize() -> void:
+func randomize_effect() -> void:
 	await _set_seed(randi())
 
 

--- a/scenes/game_elements/fx/rain/components/rain.gd
+++ b/scenes/game_elements/fx/rain/components/rain.gd
@@ -3,7 +3,7 @@
 @tool
 extends CanvasLayer
 
-@export_tool_button("Random Rain") var randomize_button: Callable = randomize
+@export_tool_button("Random Rain") var randomize_button: Callable = randomize_effect
 
 @export var _seed: int:
 	set = _set_seed
@@ -27,7 +27,7 @@ func _set_seed(new_seed: int) -> void:
 	gpu_particles_2d.amount_ratio = rain_amount
 
 
-func randomize() -> void:
+func randomize_effect() -> void:
 	_set_seed(randi())
 
 

--- a/scenes/game_elements/fx/time_and_weather/components/time_and_weather.gd
+++ b/scenes/game_elements/fx/time_and_weather/components/time_and_weather.gd
@@ -192,8 +192,8 @@ func _on_lights_off_timer_timeout() -> void:
 
 
 func _on_clouds_shadow_start_timer_timeout() -> void:
-	if clouds_shadow.has_method("randomize"):
-		await clouds_shadow.randomize()
+	if clouds_shadow.has_method("randomize_effect"):
+		await clouds_shadow.randomize_effect()
 	if clouds_shadow.has_method("fade_in"):
 		clouds_shadow.fade_in()
 	_schedule_in_one_day(clouds_shadow_start_timer)
@@ -206,8 +206,8 @@ func _on_clouds_shadow_stop_timer_timeout() -> void:
 
 
 func _on_fog_start_timer_timeout() -> void:
-	if fog.has_method("randomize"):
-		await fog.randomize()
+	if fog.has_method("randomize_effect"):
+		await fog.randomize_effect()
 	if fog.has_method("fade_in"):
 		fog.fade_in()
 	_schedule_in_one_day(fog_start_timer)


### PR DESCRIPTION
To randomize_effect(). This is because there is a randomize() function already in the GlobalScope. And due to a bug [1] the Godot Editor doesn't warn about it.

[1] https://github.com/godotengine/godot/issues/106840