### PR TITLE
fog, clouds_shadow: Ignore mouse events

### DIFF
--- a/scenes/game_elements/fx/clouds_shadow/clouds_shadow.tscn
+++ b/scenes/game_elements/fx/clouds_shadow/clouds_shadow.tscn
@@ -43,3 +43,4 @@ offset_right = 1024.0
 offset_bottom = 1024.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2

--- a/scenes/game_elements/fx/fog/fog.tscn
+++ b/scenes/game_elements/fx/fog/fog.tscn
@@ -42,3 +42,4 @@ offset_right = 1024.0
 offset_bottom = 1024.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2


### PR DESCRIPTION
fog, clouds_shadow: Ignore mouse events

Previously these would swallow mouse events (e.g. clicks) and so it was
not possible to grapple on a foggy level.
