### PR TITLE
Update Still BPM and transitions

### DIFF
--- a/assets/first_party/music/The_Void_Still.ogg.import
+++ b/assets/first_party/music/The_Void_Still.ogg.import
@@ -14,6 +14,6 @@ dest_files=["res://.godot/imported/The_Void_Still.ogg-7e65310155f40ce2f414bd20a7
 
 loop=true
 loop_offset=0.0
-bpm=0.0
+bpm=52.0
 beat_count=0
 bar_beats=4

--- a/scenes/quests/lore_quests/quest_002/components/void_music.tres
+++ b/scenes/quests/lore_quests/quest_002/components/void_music.tres
@@ -30,19 +30,19 @@ clip_5/stream = ExtResource("5_s1krv")
 clip_5/auto_advance = 0
 _transitions = {
 Vector2i(0, 1): {
-"fade_beats": 0.0,
-"fade_mode": 0,
+"fade_beats": 1.0,
+"fade_mode": 2,
 "from_time": 2,
 "to_time": 1
 },
 Vector2i(0, 4): {
-"fade_beats": 2.0,
+"fade_beats": 1.0,
 "fade_mode": 4,
 "from_time": 0,
 "to_time": 2
 },
 Vector2i(0, 5): {
-"fade_beats": 2.0,
+"fade_beats": 1.0,
 "fade_mode": 4,
 "from_time": 0,
 "to_time": 2


### PR DESCRIPTION
Set The Void Still's BPM to 52.

Previously the transition from Still to Bloom/Bloom 2 was a crossfade
over 2 "beats" of whatever Godot defaults to when a clip's BPM is not
set (seconds, I think); change this to 1 beat for a slightly snappier
sound.

Previously the transition from Still to Creep Intro was immediate at
whatever point in Still was playing. Change this to transition at the
next bar of Still. Start Creep Intro immediately and fade out Still for
1 beat.

