### PR TITLE
Ink combat 3: Improve music transition

### DIFF
--- a/assets/first_party/music/Threadbare Loop_Main_Bridge_01.ogg.import
+++ b/assets/first_party/music/Threadbare Loop_Main_Bridge_01.ogg.import
@@ -14,6 +14,6 @@ dest_files=["res://.godot/imported/Threadbare Loop_Main_Bridge_01.ogg-7b041b425c
 
 loop=true
 loop_offset=0
-bpm=0
+bpm=96
 beat_count=0
 bar_beats=4

--- a/assets/first_party/music/Threadbare Loop_Main_Bridge_02.ogg.import
+++ b/assets/first_party/music/Threadbare Loop_Main_Bridge_02.ogg.import
@@ -14,6 +14,6 @@ dest_files=["res://.godot/imported/Threadbare Loop_Main_Bridge_02.ogg-d33e31f7d7
 
 loop=true
 loop_offset=0
-bpm=0
+bpm=96
 beat_count=0
 bar_beats=4

--- a/assets/first_party/music/Threadbare Loop_Main_Cresendo_01.ogg.import
+++ b/assets/first_party/music/Threadbare Loop_Main_Cresendo_01.ogg.import
@@ -14,6 +14,6 @@ dest_files=["res://.godot/imported/Threadbare Loop_Main_Cresendo_01.ogg-3a3ec687
 
 loop=true
 loop_offset=0
-bpm=0
+bpm=96
 beat_count=0
 bar_beats=4

--- a/assets/first_party/music/Threadbare Loop_Main_Intro_01.ogg.import
+++ b/assets/first_party/music/Threadbare Loop_Main_Intro_01.ogg.import
@@ -14,6 +14,6 @@ dest_files=["res://.godot/imported/Threadbare Loop_Main_Intro_01.ogg-51f13fc220c
 
 loop=true
 loop_offset=0
-bpm=0
+bpm=96
 beat_count=0
 bar_beats=4

--- a/assets/first_party/music/Threadbare_Bed.ogg.import
+++ b/assets/first_party/music/Threadbare_Bed.ogg.import
@@ -14,6 +14,6 @@ dest_files=["res://.godot/imported/Threadbare_Bed.ogg-7f8126e919e975b9230b53f13f
 
 loop=true
 loop_offset=0
-bpm=0
+bpm=88.0
 beat_count=0
 bar_beats=4

--- a/assets/first_party/music/Threadbare_Combat.ogg.import
+++ b/assets/first_party/music/Threadbare_Combat.ogg.import
@@ -14,6 +14,6 @@ dest_files=["res://.godot/imported/Threadbare_Combat.ogg-bdb792247e421edd9da8f4c
 
 loop=true
 loop_offset=0
-bpm=0
+bpm=96.0
 beat_count=0
-bar_beats=4
+bar_beats=7

--- a/assets/first_party/music/Threadbare_Main_Loud.ogg.import
+++ b/assets/first_party/music/Threadbare_Main_Loud.ogg.import
@@ -14,6 +14,6 @@ dest_files=["res://.godot/imported/Threadbare_Main_Loud.ogg-369a1cbc2c52cb911a4c
 
 loop=true
 loop_offset=0
-bpm=0
+bpm=96
 beat_count=0
 bar_beats=4

--- a/assets/first_party/music/Threadbare_Main_Quiet.ogg.import
+++ b/assets/first_party/music/Threadbare_Main_Quiet.ogg.import
@@ -13,7 +13,7 @@ dest_files=["res://.godot/imported/Threadbare_Main_Quiet.ogg-19396a260907363581b
 [params]
 
 loop=true
-loop_offset=0
-bpm=0
+loop_offset=0.0
+bpm=96.0
 beat_count=0
 bar_beats=4

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres
@@ -14,8 +14,8 @@ clip_1/auto_advance = 0
 _transitions = {
 Vector2i(0, 1): {
 "fade_beats": 2.0,
-"fade_mode": 3,
-"from_time": 0,
+"fade_mode": 2,
+"from_time": 1,
 "to_time": 1
 }
 }

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="2_je2ou"]
 [ext_resource type="AudioStream" uid="uid://dkgtyb0x1i0m2" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/combat_music.tres" id="2_t7m4v"]
 [ext_resource type="Script" uid="uid://cp54mgi54nywo" path="res://scenes/game_logic/fill_game_logic.gd" id="3_4iw8v"]
+[ext_resource type="Script" uid="uid://c2lx7gvkonxaa" path="res://scenes/game_elements/props/background_music/components/clip_switcher.gd" id="3_7kldn"]
 [ext_resource type="PackedScene" uid="uid://lgu7aeqa7o3r" path="res://scenes/game_elements/props/door/door.tscn" id="4_fgs83"]
 [ext_resource type="TileSet" uid="uid://oynx002hv8tl" path="res://tiles/water.tres" id="4_t7m4v"]
 [ext_resource type="TileSet" uid="uid://bjx3gvah0ycl1" path="res://tiles/foam_2.tres" id="5_1nd14"]
@@ -54,6 +55,11 @@ metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="BackgroundMusic" parent="." unique_id=1639553787 instance=ExtResource("2_je2ou")]
 stream = ExtResource("2_t7m4v")
+
+[node name="ClipSwitcher" type="Node" parent="BackgroundMusic" unique_id=1792251959]
+script = ExtResource("3_7kldn")
+clip = &"cozy"
+metadata/_custom_type_script = "uid://c2lx7gvkonxaa"
 
 [node name="FillGameLogic" type="Node" parent="." unique_id=884862045]
 script = ExtResource("3_4iw8v")
@@ -179,5 +185,5 @@ limit_bottom = 704
 position_smoothing_enabled = true
 editor_draw_limits = true
 
-[connection signal="goal_reached" from="FillGameLogic" to="BackgroundMusic" method="switch_to_clip" binds= [&"cozy"]]
+[connection signal="goal_reached" from="FillGameLogic" to="BackgroundMusic/ClipSwitcher" method="switch"]
 [connection signal="goal_reached" from="FillGameLogic" to="FillGameLogic/LevelCompletedAnimation" method="play" binds= ["goal_completed"]]


### PR DESCRIPTION
Previously the transition between the combat music and the cozy bed when
you complete the challenge was a 2-second crossfade. The problem with
crossfading to the cozy bed is that it has a strong chord on the
downbeat; by crossfading we miss it.

Add BPM and time signature information to the combat music (and to the
other pieces in this suite for good measure). These are by ear, but I
think they're right.

Then configure the combat -> cozy transition to occur at the end of the
current bar, then start the cozy clip at full volume and fade out the
combat clip for 2 beats. (I would prefer it if the FADE_OUT mode meant
"fade out the current clip for 2 beats, *then* start the new one"; it
doesn't, but actually this sounds OK when aligned to the start of a new
bar of the combat music.)

Use a ClipSwitcher rather than the old approach of binding to
BackgroundMusic.switch_to_clip with the extra call argument &"cozy". I
think it's much clearer to have the clip visible in the inspector.
