### PR TITLE
Fray's End: Fix Y-sorting

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -83,7 +83,6 @@ size = Vector2(52, 61)
 size = Vector2(128, 128)
 
 [node name="FraysEnd" type="Node2D" unique_id=1849947277]
-y_sort_enabled = true
 script = ExtResource("1_4gse6")
 metadata/_edit_lock_ = true
 
@@ -173,12 +172,15 @@ tile_set = ExtResource("12_f3823")
 script = ExtResource("14_f3823")
 target = NodePath(".")
 
-[node name="Player" parent="." unique_id=322121009 instance=ExtResource("3_tp7qs")]
+[node name="OnTheGround" type="Node2D" parent="." unique_id=444049774]
+y_sort_enabled = true
+
+[node name="Player" parent="OnTheGround" unique_id=322121009 instance=ExtResource("3_tp7qs")]
 position = Vector2(985, 871)
 player_name = "StoryWeaver"
 sprite_frames = ExtResource("6_06x6x")
 
-[node name="Camera2D" type="Camera2D" parent="Player" unique_id=1804658839]
+[node name="Camera2D" type="Camera2D" parent="OnTheGround/Player" unique_id=1804658839]
 limit_left = 0
 limit_top = 0
 limit_right = 2048
@@ -186,246 +188,949 @@ limit_bottom = 1950
 position_smoothing_enabled = true
 editor_draw_limits = true
 
-[node name="Props" type="Node2D" parent="." unique_id=1456259135]
+[node name="Props" type="Node2D" parent="OnTheGround" unique_id=1456259135]
 y_sort_enabled = true
 
-[node name="Flowerbed" type="Area2D" parent="Props" unique_id=1756580895]
+[node name="Flowerbed" type="Area2D" parent="OnTheGround/Props" unique_id=1756580895]
 y_sort_enabled = true
 position = Vector2(1358.05, 1693.82)
 
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Props/Flowerbed" unique_id=1572957504]
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="OnTheGround/Props/Flowerbed" unique_id=1572957504]
 polygon = PackedVector2Array(80.9502, -52.8169, 81.9502, 73.1831, 145.95, 74.1831, 146.95, 134.183, 476.95, 136.183, 480.95, 204.183, -87.05, 210.18, -91.05, -178.82, 10.95, -176.82, 11.649, -54.5072)
 disabled = true
 
-[node name="AreaFiller" type="Node" parent="Props/Flowerbed" unique_id=2112962760]
+[node name="AreaFiller" type="Node" parent="OnTheGround/Props/Flowerbed" unique_id=2112962760]
 script = ExtResource("38_cjmkx")
 scenes = Array[PackedScene]([ExtResource("45_cjmkx")])
 metadata/_custom_type_script = "uid://bdhjixygupit1"
 
-[node name="Flower" parent="Props/Flowerbed" unique_id=1988763718 instance=ExtResource("45_cjmkx")]
+[node name="Flower" parent="OnTheGround/Props/Flowerbed" unique_id=1988763718 instance=ExtResource("45_cjmkx")]
 position = Vector2(145.987, 76.4082)
 
-[node name="Flower2" parent="Props/Flowerbed" unique_id=1548333974 instance=ExtResource("45_cjmkx")]
+[node name="Flower2" parent="OnTheGround/Props/Flowerbed" unique_id=1548333974 instance=ExtResource("45_cjmkx")]
 position = Vector2(162.489, 161.379)
 
-[node name="Flower3" parent="Props/Flowerbed" unique_id=2134303870 instance=ExtResource("45_cjmkx")]
+[node name="Flower3" parent="OnTheGround/Props/Flowerbed" unique_id=2134303870 instance=ExtResource("45_cjmkx")]
 position = Vector2(57.5313, 127.062)
 
-[node name="Flower4" parent="Props/Flowerbed" unique_id=1752128493 instance=ExtResource("45_cjmkx")]
+[node name="Flower4" parent="OnTheGround/Props/Flowerbed" unique_id=1752128493 instance=ExtResource("45_cjmkx")]
 position = Vector2(82.1759, 198.141)
 
-[node name="Flower5" parent="Props/Flowerbed" unique_id=1943009921 instance=ExtResource("45_cjmkx")]
+[node name="Flower5" parent="OnTheGround/Props/Flowerbed" unique_id=1943009921 instance=ExtResource("45_cjmkx")]
 position = Vector2(80.8003, -8.4669)
 
-[node name="Flower6" parent="Props/Flowerbed" unique_id=745432647 instance=ExtResource("45_cjmkx")]
+[node name="Flower6" parent="OnTheGround/Props/Flowerbed" unique_id=745432647 instance=ExtResource("45_cjmkx")]
 position = Vector2(74.8754, 58.9827)
 
-[node name="Flower7" parent="Props/Flowerbed" unique_id=138652301 instance=ExtResource("45_cjmkx")]
+[node name="Flower7" parent="OnTheGround/Props/Flowerbed" unique_id=138652301 instance=ExtResource("45_cjmkx")]
 position = Vector2(-4.8579, -36.5672)
 
-[node name="Flower8" parent="Props/Flowerbed" unique_id=1436937558 instance=ExtResource("45_cjmkx")]
+[node name="Flower8" parent="OnTheGround/Props/Flowerbed" unique_id=1436937558 instance=ExtResource("45_cjmkx")]
 position = Vector2(-32.8836, 174.97)
 
-[node name="Flower9" parent="Props/Flowerbed" unique_id=1859873472 instance=ExtResource("45_cjmkx")]
+[node name="Flower9" parent="OnTheGround/Props/Flowerbed" unique_id=1859873472 instance=ExtResource("45_cjmkx")]
 position = Vector2(-15.228, 43.4394)
 
-[node name="Flower10" parent="Props/Flowerbed" unique_id=1386057877 instance=ExtResource("45_cjmkx")]
+[node name="Flower10" parent="OnTheGround/Props/Flowerbed" unique_id=1386057877 instance=ExtResource("45_cjmkx")]
 position = Vector2(2.49678, -154.987)
 
-[node name="Flower11" parent="Props/Flowerbed" unique_id=1994124578 instance=ExtResource("45_cjmkx")]
+[node name="Flower11" parent="OnTheGround/Props/Flowerbed" unique_id=1994124578 instance=ExtResource("45_cjmkx")]
 position = Vector2(-88.8473, -124.21)
 
-[node name="Flower12" parent="Props/Flowerbed" unique_id=1382502556 instance=ExtResource("45_cjmkx")]
+[node name="Flower12" parent="OnTheGround/Props/Flowerbed" unique_id=1382502556 instance=ExtResource("45_cjmkx")]
 position = Vector2(-69.4298, -27.7301)
 
-[node name="Flower13" parent="Props/Flowerbed" unique_id=1907674779 instance=ExtResource("45_cjmkx")]
+[node name="Flower13" parent="OnTheGround/Props/Flowerbed" unique_id=1907674779 instance=ExtResource("45_cjmkx")]
 position = Vector2(-58.1484, 99.4569)
 
-[node name="Flower14" parent="Props/Flowerbed" unique_id=695590111 instance=ExtResource("45_cjmkx")]
+[node name="Flower14" parent="OnTheGround/Props/Flowerbed" unique_id=695590111 instance=ExtResource("45_cjmkx")]
 position = Vector2(242.783, 153.786)
 
-[node name="Flower15" parent="Props/Flowerbed" unique_id=115557080 instance=ExtResource("45_cjmkx")]
+[node name="Flower15" parent="OnTheGround/Props/Flowerbed" unique_id=115557080 instance=ExtResource("45_cjmkx")]
 position = Vector2(360.015, 195.757)
 
-[node name="Flower16" parent="Props/Flowerbed" unique_id=1528302531 instance=ExtResource("45_cjmkx")]
+[node name="Flower16" parent="OnTheGround/Props/Flowerbed" unique_id=1528302531 instance=ExtResource("45_cjmkx")]
 position = Vector2(290.57, 206.026)
 
-[node name="Flower17" parent="Props/Flowerbed" unique_id=1997626178 instance=ExtResource("45_cjmkx")]
+[node name="Flower17" parent="OnTheGround/Props/Flowerbed" unique_id=1997626178 instance=ExtResource("45_cjmkx")]
 position = Vector2(465.862, 159.547)
 
-[node name="HidingMushroom" parent="Props" unique_id=806733559 instance=ExtResource("11_jqkod")]
+[node name="HidingMushroom" parent="OnTheGround/Props" unique_id=806733559 instance=ExtResource("11_jqkod")]
 position = Vector2(906, 1516)
 
-[node name="HidingMushroom2" parent="Props" unique_id=320834486 instance=ExtResource("11_jqkod")]
+[node name="HidingMushroom2" parent="OnTheGround/Props" unique_id=320834486 instance=ExtResource("11_jqkod")]
 position = Vector2(1061, 1643)
 
-[node name="HidingMushroom3" parent="Props" unique_id=47733831 instance=ExtResource("11_jqkod")]
+[node name="HidingMushroom3" parent="OnTheGround/Props" unique_id=47733831 instance=ExtResource("11_jqkod")]
 position = Vector2(929, 1235)
 
-[node name="HidingMushroom4" parent="Props" unique_id=631928334 instance=ExtResource("11_jqkod")]
+[node name="HidingMushroom4" parent="OnTheGround/Props" unique_id=631928334 instance=ExtResource("11_jqkod")]
 position = Vector2(1049, 1193)
 
-[node name="Books" parent="Props" unique_id=605503809 instance=ExtResource("12_06x6x")]
+[node name="Books" parent="OnTheGround/Props" unique_id=605503809 instance=ExtResource("12_06x6x")]
 position = Vector2(616, 611)
 flip_h = true
 
-[node name="Books2" parent="Props" unique_id=684398653 instance=ExtResource("12_06x6x")]
+[node name="Books2" parent="OnTheGround/Props" unique_id=684398653 instance=ExtResource("12_06x6x")]
 position = Vector2(584, 597)
 
-[node name="Books3" parent="Props" unique_id=78212091 instance=ExtResource("12_06x6x")]
+[node name="Books3" parent="OnTheGround/Props" unique_id=78212091 instance=ExtResource("12_06x6x")]
 position = Vector2(625, 587)
 
-[node name="Books4" parent="Props" unique_id=1621819696 instance=ExtResource("12_06x6x")]
+[node name="Books4" parent="OnTheGround/Props" unique_id=1621819696 instance=ExtResource("12_06x6x")]
 position = Vector2(615, 611)
 texture = ExtResource("13_xt3dw")
 offset = Vector2(0, -32)
 
-[node name="Books5" parent="Props" unique_id=392060181 instance=ExtResource("12_06x6x")]
+[node name="Books5" parent="OnTheGround/Props" unique_id=392060181 instance=ExtResource("12_06x6x")]
 position = Vector2(1390, 607)
 texture = ExtResource("13_xt3dw")
 flip_h = true
 
-[node name="Books6" parent="Props" unique_id=2006272186 instance=ExtResource("12_06x6x")]
+[node name="Books6" parent="OnTheGround/Props" unique_id=2006272186 instance=ExtResource("12_06x6x")]
 position = Vector2(1380, 606)
 offset = Vector2(0, -38.745)
 
-[node name="Books7" parent="Props" unique_id=895530811 instance=ExtResource("12_06x6x")]
+[node name="Books7" parent="OnTheGround/Props" unique_id=895530811 instance=ExtResource("12_06x6x")]
 position = Vector2(1217, 596)
 texture = ExtResource("13_xt3dw")
 
-[node name="Books8" parent="Props" unique_id=109380584 instance=ExtResource("12_06x6x")]
+[node name="Books8" parent="OnTheGround/Props" unique_id=109380584 instance=ExtResource("12_06x6x")]
 position = Vector2(1247, 583)
 flip_h = true
 
-[node name="Books9" parent="Props" unique_id=725853317 instance=ExtResource("12_06x6x")]
+[node name="Books9" parent="OnTheGround/Props" unique_id=725853317 instance=ExtResource("12_06x6x")]
 position = Vector2(764, 593)
 texture = ExtResource("13_xt3dw")
 flip_h = true
 
-[node name="Books10" parent="Props" unique_id=275297103 instance=ExtResource("12_06x6x")]
+[node name="Books10" parent="OnTheGround/Props" unique_id=275297103 instance=ExtResource("12_06x6x")]
 position = Vector2(781, 614)
 
-[node name="Mushroom" type="Sprite2D" parent="Props" unique_id=1958366461]
+[node name="Mushroom" type="Sprite2D" parent="OnTheGround/Props" unique_id=1958366461]
 position = Vector2(501, 679)
 texture = ExtResource("28_6r0j2")
 
-[node name="Buildings" type="Node2D" parent="." unique_id=1875429791]
+[node name="Buildings" type="Node2D" parent="OnTheGround" unique_id=1875429791]
 y_sort_enabled = true
 
-[node name="House_1" parent="Buildings" unique_id=1159586657 instance=ExtResource("5_5jg1p")]
+[node name="House_1" parent="OnTheGround/Buildings" unique_id=1159586657 instance=ExtResource("5_5jg1p")]
 position = Vector2(1600, 815)
 texture = ExtResource("5_uhynt")
 
-[node name="House_2" parent="Buildings" unique_id=821648560 instance=ExtResource("15_uhynt")]
+[node name="House_2" parent="OnTheGround/Buildings" unique_id=821648560 instance=ExtResource("15_uhynt")]
 position = Vector2(1760, 810)
 texture = ExtResource("5_uojly")
 
-[node name="House_3" parent="Buildings" unique_id=2108055439 instance=ExtResource("5_5jg1p")]
+[node name="House_3" parent="OnTheGround/Buildings" unique_id=2108055439 instance=ExtResource("5_5jg1p")]
 position = Vector2(316, 1043)
 
-[node name="House_4" parent="Buildings" unique_id=1336347029 instance=ExtResource("15_uhynt")]
+[node name="House_4" parent="OnTheGround/Buildings" unique_id=1336347029 instance=ExtResource("15_uhynt")]
 position = Vector2(352, 673)
 texture = ExtResource("6_uhynt")
 
-[node name="House_5" parent="Buildings" unique_id=32389067 instance=ExtResource("5_5jg1p")]
+[node name="House_5" parent="OnTheGround/Buildings" unique_id=32389067 instance=ExtResource("5_5jg1p")]
 position = Vector2(176, 626)
 texture = ExtResource("6_ojp30")
 
-[node name="House_6" parent="Buildings" unique_id=1538226071 instance=ExtResource("5_5jg1p")]
+[node name="House_6" parent="OnTheGround/Buildings" unique_id=1538226071 instance=ExtResource("5_5jg1p")]
 position = Vector2(227, 832)
 texture = ExtResource("5_uhynt")
 
-[node name="House_7" parent="Buildings" unique_id=2109293750 instance=ExtResource("5_5jg1p")]
+[node name="House_7" parent="OnTheGround/Buildings" unique_id=2109293750 instance=ExtResource("5_5jg1p")]
 position = Vector2(1565, 1110)
 
-[node name="House_8" parent="Buildings" unique_id=2122984790 instance=ExtResource("15_uhynt")]
+[node name="House_8" parent="OnTheGround/Buildings" unique_id=2122984790 instance=ExtResource("15_uhynt")]
 position = Vector2(480, 1043)
 
-[node name="House_9" parent="Buildings" unique_id=679799188 instance=ExtResource("5_5jg1p")]
+[node name="House_9" parent="OnTheGround/Buildings" unique_id=679799188 instance=ExtResource("5_5jg1p")]
 position = Vector2(781, 1095)
 texture = ExtResource("5_uhynt")
 
-[node name="House_10" parent="Buildings" unique_id=1796299989 instance=ExtResource("5_5jg1p")]
+[node name="House_10" parent="OnTheGround/Buildings" unique_id=1796299989 instance=ExtResource("5_5jg1p")]
 position = Vector2(1758, 1185)
 texture = ExtResource("5_uhynt")
 
-[node name="NPCs" type="Node2D" parent="." unique_id=1415886134]
+[node name="NPCs" type="Node2D" parent="OnTheGround" unique_id=1415886134]
 y_sort_enabled = true
 
-[node name="LoreQuestElder" parent="NPCs" unique_id=1976657330 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_xt3dw")]
+[node name="LoreQuestElder" parent="OnTheGround/NPCs" unique_id=1976657330 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_xt3dw")]
 position = Vector2(690, 600)
 eternal_loom = NodePath("../../EternalLoom")
 
-[node name="StoryQuestElder" parent="NPCs" unique_id=481001643 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_jqkod")]
+[node name="StoryQuestElder" parent="OnTheGround/NPCs" unique_id=481001643 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_jqkod")]
 position = Vector2(1310, 598)
 eternal_loom = NodePath("../../EternalLoom")
 
-[node name="TemplateElder" parent="NPCs" unique_id=45322364 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("43_ppslc")]
+[node name="TemplateElder" parent="OnTheGround/NPCs" unique_id=45322364 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("43_ppslc")]
 position = Vector2(1455, 493)
 eternal_loom = NodePath("../../EternalLoom")
 
-[node name="Axeman" parent="NPCs" unique_id=1020611644 instance=ExtResource("17_0a1i7")]
+[node name="Axeman" parent="OnTheGround/NPCs" unique_id=1020611644 instance=ExtResource("17_0a1i7")]
 position = Vector2(1506, 1263)
 
-[node name="Hammerman" parent="NPCs" unique_id=1228849708 instance=ExtResource("19_yntpr")]
+[node name="Hammerman" parent="OnTheGround/NPCs" unique_id=1228849708 instance=ExtResource("19_yntpr")]
 position = Vector2(1663, 1102)
 
-[node name="Farmer" parent="NPCs" unique_id=1098678013 instance=ExtResource("54_duxxr")]
+[node name="Farmer" parent="OnTheGround/NPCs" unique_id=1098678013 instance=ExtResource("54_duxxr")]
 position = Vector2(1625, 625)
 scale = Vector2(-1, 1)
 character_seed = 3442244821
 look_at_side = 1
 
-[node name="TalkBehavior" type="Node" parent="NPCs/Farmer" unique_id=732454003 node_paths=PackedStringArray("interact_area")]
+[node name="TalkBehavior" type="Node" parent="OnTheGround/NPCs/Farmer" unique_id=732454003 node_paths=PackedStringArray("interact_area")]
 script = ExtResource("56_ojao8")
 dialogue = ExtResource("25_6r0j2")
 interact_area = NodePath("../InteractArea")
 metadata/_custom_type_script = "uid://edcifob4jc4s"
 
-[node name="InteractArea" parent="NPCs/Farmer" unique_id=248145530 instance=ExtResource("55_2vvub")]
+[node name="InteractArea" parent="OnTheGround/NPCs/Farmer" unique_id=248145530 instance=ExtResource("55_2vvub")]
 visible = false
 interact_label_position = Vector2(0, -100)
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="NPCs/Farmer/InteractArea" unique_id=1727136394]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/NPCs/Farmer/InteractArea" unique_id=1727136394]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_duxxr")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
-[node name="FarmersPartner" parent="NPCs" unique_id=1246028381 instance=ExtResource("54_duxxr")]
+[node name="FarmersPartner" parent="OnTheGround/NPCs" unique_id=1246028381 instance=ExtResource("54_duxxr")]
 position = Vector2(1638, 841)
 scale = Vector2(-1, 1)
 character_seed = 3260235337
 look_at_side = 1
 
-[node name="GardenerA" parent="NPCs" unique_id=1887606289 instance=ExtResource("54_duxxr")]
+[node name="GardenerA" parent="OnTheGround/NPCs" unique_id=1887606289 instance=ExtResource("54_duxxr")]
 position = Vector2(199, 899)
 character_seed = 2422434786
 
-[node name="TalkBehavior" type="Node" parent="NPCs/GardenerA" unique_id=1669484224 node_paths=PackedStringArray("interact_area", "extra_context")]
+[node name="TalkBehavior" type="Node" parent="OnTheGround/NPCs/GardenerA" unique_id=1669484224 node_paths=PackedStringArray("interact_area", "extra_context")]
 script = ExtResource("56_ojao8")
 dialogue = ExtResource("34_ulm71")
 interact_area = NodePath("../InteractArea")
 extra_context = [NodePath("../../../WestPath/Unlocker")]
 metadata/_custom_type_script = "uid://edcifob4jc4s"
 
-[node name="InteractArea" parent="NPCs/GardenerA" unique_id=1100609138 instance=ExtResource("55_2vvub")]
+[node name="InteractArea" parent="OnTheGround/NPCs/GardenerA" unique_id=1100609138 instance=ExtResource("55_2vvub")]
 visible = false
 interact_label_position = Vector2(0, -100)
 action = "Talk to Marie"
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="NPCs/GardenerA/InteractArea" unique_id=1159647598]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/NPCs/GardenerA/InteractArea" unique_id=1159647598]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_duxxr")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
-[node name="GardenerB" parent="NPCs" unique_id=514890698 instance=ExtResource("54_duxxr")]
+[node name="GardenerB" parent="OnTheGround/NPCs" unique_id=514890698 instance=ExtResource("54_duxxr")]
 position = Vector2(268, 894)
 scale = Vector2(-1, 1)
 character_seed = 3363471871
 look_at_side = 1
 
-[node name="Cat" parent="NPCs" unique_id=1091997689 instance=ExtResource("52_ppslc")]
+[node name="Cat" parent="OnTheGround/NPCs" unique_id=1091997689 instance=ExtResource("52_ppslc")]
 position = Vector2(267, 650)
+
+[node name="EternalLoom" parent="OnTheGround" unique_id=17061783 instance=ExtResource("16_ojp30")]
+unique_name_in_owner = true
+position = Vector2(993, 485)
+scale = Vector2(0.9, 0.9)
+
+[node name="ForestLimit" type="StaticBody2D" parent="OnTheGround" unique_id=1908977889]
+position = Vector2(972, 2047)
+scale = Vector2(1.10441, 1.00725)
+collision_layer = 16
+collision_mask = 0
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="OnTheGround/ForestLimit" unique_id=748237013]
+position = Vector2(-2.33667, 6.93182)
+scale = Vector2(1.00152, 1.02166)
+polygon = PackedVector2Array(-877.343, -208.91, -817.673, -167.124, -758.004, -191.418, -697.43, -150.605, -638.664, -170.04, -579.899, -209.882, -460.559, -201.136, -390.04, -228.345, -324.042, -206.966, -255.332, -160.322, -168.539, -205.023, -99.8287, -193.362, -2.18738, -175.87, 55.6742, -183.644, 109.919, -223.486, 171.397, -226.401, 217.506, -200.164, 320.572, -186.559, 404.652, -186.559, 505.005, -189.475, 517.662, -237.091, 589.455, -238.273, 670.946, -241.251, 812.201, -217.423, 889.163, -140.978, 974.222, 0.017334, -874.675, -0.992798)
+
+[node name="CollisionPolygon2D2" type="CollisionPolygon2D" parent="OnTheGround/ForestLimit" unique_id=188105721]
+position = Vector2(6.10352e-05, -1792.01)
+scale = Vector2(1.00305, 1)
+polygon = PackedVector2Array(-873.82, 17.8702, -689.668, 200.546, -618.354, 169.769, -545.235, 221.395, -473.921, 218.416, -396.288, 198.56, -292.477, 203.524, -221.163, 234.301, -112.838, 248.2, 16.2487, 229.337, 102.908, 234.301, 180.541, 220.402, 250.952, 228.344, 366.499, 163.812, 447.742, 157.855, 557.873, 112.186, 637.311, 51.6255, 710.43, 88.3592, 853.058, 87.3664, 974.02, -238.273, -881.944, -234.302)
+
+[node name="Trees" type="Node2D" parent="OnTheGround" unique_id=378434157]
+y_sort_enabled = true
+metadata/_edit_lock_ = true
+
+[node name="Tree" parent="OnTheGround/Trees" unique_id=1932501761 instance=ExtResource("7_7v00g")]
+position = Vector2(1376, 405)
+scale = Vector2(1.001, 1.001)
+
+[node name="Tree3" parent="OnTheGround/Trees" unique_id=1678596388 instance=ExtResource("7_7v00g")]
+position = Vector2(323.669, 1963.03)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree4" parent="OnTheGround/Trees" unique_id=530347632 instance=ExtResource("7_7v00g")]
+position = Vector2(689.696, 2027.02)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree5" parent="OnTheGround/Trees" unique_id=1674843860 instance=ExtResource("7_7v00g")]
+position = Vector2(552.436, 1940.99)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree6" parent="OnTheGround/Trees" unique_id=79446423 instance=ExtResource("7_7v00g")]
+position = Vector2(802.62, 1968.27)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree7" parent="OnTheGround/Trees" unique_id=649963827 instance=ExtResource("7_7v00g")]
+position = Vector2(948.642, 1993.45)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree8" parent="OnTheGround/Trees" unique_id=500116567 instance=ExtResource("7_7v00g")]
+position = Vector2(1178.38, 2021.78)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree10" parent="OnTheGround/Trees" unique_id=1207688304 instance=ExtResource("7_7v00g")]
+position = Vector2(1064.49, 2012.34)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree11" parent="OnTheGround/Trees" unique_id=1813349792 instance=ExtResource("7_7v00g")]
+position = Vector2(1669.99, 253.919)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree12" parent="OnTheGround/Trees" unique_id=142989831 instance=ExtResource("7_7v00g")]
+position = Vector2(1083.96, 1949.38)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree13" parent="OnTheGround/Trees" unique_id=831282679 instance=ExtResource("7_7v00g")]
+position = Vector2(1234.84, 2008.14)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree14" parent="OnTheGround/Trees" unique_id=1307485281 instance=ExtResource("7_7v00g")]
+position = Vector2(1875.39, 905.457)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree15" parent="OnTheGround/Trees" unique_id=2053677081 instance=ExtResource("7_7v00g")]
+position = Vector2(1389.63, 1982.96)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree16" parent="OnTheGround/Trees" unique_id=2124166383 instance=ExtResource("7_7v00g")]
+position = Vector2(403.493, 416.541)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree17" parent="OnTheGround/Trees" unique_id=1427257925 instance=ExtResource("7_7v00g")]
+position = Vector2(402.52, 467.951)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree74" parent="OnTheGround/Trees" unique_id=1148920514 instance=ExtResource("7_7v00g")]
+position = Vector2(702, 529)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree18" parent="OnTheGround/Trees" unique_id=1024302850 instance=ExtResource("7_7v00g")]
+position = Vector2(479.425, 461.655)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree19" parent="OnTheGround/Trees" unique_id=549093584 instance=ExtResource("7_7v00g")]
+position = Vector2(489.16, 403.951)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree73" parent="OnTheGround/Trees" unique_id=202446030 instance=ExtResource("7_7v00g")]
+position = Vector2(489.16, 403.951)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree20" parent="OnTheGround/Trees" unique_id=1987312795 instance=ExtResource("7_7v00g")]
+position = Vector2(747.132, 464.803)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree21" parent="OnTheGround/Trees" unique_id=1909086150 instance=ExtResource("7_7v00g")]
+position = Vector2(548.542, 376.672)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree23" parent="OnTheGround/Trees" unique_id=565373046 instance=ExtResource("7_7v00g")]
+position = Vector2(559.25, 445.918)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree71" parent="OnTheGround/Trees" unique_id=508746342 instance=ExtResource("7_7v00g")]
+position = Vector2(1322, 535)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree24" parent="OnTheGround/Trees" unique_id=1413823818 instance=ExtResource("7_7v00g")]
+position = Vector2(411.281, 1993.45)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree25" parent="OnTheGround/Trees" unique_id=622131440 instance=ExtResource("7_7v00g")]
+position = Vector2(1426.62, 377.721)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree26" parent="OnTheGround/Trees" unique_id=1149585713 instance=ExtResource("7_7v00g")]
+position = Vector2(878.552, 2013.39)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree30" parent="OnTheGround/Trees" unique_id=1360494059 instance=ExtResource("7_7v00g")]
+position = Vector2(960.324, 2041.72)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree31" parent="OnTheGround/Trees" unique_id=217219671 instance=ExtResource("7_7v00g")]
+position = Vector2(1377.95, 1170.9)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree32" parent="OnTheGround/Trees" unique_id=921811469 instance=ExtResource("7_7v00g")]
+position = Vector2(1160.86, 1940.99)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree33" parent="OnTheGround/Trees" unique_id=275476476 instance=ExtResource("7_7v00g")]
+position = Vector2(1744.95, 308.476)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree36" parent="OnTheGround/Trees" unique_id=1997957129 instance=ExtResource("7_7v00g")]
+position = Vector2(1510.34, 380.869)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree37" parent="OnTheGround/Trees" unique_id=1733761308 instance=ExtResource("7_7v00g")]
+position = Vector2(1579.46, 346.246)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree38" parent="OnTheGround/Trees" unique_id=794097989 instance=ExtResource("7_7v00g")]
+position = Vector2(78.3536, 2020.73)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree39" parent="OnTheGround/Trees" unique_id=1427896511 instance=ExtResource("7_7v00g")]
+position = Vector2(1289.36, 410.246)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree41" parent="OnTheGround/Trees" unique_id=1126274595 instance=ExtResource("7_7v00g")]
+position = Vector2(1093.69, 352.541)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree42" parent="OnTheGround/Trees" unique_id=1219058508 instance=ExtResource("7_7v00g")]
+position = Vector2(240.926, 446.967)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree45" parent="OnTheGround/Trees" unique_id=1331885057 instance=ExtResource("7_7v00g")]
+position = Vector2(343.138, 414.443)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree46" parent="OnTheGround/Trees" unique_id=1299102072 instance=ExtResource("7_7v00g")]
+position = Vector2(281.807, 405)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree47" parent="OnTheGround/Trees" unique_id=1431325735 instance=ExtResource("7_7v00g")]
+position = Vector2(743.238, 1993.45)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree48" parent="OnTheGround/Trees" unique_id=512917549 instance=ExtResource("7_7v00g")]
+position = Vector2(129.945, 1990.3)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree49" parent="OnTheGround/Trees" unique_id=984311786 instance=ExtResource("7_7v00g")]
+position = Vector2(1439, 1255)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree76" parent="OnTheGround/Trees" unique_id=371398351 instance=ExtResource("7_7v00g")]
+position = Vector2(740.431, 174.365)
+scale = Vector2(1.003, 1.003)
+
+[node name="Tree50" parent="OnTheGround/Trees" unique_id=1448306675 instance=ExtResource("7_7v00g")]
+position = Vector2(1249.45, 467.951)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree51" parent="OnTheGround/Trees" unique_id=1240948872 instance=ExtResource("7_7v00g")]
+position = Vector2(1339.01, 374.574)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree52" parent="OnTheGround/Trees" unique_id=233056165 instance=ExtResource("7_7v00g")]
+position = Vector2(224.37, 2044.86)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree53" parent="OnTheGround/Trees" unique_id=1003033914 instance=ExtResource("7_7v00g")]
+position = Vector2(614.738, 1989.25)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree54" parent="OnTheGround/Trees" unique_id=2052048686 instance=ExtResource("7_7v00g")]
+position = Vector2(1807.25, 354.64)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree55" parent="OnTheGround/Trees" unique_id=539355872 instance=ExtResource("7_7v00g")]
+position = Vector2(1610.61, 248.673)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree56" parent="OnTheGround/Trees" unique_id=1903601485 instance=ExtResource("7_7v00g")]
+position = Vector2(1850, 829)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree57" parent="OnTheGround/Trees" unique_id=1346125759 instance=ExtResource("7_7v00g")]
+position = Vector2(1464.59, 1990.3)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree58" parent="OnTheGround/Trees" unique_id=2117949852 instance=ExtResource("7_7v00g")]
+position = Vector2(1318.56, 1994.5)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree59" parent="OnTheGround/Trees" unique_id=1111374746 instance=ExtResource("7_7v00g")]
+position = Vector2(1617.42, 1995.55)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree60" parent="OnTheGround/Trees" unique_id=1733767052 instance=ExtResource("7_7v00g")]
+position = Vector2(1494.76, 1998.69)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree61" parent="OnTheGround/Trees" unique_id=1069014224 instance=ExtResource("7_7v00g")]
+position = Vector2(1816.99, 1967.22)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree62" parent="OnTheGround/Trees" unique_id=161458005 instance=ExtResource("7_7v00g")]
+position = Vector2(1758.58, 1981.91)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree63" parent="OnTheGround/Trees" unique_id=2128417183 instance=ExtResource("7_7v00g")]
+position = Vector2(695.537, 431.229)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree64" parent="OnTheGround/Trees" unique_id=1470271340 instance=ExtResource("7_7v00g")]
+position = Vector2(630.314, 421.787)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree65" parent="OnTheGround/Trees" unique_id=1237537773 instance=ExtResource("7_7v00g")]
+position = Vector2(873.684, 459.557)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree66" parent="OnTheGround/Trees" unique_id=192479901 instance=ExtResource("7_7v00g")]
+position = Vector2(814.302, 473.196)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree72" parent="OnTheGround/Trees" unique_id=30595985 instance=ExtResource("7_7v00g")]
+position = Vector2(138.704, 1164.6)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree75" parent="OnTheGround/Trees" unique_id=1265010944 instance=ExtResource("7_7v00g")]
+position = Vector2(384.998, 1028.21)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree67" parent="OnTheGround/Trees" unique_id=1384953353 instance=ExtResource("7_7v00g")]
+position = Vector2(1951, 552)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree68" parent="OnTheGround/Trees" unique_id=2100997314 instance=ExtResource("7_7v00g")]
+position = Vector2(478.451, 1988.2)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree69" parent="OnTheGround/Trees" unique_id=877766008 instance=ExtResource("7_7v00g")]
+position = Vector2(176.672, 2049.05)
+scale = Vector2(1.002, 1.002)
+
+[node name="Tree70" parent="OnTheGround/Trees" unique_id=1280154167 instance=ExtResource("7_7v00g")]
+position = Vector2(1173.52, 441.721)
+scale = Vector2(1.002, 1.002)
+
+[node name="Bushes" type="Node2D" parent="OnTheGround" unique_id=2142789308]
+y_sort_enabled = true
+metadata/_edit_lock_ = true
+
+[node name="Bush" parent="OnTheGround/Bushes" unique_id=691594667 instance=ExtResource("18_yntpr")]
+position = Vector2(720, 1111)
+
+[node name="Bush2" parent="OnTheGround/Bushes" unique_id=674809064 instance=ExtResource("18_yntpr")]
+position = Vector2(702, 1128)
+scale = Vector2(0.4, 0.4)
+
+[node name="Bush3" parent="OnTheGround/Bushes" unique_id=1790836883 instance=ExtResource("18_yntpr")]
+position = Vector2(1813, 1197)
+
+[node name="Bush4" parent="OnTheGround/Bushes" unique_id=685970372 instance=ExtResource("18_yntpr")]
+position = Vector2(1828, 1225)
+scale = Vector2(0.8, 0.8)
+
+[node name="Bush5" parent="OnTheGround/Bushes" unique_id=1814837063 instance=ExtResource("18_yntpr")]
+position = Vector2(1803, 1275)
+scale = Vector2(0.6, 0.6)
+
+[node name="Bush6" parent="OnTheGround/Bushes" unique_id=681414570 instance=ExtResource("18_yntpr")]
+position = Vector2(225, 469)
+
+[node name="Bush7" parent="OnTheGround/Bushes" unique_id=507391137 instance=ExtResource("18_yntpr")]
+position = Vector2(242, 480)
+scale = Vector2(0.6, 0.6)
+
+[node name="Bush8" parent="OnTheGround/Bushes" unique_id=113159105 instance=ExtResource("18_yntpr")]
+position = Vector2(364, 480)
+scale = Vector2(0.6, 0.6)
+
+[node name="Bush9" parent="OnTheGround/Bushes" unique_id=991872612 instance=ExtResource("18_yntpr")]
+position = Vector2(192, 521)
+scale = Vector2(0.6, 0.6)
+
+[node name="Bush10" parent="OnTheGround/Bushes" unique_id=1741388599 instance=ExtResource("18_yntpr")]
+position = Vector2(383, 485)
+scale = Vector2(0.6, 0.6)
+
+[node name="Bush11" parent="OnTheGround/Bushes" unique_id=258553976 instance=ExtResource("18_yntpr")]
+position = Vector2(593, 402)
+
+[node name="Bush12" parent="OnTheGround/Bushes" unique_id=331374579 instance=ExtResource("18_yntpr")]
+position = Vector2(618, 392)
+
+[node name="Bush13" parent="OnTheGround/Bushes" unique_id=1819127771 instance=ExtResource("18_yntpr")]
+position = Vector2(703, 401)
+
+[node name="Bush14" parent="OnTheGround/Bushes" unique_id=1799152780 instance=ExtResource("18_yntpr")]
+position = Vector2(838, 479)
+
+[node name="Bush15" parent="OnTheGround/Bushes" unique_id=907391532 instance=ExtResource("18_yntpr")]
+position = Vector2(777, 572)
+scale = Vector2(0.8, 0.8)
+
+[node name="Bush17" parent="OnTheGround/Bushes" unique_id=2079878338 instance=ExtResource("18_yntpr")]
+position = Vector2(346, 1052)
+scale = Vector2(0.5, 0.5)
+
+[node name="Bush18" parent="OnTheGround/Bushes" unique_id=500874609 instance=ExtResource("18_yntpr")]
+position = Vector2(346, 1066)
+scale = Vector2(0.4, 0.4)
+
+[node name="Bush19" parent="OnTheGround/Bushes" unique_id=920262933 instance=ExtResource("18_yntpr")]
+position = Vector2(363, 1057)
+scale = Vector2(0.6, 0.6)
+
+[node name="Bush20" parent="OnTheGround/Bushes" unique_id=39430491 instance=ExtResource("18_yntpr")]
+position = Vector2(287, 1050)
+scale = Vector2(0.5, 0.5)
+
+[node name="Bush21" parent="OnTheGround/Bushes" unique_id=1989598020 instance=ExtResource("18_yntpr")]
+position = Vector2(265, 1047)
+scale = Vector2(0.65, 0.65)
+
+[node name="Bush22" parent="OnTheGround/Bushes" unique_id=1585214049 instance=ExtResource("18_yntpr")]
+position = Vector2(255, 1033)
+scale = Vector2(0.5, 0.5)
+
+[node name="Bush23" parent="OnTheGround/Bushes" unique_id=1086059623 instance=ExtResource("18_yntpr")]
+position = Vector2(370, 1035)
+scale = Vector2(0.5, 0.5)
+
+[node name="Bush16" parent="OnTheGround/Bushes" unique_id=1299614484 instance=ExtResource("18_yntpr")]
+position = Vector2(663, 439)
+scale = Vector2(0.3, 0.3)
+
+[node name="Bush24" parent="OnTheGround/Bushes" unique_id=2096690297 instance=ExtResource("18_yntpr")]
+position = Vector2(298, 691)
+scale = Vector2(1.1, 1.1)
+
+[node name="Bush25" parent="OnTheGround/Bushes" unique_id=1620262277 instance=ExtResource("18_yntpr")]
+position = Vector2(263, 991)
+scale = Vector2(1.1, 1.1)
+
+[node name="Bush26" parent="OnTheGround/Bushes" unique_id=1628581492 instance=ExtResource("18_yntpr")]
+position = Vector2(127, 1149)
+scale = Vector2(1.1, 1.1)
+
+[node name="Bush27" parent="OnTheGround/Bushes" unique_id=825955768 instance=ExtResource("18_yntpr")]
+position = Vector2(1054, 1520)
+scale = Vector2(1.1, 1.1)
+
+[node name="Bush30" parent="OnTheGround/Bushes" unique_id=1876568460 instance=ExtResource("18_yntpr")]
+y_sort_enabled = true
+position = Vector2(1166, 1155)
+scale = Vector2(1.1, 1.1)
+
+[node name="Bush31" parent="OnTheGround/Bushes" unique_id=274647831 instance=ExtResource("18_yntpr")]
+y_sort_enabled = true
+position = Vector2(1150, 1120)
+scale = Vector2(0.9, 0.9)
+
+[node name="Bush32" parent="OnTheGround/Bushes" unique_id=1448795033 instance=ExtResource("18_yntpr")]
+y_sort_enabled = true
+position = Vector2(1253, 1134)
+scale = Vector2(1.1, 1.1)
+
+[node name="Bush28" parent="OnTheGround/Bushes" unique_id=2046022114 instance=ExtResource("18_yntpr")]
+position = Vector2(1074, 1548)
+scale = Vector2(0.8, 0.8)
+
+[node name="Bush29" parent="OnTheGround/Bushes" unique_id=1996658338 instance=ExtResource("18_yntpr")]
+position = Vector2(280, 1698)
+scale = Vector2(1.1, 1.1)
+
+[node name="Bush65" parent="OnTheGround/Bushes" unique_id=1084107524 instance=ExtResource("18_yntpr")]
+position = Vector2(270, 1729)
+scale = Vector2(0.8, 0.8)
+
+[node name="Tomatoes" type="Node2D" parent="OnTheGround" unique_id=1216935970]
+y_sort_enabled = true
+
+[node name="Tomato" parent="OnTheGround/Tomatoes" unique_id=1417180670 instance=ExtResource("39_ljovl")]
+position = Vector2(1571, 619)
+
+[node name="Tomato2" parent="OnTheGround/Tomatoes" unique_id=414353665 instance=ExtResource("39_ljovl")]
+position = Vector2(310, 807)
+
+[node name="Tomato3" parent="OnTheGround/Tomatoes" unique_id=563242510 instance=ExtResource("39_ljovl")]
+position = Vector2(348, 819)
+
+[node name="Carrots" type="Node2D" parent="OnTheGround" unique_id=1524389710]
+y_sort_enabled = true
+
+[node name="Carrot" parent="OnTheGround/Carrots" unique_id=1056869770 instance=ExtResource("42_ljovl")]
+position = Vector2(1563, 417)
+
+[node name="Carrot2" parent="OnTheGround/Carrots" unique_id=1916365556 instance=ExtResource("42_ljovl")]
+position = Vector2(1700, 417)
+
+[node name="Carrot3" parent="OnTheGround/Carrots" unique_id=2132997827 instance=ExtResource("42_ljovl")]
+position = Vector2(1667, 417)
+
+[node name="Carrot4" parent="OnTheGround/Carrots" unique_id=109758211 instance=ExtResource("42_ljovl")]
+position = Vector2(1632, 417)
+
+[node name="Carrot5" parent="OnTheGround/Carrots" unique_id=610508846 instance=ExtResource("42_ljovl")]
+position = Vector2(1599, 417)
+
+[node name="Carrot6" parent="OnTheGround/Carrots" unique_id=1940457300 instance=ExtResource("42_ljovl")]
+position = Vector2(1667, 468)
+
+[node name="Carrot7" parent="OnTheGround/Carrots" unique_id=222111516 instance=ExtResource("42_ljovl")]
+position = Vector2(1599, 443)
+
+[node name="Carrot8" parent="OnTheGround/Carrots" unique_id=844021272 instance=ExtResource("42_ljovl")]
+position = Vector2(1700, 443)
+
+[node name="Carrot9" parent="OnTheGround/Carrots" unique_id=1267982260 instance=ExtResource("42_ljovl")]
+position = Vector2(1632, 443)
+
+[node name="Carrot10" parent="OnTheGround/Carrots" unique_id=1863703007 instance=ExtResource("42_ljovl")]
+position = Vector2(1632, 468)
+
+[node name="Carrot11" parent="OnTheGround/Carrots" unique_id=1394205731 instance=ExtResource("42_ljovl")]
+position = Vector2(1667, 443)
+
+[node name="Carrot12" parent="OnTheGround/Carrots" unique_id=1624450720 instance=ExtResource("42_ljovl")]
+position = Vector2(1700, 469)
+
+[node name="Carrot13" parent="OnTheGround/Carrots" unique_id=1059663737 instance=ExtResource("42_ljovl")]
+position = Vector2(1632, 495)
+
+[node name="Carrot14" parent="OnTheGround/Carrots" unique_id=418701471 instance=ExtResource("42_ljovl")]
+position = Vector2(1563, 495)
+
+[node name="Carrot15" parent="OnTheGround/Carrots" unique_id=1760950291 instance=ExtResource("42_ljovl")]
+position = Vector2(1599, 495)
+
+[node name="Carrot16" parent="OnTheGround/Carrots" unique_id=1488315489 instance=ExtResource("42_ljovl")]
+position = Vector2(1563, 443)
+
+[node name="Carrot17" parent="OnTheGround/Carrots" unique_id=1581919746 instance=ExtResource("42_ljovl")]
+position = Vector2(1700, 495)
+
+[node name="Carrot18" parent="OnTheGround/Carrots" unique_id=911076394 instance=ExtResource("42_ljovl")]
+position = Vector2(1668, 495)
+
+[node name="Carrot19" parent="OnTheGround/Carrots" unique_id=44580834 instance=ExtResource("42_ljovl")]
+position = Vector2(1563, 469)
+
+[node name="Carrot20" parent="OnTheGround/Carrots" unique_id=1299594892 instance=ExtResource("42_ljovl")]
+position = Vector2(1599, 468)
+
+[node name="BarleyField" type="Node2D" parent="OnTheGround" unique_id=1870831195]
+y_sort_enabled = true
+
+[node name="Barley" parent="OnTheGround/BarleyField" unique_id=1837240364 instance=ExtResource("42_eodqy")]
+position = Vector2(400, 1176)
+
+[node name="Barley2" parent="OnTheGround/BarleyField" unique_id=1289698623 instance=ExtResource("42_eodqy")]
+position = Vector2(432, 1176)
+
+[node name="Barley3" parent="OnTheGround/BarleyField" unique_id=1975880228 instance=ExtResource("42_eodqy")]
+position = Vector2(464, 1176)
+
+[node name="Barley4" parent="OnTheGround/BarleyField" unique_id=839588657 instance=ExtResource("42_eodqy")]
+position = Vector2(496, 1176)
+
+[node name="Barley5" parent="OnTheGround/BarleyField" unique_id=224088482 instance=ExtResource("42_eodqy")]
+position = Vector2(400, 1208)
+
+[node name="Barley6" parent="OnTheGround/BarleyField" unique_id=1934226171 instance=ExtResource("42_eodqy")]
+position = Vector2(432, 1208)
+
+[node name="Barley7" parent="OnTheGround/BarleyField" unique_id=549737272 instance=ExtResource("42_eodqy")]
+position = Vector2(464, 1208)
+
+[node name="Barley8" parent="OnTheGround/BarleyField" unique_id=2045741632 instance=ExtResource("42_eodqy")]
+position = Vector2(496, 1208)
+
+[node name="Barley9" parent="OnTheGround/BarleyField" unique_id=538175638 instance=ExtResource("42_eodqy")]
+position = Vector2(416, 1192)
+
+[node name="Barley10" parent="OnTheGround/BarleyField" unique_id=1071950050 instance=ExtResource("42_eodqy")]
+position = Vector2(448, 1192)
+
+[node name="Barley11" parent="OnTheGround/BarleyField" unique_id=1825484614 instance=ExtResource("42_eodqy")]
+position = Vector2(480, 1192)
+
+[node name="Barley12" parent="OnTheGround/BarleyField" unique_id=375805475 instance=ExtResource("42_eodqy")]
+position = Vector2(512, 1192)
+
+[node name="Barley13" parent="OnTheGround/BarleyField" unique_id=471895812 instance=ExtResource("42_eodqy")]
+position = Vector2(528, 1176)
+
+[node name="Barley15" parent="OnTheGround/BarleyField" unique_id=685489223 instance=ExtResource("42_eodqy")]
+position = Vector2(560, 1176)
+
+[node name="Barley16" parent="OnTheGround/BarleyField" unique_id=1341055599 instance=ExtResource("42_eodqy")]
+position = Vector2(592, 1176)
+
+[node name="Barley17" parent="OnTheGround/BarleyField" unique_id=87788605 instance=ExtResource("42_eodqy")]
+position = Vector2(624, 1176)
+
+[node name="Barley18" parent="OnTheGround/BarleyField" unique_id=1352773935 instance=ExtResource("42_eodqy")]
+position = Vector2(528, 1208)
+
+[node name="Barley19" parent="OnTheGround/BarleyField" unique_id=79238951 instance=ExtResource("42_eodqy")]
+position = Vector2(560, 1208)
+
+[node name="Barley20" parent="OnTheGround/BarleyField" unique_id=751860807 instance=ExtResource("42_eodqy")]
+position = Vector2(592, 1208)
+
+[node name="Barley21" parent="OnTheGround/BarleyField" unique_id=1102146350 instance=ExtResource("42_eodqy")]
+position = Vector2(624, 1208)
+
+[node name="Barley22" parent="OnTheGround/BarleyField" unique_id=614595146 instance=ExtResource("42_eodqy")]
+position = Vector2(544, 1192)
+
+[node name="Barley23" parent="OnTheGround/BarleyField" unique_id=198452717 instance=ExtResource("42_eodqy")]
+position = Vector2(576, 1192)
+
+[node name="Barley24" parent="OnTheGround/BarleyField" unique_id=835543798 instance=ExtResource("42_eodqy")]
+position = Vector2(608, 1192)
+
+[node name="Barley25" parent="OnTheGround/BarleyField" unique_id=526955960 instance=ExtResource("42_eodqy")]
+position = Vector2(640, 1192)
+
+[node name="Barley14" parent="OnTheGround/BarleyField" unique_id=83830217 instance=ExtResource("42_eodqy")]
+position = Vector2(656, 1176)
+
+[node name="Barley26" parent="OnTheGround/BarleyField" unique_id=2072105437 instance=ExtResource("42_eodqy")]
+position = Vector2(688, 1176)
+
+[node name="Barley27" parent="OnTheGround/BarleyField" unique_id=1155363070 instance=ExtResource("42_eodqy")]
+position = Vector2(656, 1208)
+
+[node name="Barley28" parent="OnTheGround/BarleyField" unique_id=1542366425 instance=ExtResource("42_eodqy")]
+position = Vector2(688, 1208)
+
+[node name="Barley29" parent="OnTheGround/BarleyField" unique_id=1961323276 instance=ExtResource("42_eodqy")]
+position = Vector2(672, 1192)
+
+[node name="Rocks" type="Node2D" parent="OnTheGround" unique_id=1924548706]
+y_sort_enabled = true
+
+[node name="Rock" parent="OnTheGround/Rocks" unique_id=890604313 instance=ExtResource("18_jbsab")]
+position = Vector2(91, 1256)
+
+[node name="Rock2" parent="OnTheGround/Rocks" unique_id=762180858 instance=ExtResource("18_jbsab")]
+position = Vector2(97, 1240)
+scale = Vector2(1.1, 1.1)
+
+[node name="Rock3" parent="OnTheGround/Rocks" unique_id=1836828759 instance=ExtResource("18_jbsab")]
+position = Vector2(97, 1240)
+rotation = -1.04809
+scale = Vector2(1.1, 1.1)
+
+[node name="Rock4" parent="OnTheGround/Rocks" unique_id=1590479870 instance=ExtResource("18_jbsab")]
+position = Vector2(422, 1045)
+scale = Vector2(0.9, 0.9)
+
+[node name="Rock5" parent="OnTheGround/Rocks" unique_id=626363495 instance=ExtResource("18_jbsab")]
+position = Vector2(1720, 513)
+scale = Vector2(0.9, 0.9)
+
+[node name="Rock6" parent="OnTheGround/Rocks" unique_id=2113232597 instance=ExtResource("18_jbsab")]
+position = Vector2(1960, 1075)
+scale = Vector2(0.9, 0.9)
+
+[node name="Rock7" parent="OnTheGround/Rocks" unique_id=861958038 instance=ExtResource("18_jbsab")]
+position = Vector2(1948, 1063)
+scale = Vector2(1.1, 1.1)
+
+[node name="Rock8" parent="OnTheGround/Rocks" unique_id=307232558 instance=ExtResource("18_jbsab")]
+position = Vector2(1529, 828)
+scale = Vector2(1.05, 1.05)
+
+[node name="WaterRocks" type="Node2D" parent="OnTheGround" unique_id=493156613]
+editor_description = "Holds rocks that are in the water."
+y_sort_enabled = true
+
+[node name="WaterRock" parent="OnTheGround/WaterRocks" unique_id=198443660 instance=ExtResource("38_jqkod")]
+position = Vector2(931, 1378)
+
+[node name="WaterRock2" parent="OnTheGround/WaterRocks" unique_id=286434874 instance=ExtResource("38_jqkod")]
+position = Vector2(708, 1437)
+
+[node name="WaterRock3" parent="OnTheGround/WaterRocks" unique_id=1901788172 instance=ExtResource("38_jqkod")]
+position = Vector2(1578, 1477)
+
+[node name="WaterRock4" parent="OnTheGround/WaterRocks" unique_id=1688358840 instance=ExtResource("38_jqkod")]
+position = Vector2(1689, 1694)
+
+[node name="Tutorial" type="Node2D" parent="OnTheGround" unique_id=1760774148]
+y_sort_enabled = true
+
+[node name="MovementInputHint" parent="OnTheGround/Tutorial" unique_id=1630623962 node_paths=PackedStringArray("hint_node") instance=ExtResource("26_w8iew")]
+position = Vector2(474, 1658)
+hint_node = NodePath("../../../ScreenOverlay/HBoxContainer/MovementInputHints")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Tutorial/MovementInputHint" unique_id=1450943447]
+visible = false
+position = Vector2(552, 112.5)
+shape = SubResource("RectangleShape2D_h30yx")
+
+[node name="InteractInputHint" parent="OnTheGround/Tutorial/MovementInputHint" unique_id=1614272832 node_paths=PackedStringArray("hint_node") instance=ExtResource("26_w8iew")]
+position = Vector2(40, -45)
+hint_node = NodePath("../../../../ScreenOverlay/HBoxContainer/Repel_hint/InteractionInputHints")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Tutorial/MovementInputHint/InteractInputHint" unique_id=9243216]
+position = Vector2(0.5, -8.5)
+shape = SubResource("RectangleShape2D_djq26")
+
+[node name="TutorialGuy" parent="OnTheGround/Tutorial" unique_id=618221375 instance=ExtResource("54_duxxr")]
+position = Vector2(514, 1613)
+scale = Vector2(-1, 1)
+character_seed = 2433932515
+look_at_side = 1
+
+[node name="InteractArea" parent="OnTheGround/Tutorial/TutorialGuy" unique_id=226800588 instance=ExtResource("55_2vvub")]
+visible = false
+interact_label_position = Vector2(0, -100)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Tutorial/TutorialGuy/InteractArea" unique_id=1652917244]
+position = Vector2(0, -23.5)
+shape = SubResource("RectangleShape2D_2vvub")
+debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="TalkBehavior" type="Node" parent="OnTheGround/Tutorial/TutorialGuy" unique_id=283277394 node_paths=PackedStringArray("interact_area")]
+script = ExtResource("56_ojao8")
+dialogue = ExtResource("32_djq26")
+interact_area = NodePath("../InteractArea")
+metadata/_custom_type_script = "uid://edcifob4jc4s"
+
+[node name="WestPath" type="Node2D" parent="OnTheGround" unique_id=2042146768]
+y_sort_enabled = true
+
+[node name="Unlocker" type="Node" parent="OnTheGround/WestPath" unique_id=1461023268 node_paths=PackedStringArray("targets")]
+script = ExtResource("58_ojao8")
+targets = [NodePath("../../../TileMapLayers/WestPathBarrierVoid")]
+required_quests = Array[ExtResource("59_qgpx3")]([ExtResource("60_6b07c")])
+
+[node name="SpawnPointWestPath" type="Marker2D" parent="OnTheGround/WestPath" unique_id=730185770 groups=["spawn_point"]]
+position = Vector2(57, 719)
+script = ExtResource("61_6b07c")
+look_at_side_on_spawn = 1
+metadata/_custom_type_script = "uid://0enyu5v4ra34"
+
+[node name="Teleporter" type="Area2D" parent="OnTheGround/WestPath" unique_id=39493186]
+position = Vector2(-63, 712)
+collision_layer = 4
+script = ExtResource("62_t7c6s")
+next_scene = "uid://c3pi5sjiy5tlg"
+spawn_point_path = NodePath("SpawnPoint")
+metadata/_custom_type_script = "uid://hqdquinbimce"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/WestPath/Teleporter" unique_id=1827344313]
+shape = SubResource("RectangleShape2D_ulm71")
+
+[node name="Sign" parent="OnTheGround/WestPath" unique_id=1579530966 instance=ExtResource("64_uxfrp")]
+position = Vector2(95, 664)
+text = "West End"
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="." unique_id=1144668032]
 
@@ -481,717 +1186,14 @@ text = "Interact"
 [node name="HUD" parent="." unique_id=1876437396 instance=ExtResource("27_aj6tp")]
 unique_name_in_owner = true
 
-[node name="EternalLoom" parent="." unique_id=17061783 instance=ExtResource("16_ojp30")]
-unique_name_in_owner = true
-position = Vector2(993, 485)
-scale = Vector2(0.9, 0.9)
-
-[node name="ForestLimit" type="StaticBody2D" parent="." unique_id=1908977889]
-position = Vector2(972, 2047)
-scale = Vector2(1.10441, 1.00725)
-collision_layer = 16
-collision_mask = 0
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="ForestLimit" unique_id=748237013]
-position = Vector2(-2.33667, 6.93182)
-scale = Vector2(1.00152, 1.02166)
-polygon = PackedVector2Array(-877.343, -208.91, -817.673, -167.124, -758.004, -191.418, -697.43, -150.605, -638.664, -170.04, -579.899, -209.882, -460.559, -201.136, -390.04, -228.345, -324.042, -206.966, -255.332, -160.322, -168.539, -205.023, -99.8287, -193.362, -2.18738, -175.87, 55.6742, -183.644, 109.919, -223.486, 171.397, -226.401, 217.506, -200.164, 320.572, -186.559, 404.652, -186.559, 505.005, -189.475, 517.662, -237.091, 589.455, -238.273, 670.946, -241.251, 812.201, -217.423, 889.163, -140.978, 974.222, 0.017334, -874.675, -0.992798)
-
-[node name="CollisionPolygon2D2" type="CollisionPolygon2D" parent="ForestLimit" unique_id=188105721]
-position = Vector2(6.10352e-05, -1792.01)
-scale = Vector2(1.00305, 1)
-polygon = PackedVector2Array(-873.82, 17.8702, -689.668, 200.546, -618.354, 169.769, -545.235, 221.395, -473.921, 218.416, -396.288, 198.56, -292.477, 203.524, -221.163, 234.301, -112.838, 248.2, 16.2487, 229.337, 102.908, 234.301, 180.541, 220.402, 250.952, 228.344, 366.499, 163.812, 447.742, 157.855, 557.873, 112.186, 637.311, 51.6255, 710.43, 88.3592, 853.058, 87.3664, 974.02, -238.273, -881.944, -234.302)
-
-[node name="Trees" type="Node2D" parent="." unique_id=378434157]
-y_sort_enabled = true
-metadata/_edit_lock_ = true
-
-[node name="Tree" parent="Trees" unique_id=1932501761 instance=ExtResource("7_7v00g")]
-position = Vector2(1376, 405)
-scale = Vector2(1.001, 1.001)
-
-[node name="Tree3" parent="Trees" unique_id=1678596388 instance=ExtResource("7_7v00g")]
-position = Vector2(323.669, 1963.03)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree4" parent="Trees" unique_id=530347632 instance=ExtResource("7_7v00g")]
-position = Vector2(689.696, 2027.02)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree5" parent="Trees" unique_id=1674843860 instance=ExtResource("7_7v00g")]
-position = Vector2(552.436, 1940.99)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree6" parent="Trees" unique_id=79446423 instance=ExtResource("7_7v00g")]
-position = Vector2(802.62, 1968.27)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree7" parent="Trees" unique_id=649963827 instance=ExtResource("7_7v00g")]
-position = Vector2(948.642, 1993.45)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree8" parent="Trees" unique_id=500116567 instance=ExtResource("7_7v00g")]
-position = Vector2(1178.38, 2021.78)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree10" parent="Trees" unique_id=1207688304 instance=ExtResource("7_7v00g")]
-position = Vector2(1064.49, 2012.34)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree11" parent="Trees" unique_id=1813349792 instance=ExtResource("7_7v00g")]
-position = Vector2(1669.99, 253.919)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree12" parent="Trees" unique_id=142989831 instance=ExtResource("7_7v00g")]
-position = Vector2(1083.96, 1949.38)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree13" parent="Trees" unique_id=831282679 instance=ExtResource("7_7v00g")]
-position = Vector2(1234.84, 2008.14)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree14" parent="Trees" unique_id=1307485281 instance=ExtResource("7_7v00g")]
-position = Vector2(1875.39, 905.457)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree15" parent="Trees" unique_id=2053677081 instance=ExtResource("7_7v00g")]
-position = Vector2(1389.63, 1982.96)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree16" parent="Trees" unique_id=2124166383 instance=ExtResource("7_7v00g")]
-position = Vector2(403.493, 416.541)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree17" parent="Trees" unique_id=1427257925 instance=ExtResource("7_7v00g")]
-position = Vector2(402.52, 467.951)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree74" parent="Trees" unique_id=1148920514 instance=ExtResource("7_7v00g")]
-position = Vector2(702, 529)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree18" parent="Trees" unique_id=1024302850 instance=ExtResource("7_7v00g")]
-position = Vector2(479.425, 461.655)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree19" parent="Trees" unique_id=549093584 instance=ExtResource("7_7v00g")]
-position = Vector2(489.16, 403.951)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree73" parent="Trees" unique_id=202446030 instance=ExtResource("7_7v00g")]
-position = Vector2(489.16, 403.951)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree20" parent="Trees" unique_id=1987312795 instance=ExtResource("7_7v00g")]
-position = Vector2(747.132, 464.803)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree21" parent="Trees" unique_id=1909086150 instance=ExtResource("7_7v00g")]
-position = Vector2(548.542, 376.672)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree23" parent="Trees" unique_id=565373046 instance=ExtResource("7_7v00g")]
-position = Vector2(559.25, 445.918)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree71" parent="Trees" unique_id=508746342 instance=ExtResource("7_7v00g")]
-position = Vector2(1322, 535)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree24" parent="Trees" unique_id=1413823818 instance=ExtResource("7_7v00g")]
-position = Vector2(411.281, 1993.45)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree25" parent="Trees" unique_id=622131440 instance=ExtResource("7_7v00g")]
-position = Vector2(1426.62, 377.721)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree26" parent="Trees" unique_id=1149585713 instance=ExtResource("7_7v00g")]
-position = Vector2(878.552, 2013.39)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree30" parent="Trees" unique_id=1360494059 instance=ExtResource("7_7v00g")]
-position = Vector2(960.324, 2041.72)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree31" parent="Trees" unique_id=217219671 instance=ExtResource("7_7v00g")]
-position = Vector2(1377.95, 1170.9)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree32" parent="Trees" unique_id=921811469 instance=ExtResource("7_7v00g")]
-position = Vector2(1160.86, 1940.99)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree33" parent="Trees" unique_id=275476476 instance=ExtResource("7_7v00g")]
-position = Vector2(1744.95, 308.476)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree36" parent="Trees" unique_id=1997957129 instance=ExtResource("7_7v00g")]
-position = Vector2(1510.34, 380.869)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree37" parent="Trees" unique_id=1733761308 instance=ExtResource("7_7v00g")]
-position = Vector2(1579.46, 346.246)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree38" parent="Trees" unique_id=794097989 instance=ExtResource("7_7v00g")]
-position = Vector2(78.3536, 2020.73)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree39" parent="Trees" unique_id=1427896511 instance=ExtResource("7_7v00g")]
-position = Vector2(1289.36, 410.246)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree41" parent="Trees" unique_id=1126274595 instance=ExtResource("7_7v00g")]
-position = Vector2(1093.69, 352.541)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree42" parent="Trees" unique_id=1219058508 instance=ExtResource("7_7v00g")]
-position = Vector2(240.926, 446.967)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree45" parent="Trees" unique_id=1331885057 instance=ExtResource("7_7v00g")]
-position = Vector2(343.138, 414.443)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree46" parent="Trees" unique_id=1299102072 instance=ExtResource("7_7v00g")]
-position = Vector2(281.807, 405)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree47" parent="Trees" unique_id=1431325735 instance=ExtResource("7_7v00g")]
-position = Vector2(743.238, 1993.45)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree48" parent="Trees" unique_id=512917549 instance=ExtResource("7_7v00g")]
-position = Vector2(129.945, 1990.3)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree49" parent="Trees" unique_id=984311786 instance=ExtResource("7_7v00g")]
-position = Vector2(1439, 1255)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree76" parent="Trees" unique_id=371398351 instance=ExtResource("7_7v00g")]
-position = Vector2(740.431, 174.365)
-scale = Vector2(1.003, 1.003)
-
-[node name="Tree50" parent="Trees" unique_id=1448306675 instance=ExtResource("7_7v00g")]
-position = Vector2(1249.45, 467.951)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree51" parent="Trees" unique_id=1240948872 instance=ExtResource("7_7v00g")]
-position = Vector2(1339.01, 374.574)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree52" parent="Trees" unique_id=233056165 instance=ExtResource("7_7v00g")]
-position = Vector2(224.37, 2044.86)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree53" parent="Trees" unique_id=1003033914 instance=ExtResource("7_7v00g")]
-position = Vector2(614.738, 1989.25)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree54" parent="Trees" unique_id=2052048686 instance=ExtResource("7_7v00g")]
-position = Vector2(1807.25, 354.64)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree55" parent="Trees" unique_id=539355872 instance=ExtResource("7_7v00g")]
-position = Vector2(1610.61, 248.673)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree56" parent="Trees" unique_id=1903601485 instance=ExtResource("7_7v00g")]
-position = Vector2(1850, 829)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree57" parent="Trees" unique_id=1346125759 instance=ExtResource("7_7v00g")]
-position = Vector2(1464.59, 1990.3)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree58" parent="Trees" unique_id=2117949852 instance=ExtResource("7_7v00g")]
-position = Vector2(1318.56, 1994.5)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree59" parent="Trees" unique_id=1111374746 instance=ExtResource("7_7v00g")]
-position = Vector2(1617.42, 1995.55)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree60" parent="Trees" unique_id=1733767052 instance=ExtResource("7_7v00g")]
-position = Vector2(1494.76, 1998.69)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree61" parent="Trees" unique_id=1069014224 instance=ExtResource("7_7v00g")]
-position = Vector2(1816.99, 1967.22)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree62" parent="Trees" unique_id=161458005 instance=ExtResource("7_7v00g")]
-position = Vector2(1758.58, 1981.91)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree63" parent="Trees" unique_id=2128417183 instance=ExtResource("7_7v00g")]
-position = Vector2(695.537, 431.229)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree64" parent="Trees" unique_id=1470271340 instance=ExtResource("7_7v00g")]
-position = Vector2(630.314, 421.787)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree65" parent="Trees" unique_id=1237537773 instance=ExtResource("7_7v00g")]
-position = Vector2(873.684, 459.557)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree66" parent="Trees" unique_id=192479901 instance=ExtResource("7_7v00g")]
-position = Vector2(814.302, 473.196)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree72" parent="Trees" unique_id=30595985 instance=ExtResource("7_7v00g")]
-position = Vector2(138.704, 1164.6)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree75" parent="Trees" unique_id=1265010944 instance=ExtResource("7_7v00g")]
-position = Vector2(384.998, 1028.21)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree67" parent="Trees" unique_id=1384953353 instance=ExtResource("7_7v00g")]
-position = Vector2(1951, 552)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree68" parent="Trees" unique_id=2100997314 instance=ExtResource("7_7v00g")]
-position = Vector2(478.451, 1988.2)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree69" parent="Trees" unique_id=877766008 instance=ExtResource("7_7v00g")]
-position = Vector2(176.672, 2049.05)
-scale = Vector2(1.002, 1.002)
-
-[node name="Tree70" parent="Trees" unique_id=1280154167 instance=ExtResource("7_7v00g")]
-position = Vector2(1173.52, 441.721)
-scale = Vector2(1.002, 1.002)
-
-[node name="Bushes" type="Node2D" parent="." unique_id=2142789308]
-y_sort_enabled = true
-metadata/_edit_lock_ = true
-
-[node name="Bush" parent="Bushes" unique_id=691594667 instance=ExtResource("18_yntpr")]
-position = Vector2(720, 1111)
-
-[node name="Bush2" parent="Bushes" unique_id=674809064 instance=ExtResource("18_yntpr")]
-position = Vector2(702, 1128)
-scale = Vector2(0.4, 0.4)
-
-[node name="Bush3" parent="Bushes" unique_id=1790836883 instance=ExtResource("18_yntpr")]
-position = Vector2(1813, 1197)
-
-[node name="Bush4" parent="Bushes" unique_id=685970372 instance=ExtResource("18_yntpr")]
-position = Vector2(1828, 1225)
-scale = Vector2(0.8, 0.8)
-
-[node name="Bush5" parent="Bushes" unique_id=1814837063 instance=ExtResource("18_yntpr")]
-position = Vector2(1803, 1275)
-scale = Vector2(0.6, 0.6)
-
-[node name="Bush6" parent="Bushes" unique_id=681414570 instance=ExtResource("18_yntpr")]
-position = Vector2(225, 469)
-
-[node name="Bush7" parent="Bushes" unique_id=507391137 instance=ExtResource("18_yntpr")]
-position = Vector2(242, 480)
-scale = Vector2(0.6, 0.6)
-
-[node name="Bush8" parent="Bushes" unique_id=113159105 instance=ExtResource("18_yntpr")]
-position = Vector2(364, 480)
-scale = Vector2(0.6, 0.6)
-
-[node name="Bush9" parent="Bushes" unique_id=991872612 instance=ExtResource("18_yntpr")]
-position = Vector2(192, 521)
-scale = Vector2(0.6, 0.6)
-
-[node name="Bush10" parent="Bushes" unique_id=1741388599 instance=ExtResource("18_yntpr")]
-position = Vector2(383, 485)
-scale = Vector2(0.6, 0.6)
-
-[node name="Bush11" parent="Bushes" unique_id=258553976 instance=ExtResource("18_yntpr")]
-position = Vector2(593, 402)
-
-[node name="Bush12" parent="Bushes" unique_id=331374579 instance=ExtResource("18_yntpr")]
-position = Vector2(618, 392)
-
-[node name="Bush13" parent="Bushes" unique_id=1819127771 instance=ExtResource("18_yntpr")]
-position = Vector2(703, 401)
-
-[node name="Bush14" parent="Bushes" unique_id=1799152780 instance=ExtResource("18_yntpr")]
-position = Vector2(838, 479)
-
-[node name="Bush15" parent="Bushes" unique_id=907391532 instance=ExtResource("18_yntpr")]
-position = Vector2(777, 572)
-scale = Vector2(0.8, 0.8)
-
-[node name="Bush17" parent="Bushes" unique_id=2079878338 instance=ExtResource("18_yntpr")]
-position = Vector2(346, 1052)
-scale = Vector2(0.5, 0.5)
-
-[node name="Bush18" parent="Bushes" unique_id=500874609 instance=ExtResource("18_yntpr")]
-position = Vector2(346, 1066)
-scale = Vector2(0.4, 0.4)
-
-[node name="Bush19" parent="Bushes" unique_id=920262933 instance=ExtResource("18_yntpr")]
-position = Vector2(363, 1057)
-scale = Vector2(0.6, 0.6)
-
-[node name="Bush20" parent="Bushes" unique_id=39430491 instance=ExtResource("18_yntpr")]
-position = Vector2(287, 1050)
-scale = Vector2(0.5, 0.5)
-
-[node name="Bush21" parent="Bushes" unique_id=1989598020 instance=ExtResource("18_yntpr")]
-position = Vector2(265, 1047)
-scale = Vector2(0.65, 0.65)
-
-[node name="Bush22" parent="Bushes" unique_id=1585214049 instance=ExtResource("18_yntpr")]
-position = Vector2(255, 1033)
-scale = Vector2(0.5, 0.5)
-
-[node name="Bush23" parent="Bushes" unique_id=1086059623 instance=ExtResource("18_yntpr")]
-position = Vector2(370, 1035)
-scale = Vector2(0.5, 0.5)
-
-[node name="Bush16" parent="Bushes" unique_id=1299614484 instance=ExtResource("18_yntpr")]
-position = Vector2(663, 439)
-scale = Vector2(0.3, 0.3)
-
-[node name="Bush24" parent="Bushes" unique_id=2096690297 instance=ExtResource("18_yntpr")]
-position = Vector2(298, 691)
-scale = Vector2(1.1, 1.1)
-
-[node name="Bush25" parent="Bushes" unique_id=1620262277 instance=ExtResource("18_yntpr")]
-position = Vector2(263, 991)
-scale = Vector2(1.1, 1.1)
-
-[node name="Bush26" parent="Bushes" unique_id=1628581492 instance=ExtResource("18_yntpr")]
-position = Vector2(127, 1149)
-scale = Vector2(1.1, 1.1)
-
-[node name="Bush27" parent="Bushes" unique_id=825955768 instance=ExtResource("18_yntpr")]
-position = Vector2(1054, 1520)
-scale = Vector2(1.1, 1.1)
-
-[node name="Bush30" parent="Bushes" unique_id=1876568460 instance=ExtResource("18_yntpr")]
-y_sort_enabled = true
-position = Vector2(1166, 1155)
-scale = Vector2(1.1, 1.1)
-
-[node name="Bush31" parent="Bushes" unique_id=274647831 instance=ExtResource("18_yntpr")]
-y_sort_enabled = true
-position = Vector2(1150, 1120)
-scale = Vector2(0.9, 0.9)
-
-[node name="Bush32" parent="Bushes" unique_id=1448795033 instance=ExtResource("18_yntpr")]
-y_sort_enabled = true
-position = Vector2(1253, 1134)
-scale = Vector2(1.1, 1.1)
-
-[node name="Bush28" parent="Bushes" unique_id=2046022114 instance=ExtResource("18_yntpr")]
-position = Vector2(1074, 1548)
-scale = Vector2(0.8, 0.8)
-
-[node name="Bush29" parent="Bushes" unique_id=1996658338 instance=ExtResource("18_yntpr")]
-position = Vector2(280, 1698)
-scale = Vector2(1.1, 1.1)
-
-[node name="Bush65" parent="Bushes" unique_id=1084107524 instance=ExtResource("18_yntpr")]
-position = Vector2(270, 1729)
-scale = Vector2(0.8, 0.8)
-
-[node name="Tomatoes" type="Node2D" parent="." unique_id=1216935970]
-y_sort_enabled = true
-
-[node name="Tomato" parent="Tomatoes" unique_id=1417180670 instance=ExtResource("39_ljovl")]
-position = Vector2(1571, 619)
-
-[node name="Tomato2" parent="Tomatoes" unique_id=414353665 instance=ExtResource("39_ljovl")]
-position = Vector2(310, 807)
-
-[node name="Tomato3" parent="Tomatoes" unique_id=563242510 instance=ExtResource("39_ljovl")]
-position = Vector2(348, 819)
-
-[node name="Carrots" type="Node2D" parent="." unique_id=1524389710]
-y_sort_enabled = true
-
-[node name="Carrot" parent="Carrots" unique_id=1056869770 instance=ExtResource("42_ljovl")]
-position = Vector2(1563, 417)
-
-[node name="Carrot2" parent="Carrots" unique_id=1916365556 instance=ExtResource("42_ljovl")]
-position = Vector2(1700, 417)
-
-[node name="Carrot3" parent="Carrots" unique_id=2132997827 instance=ExtResource("42_ljovl")]
-position = Vector2(1667, 417)
-
-[node name="Carrot4" parent="Carrots" unique_id=109758211 instance=ExtResource("42_ljovl")]
-position = Vector2(1632, 417)
-
-[node name="Carrot5" parent="Carrots" unique_id=610508846 instance=ExtResource("42_ljovl")]
-position = Vector2(1599, 417)
-
-[node name="Carrot6" parent="Carrots" unique_id=1940457300 instance=ExtResource("42_ljovl")]
-position = Vector2(1667, 468)
-
-[node name="Carrot7" parent="Carrots" unique_id=222111516 instance=ExtResource("42_ljovl")]
-position = Vector2(1599, 443)
-
-[node name="Carrot8" parent="Carrots" unique_id=844021272 instance=ExtResource("42_ljovl")]
-position = Vector2(1700, 443)
-
-[node name="Carrot9" parent="Carrots" unique_id=1267982260 instance=ExtResource("42_ljovl")]
-position = Vector2(1632, 443)
-
-[node name="Carrot10" parent="Carrots" unique_id=1863703007 instance=ExtResource("42_ljovl")]
-position = Vector2(1632, 468)
-
-[node name="Carrot11" parent="Carrots" unique_id=1394205731 instance=ExtResource("42_ljovl")]
-position = Vector2(1667, 443)
-
-[node name="Carrot12" parent="Carrots" unique_id=1624450720 instance=ExtResource("42_ljovl")]
-position = Vector2(1700, 469)
-
-[node name="Carrot13" parent="Carrots" unique_id=1059663737 instance=ExtResource("42_ljovl")]
-position = Vector2(1632, 495)
-
-[node name="Carrot14" parent="Carrots" unique_id=418701471 instance=ExtResource("42_ljovl")]
-position = Vector2(1563, 495)
-
-[node name="Carrot15" parent="Carrots" unique_id=1760950291 instance=ExtResource("42_ljovl")]
-position = Vector2(1599, 495)
-
-[node name="Carrot16" parent="Carrots" unique_id=1488315489 instance=ExtResource("42_ljovl")]
-position = Vector2(1563, 443)
-
-[node name="Carrot17" parent="Carrots" unique_id=1581919746 instance=ExtResource("42_ljovl")]
-position = Vector2(1700, 495)
-
-[node name="Carrot18" parent="Carrots" unique_id=911076394 instance=ExtResource("42_ljovl")]
-position = Vector2(1668, 495)
-
-[node name="Carrot19" parent="Carrots" unique_id=44580834 instance=ExtResource("42_ljovl")]
-position = Vector2(1563, 469)
-
-[node name="Carrot20" parent="Carrots" unique_id=1299594892 instance=ExtResource("42_ljovl")]
-position = Vector2(1599, 468)
-
-[node name="BarleyField" type="Node2D" parent="." unique_id=1870831195]
-y_sort_enabled = true
-
-[node name="Barley" parent="BarleyField" unique_id=1837240364 instance=ExtResource("42_eodqy")]
-position = Vector2(400, 1176)
-
-[node name="Barley2" parent="BarleyField" unique_id=1289698623 instance=ExtResource("42_eodqy")]
-position = Vector2(432, 1176)
-
-[node name="Barley3" parent="BarleyField" unique_id=1975880228 instance=ExtResource("42_eodqy")]
-position = Vector2(464, 1176)
-
-[node name="Barley4" parent="BarleyField" unique_id=839588657 instance=ExtResource("42_eodqy")]
-position = Vector2(496, 1176)
-
-[node name="Barley5" parent="BarleyField" unique_id=224088482 instance=ExtResource("42_eodqy")]
-position = Vector2(400, 1208)
-
-[node name="Barley6" parent="BarleyField" unique_id=1934226171 instance=ExtResource("42_eodqy")]
-position = Vector2(432, 1208)
-
-[node name="Barley7" parent="BarleyField" unique_id=549737272 instance=ExtResource("42_eodqy")]
-position = Vector2(464, 1208)
-
-[node name="Barley8" parent="BarleyField" unique_id=2045741632 instance=ExtResource("42_eodqy")]
-position = Vector2(496, 1208)
-
-[node name="Barley9" parent="BarleyField" unique_id=538175638 instance=ExtResource("42_eodqy")]
-position = Vector2(416, 1192)
-
-[node name="Barley10" parent="BarleyField" unique_id=1071950050 instance=ExtResource("42_eodqy")]
-position = Vector2(448, 1192)
-
-[node name="Barley11" parent="BarleyField" unique_id=1825484614 instance=ExtResource("42_eodqy")]
-position = Vector2(480, 1192)
-
-[node name="Barley12" parent="BarleyField" unique_id=375805475 instance=ExtResource("42_eodqy")]
-position = Vector2(512, 1192)
-
-[node name="Barley13" parent="BarleyField" unique_id=471895812 instance=ExtResource("42_eodqy")]
-position = Vector2(528, 1176)
-
-[node name="Barley15" parent="BarleyField" unique_id=685489223 instance=ExtResource("42_eodqy")]
-position = Vector2(560, 1176)
-
-[node name="Barley16" parent="BarleyField" unique_id=1341055599 instance=ExtResource("42_eodqy")]
-position = Vector2(592, 1176)
-
-[node name="Barley17" parent="BarleyField" unique_id=87788605 instance=ExtResource("42_eodqy")]
-position = Vector2(624, 1176)
-
-[node name="Barley18" parent="BarleyField" unique_id=1352773935 instance=ExtResource("42_eodqy")]
-position = Vector2(528, 1208)
-
-[node name="Barley19" parent="BarleyField" unique_id=79238951 instance=ExtResource("42_eodqy")]
-position = Vector2(560, 1208)
-
-[node name="Barley20" parent="BarleyField" unique_id=751860807 instance=ExtResource("42_eodqy")]
-position = Vector2(592, 1208)
-
-[node name="Barley21" parent="BarleyField" unique_id=1102146350 instance=ExtResource("42_eodqy")]
-position = Vector2(624, 1208)
-
-[node name="Barley22" parent="BarleyField" unique_id=614595146 instance=ExtResource("42_eodqy")]
-position = Vector2(544, 1192)
-
-[node name="Barley23" parent="BarleyField" unique_id=198452717 instance=ExtResource("42_eodqy")]
-position = Vector2(576, 1192)
-
-[node name="Barley24" parent="BarleyField" unique_id=835543798 instance=ExtResource("42_eodqy")]
-position = Vector2(608, 1192)
-
-[node name="Barley25" parent="BarleyField" unique_id=526955960 instance=ExtResource("42_eodqy")]
-position = Vector2(640, 1192)
-
-[node name="Barley14" parent="BarleyField" unique_id=83830217 instance=ExtResource("42_eodqy")]
-position = Vector2(656, 1176)
-
-[node name="Barley26" parent="BarleyField" unique_id=2072105437 instance=ExtResource("42_eodqy")]
-position = Vector2(688, 1176)
-
-[node name="Barley27" parent="BarleyField" unique_id=1155363070 instance=ExtResource("42_eodqy")]
-position = Vector2(656, 1208)
-
-[node name="Barley28" parent="BarleyField" unique_id=1542366425 instance=ExtResource("42_eodqy")]
-position = Vector2(688, 1208)
-
-[node name="Barley29" parent="BarleyField" unique_id=1961323276 instance=ExtResource("42_eodqy")]
-position = Vector2(672, 1192)
-
-[node name="Rocks" type="Node2D" parent="." unique_id=1924548706]
-y_sort_enabled = true
-
-[node name="Rock" parent="Rocks" unique_id=890604313 instance=ExtResource("18_jbsab")]
-position = Vector2(91, 1256)
-
-[node name="Rock2" parent="Rocks" unique_id=762180858 instance=ExtResource("18_jbsab")]
-position = Vector2(97, 1240)
-scale = Vector2(1.1, 1.1)
-
-[node name="Rock3" parent="Rocks" unique_id=1836828759 instance=ExtResource("18_jbsab")]
-position = Vector2(97, 1240)
-rotation = -1.04809
-scale = Vector2(1.1, 1.1)
-
-[node name="Rock4" parent="Rocks" unique_id=1590479870 instance=ExtResource("18_jbsab")]
-position = Vector2(422, 1045)
-scale = Vector2(0.9, 0.9)
-
-[node name="Rock5" parent="Rocks" unique_id=626363495 instance=ExtResource("18_jbsab")]
-position = Vector2(1720, 513)
-scale = Vector2(0.9, 0.9)
-
-[node name="Rock6" parent="Rocks" unique_id=2113232597 instance=ExtResource("18_jbsab")]
-position = Vector2(1960, 1075)
-scale = Vector2(0.9, 0.9)
-
-[node name="Rock7" parent="Rocks" unique_id=861958038 instance=ExtResource("18_jbsab")]
-position = Vector2(1948, 1063)
-scale = Vector2(1.1, 1.1)
-
-[node name="Rock8" parent="Rocks" unique_id=307232558 instance=ExtResource("18_jbsab")]
-position = Vector2(1529, 828)
-scale = Vector2(1.05, 1.05)
-
-[node name="WaterRocks" type="Node2D" parent="." unique_id=493156613]
-editor_description = "Holds rocks that are in the water."
-y_sort_enabled = true
-
-[node name="WaterRock" parent="WaterRocks" unique_id=198443660 instance=ExtResource("38_jqkod")]
-position = Vector2(931, 1378)
-
-[node name="WaterRock2" parent="WaterRocks" unique_id=286434874 instance=ExtResource("38_jqkod")]
-position = Vector2(708, 1437)
-
-[node name="WaterRock3" parent="WaterRocks" unique_id=1901788172 instance=ExtResource("38_jqkod")]
-position = Vector2(1578, 1477)
-
-[node name="WaterRock4" parent="WaterRocks" unique_id=1688358840 instance=ExtResource("38_jqkod")]
-position = Vector2(1689, 1694)
-
-[node name="Tutorial" type="Node2D" parent="." unique_id=1760774148]
-y_sort_enabled = true
-
-[node name="MovementInputHint" parent="Tutorial" unique_id=1630623962 node_paths=PackedStringArray("hint_node") instance=ExtResource("26_w8iew")]
-position = Vector2(474, 1658)
-hint_node = NodePath("../../ScreenOverlay/HBoxContainer/MovementInputHints")
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Tutorial/MovementInputHint" unique_id=1450943447]
-visible = false
-position = Vector2(552, 112.5)
-shape = SubResource("RectangleShape2D_h30yx")
-
-[node name="InteractInputHint" parent="Tutorial/MovementInputHint" unique_id=1614272832 node_paths=PackedStringArray("hint_node") instance=ExtResource("26_w8iew")]
-position = Vector2(40, -45)
-hint_node = NodePath("../../../ScreenOverlay/HBoxContainer/Repel_hint/InteractionInputHints")
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Tutorial/MovementInputHint/InteractInputHint" unique_id=9243216]
-position = Vector2(0.5, -8.5)
-shape = SubResource("RectangleShape2D_djq26")
-
-[node name="TutorialGuy" parent="Tutorial" unique_id=618221375 instance=ExtResource("54_duxxr")]
-position = Vector2(514, 1613)
-scale = Vector2(-1, 1)
-character_seed = 2433932515
-look_at_side = 1
-
-[node name="InteractArea" parent="Tutorial/TutorialGuy" unique_id=226800588 instance=ExtResource("55_2vvub")]
-visible = false
-interact_label_position = Vector2(0, -100)
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Tutorial/TutorialGuy/InteractArea" unique_id=1652917244]
-position = Vector2(0, -23.5)
-shape = SubResource("RectangleShape2D_2vvub")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
-
-[node name="TalkBehavior" type="Node" parent="Tutorial/TutorialGuy" unique_id=283277394 node_paths=PackedStringArray("interact_area")]
-script = ExtResource("56_ojao8")
-dialogue = ExtResource("32_djq26")
-interact_area = NodePath("../InteractArea")
-metadata/_custom_type_script = "uid://edcifob4jc4s"
-
-[node name="WestPath" type="Node2D" parent="." unique_id=2042146768]
-y_sort_enabled = true
-
-[node name="Unlocker" type="Node" parent="WestPath" unique_id=1461023268 node_paths=PackedStringArray("targets")]
-script = ExtResource("58_ojao8")
-targets = [NodePath("../../TileMapLayers/WestPathBarrierVoid")]
-required_quests = Array[ExtResource("59_qgpx3")]([ExtResource("60_6b07c")])
-
-[node name="SpawnPointWestPath" type="Marker2D" parent="WestPath" unique_id=730185770 groups=["spawn_point"]]
-position = Vector2(57, 719)
-script = ExtResource("61_6b07c")
-look_at_side_on_spawn = 1
-metadata/_custom_type_script = "uid://0enyu5v4ra34"
-
-[node name="Teleporter" type="Area2D" parent="WestPath" unique_id=39493186]
-position = Vector2(-63, 712)
-collision_layer = 4
-script = ExtResource("62_t7c6s")
-next_scene = "uid://c3pi5sjiy5tlg"
-spawn_point_path = NodePath("SpawnPoint")
-metadata/_custom_type_script = "uid://hqdquinbimce"
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="WestPath/Teleporter" unique_id=1827344313]
-shape = SubResource("RectangleShape2D_ulm71")
-
-[node name="Sign" parent="WestPath" unique_id=1579530966 instance=ExtResource("64_uxfrp")]
-position = Vector2(95, 664)
-text = "West End"
-
 [node name="SpawnPointAfterIntro" parent="." unique_id=69976262 instance=ExtResource("37_thm8h")]
 position = Vector2(62, 1747)
 
 [node name="TimeAndWeather" parent="." unique_id=1446545037 instance=ExtResource("55_ojao8")]
 
-[connection signal="interaction_ended" from="NPCs/Farmer/InteractArea" to="NPCs/Farmer" method="_on_interact_area_interaction_ended"]
-[connection signal="interaction_started" from="NPCs/Farmer/InteractArea" to="NPCs/Farmer" method="_on_interact_area_interaction_started"]
-[connection signal="interaction_ended" from="NPCs/GardenerA/InteractArea" to="NPCs/GardenerA" method="_on_interact_area_interaction_ended"]
-[connection signal="interaction_started" from="NPCs/GardenerA/InteractArea" to="NPCs/GardenerA" method="_on_interact_area_interaction_started"]
-[connection signal="interaction_ended" from="Tutorial/TutorialGuy/InteractArea" to="Tutorial/TutorialGuy" method="_on_interact_area_interaction_ended"]
-[connection signal="interaction_started" from="Tutorial/TutorialGuy/InteractArea" to="Tutorial/TutorialGuy" method="_on_interact_area_interaction_started"]
+[connection signal="interaction_ended" from="OnTheGround/NPCs/Farmer/InteractArea" to="OnTheGround/NPCs/Farmer" method="_on_interact_area_interaction_ended"]
+[connection signal="interaction_started" from="OnTheGround/NPCs/Farmer/InteractArea" to="OnTheGround/NPCs/Farmer" method="_on_interact_area_interaction_started"]
+[connection signal="interaction_ended" from="OnTheGround/NPCs/GardenerA/InteractArea" to="OnTheGround/NPCs/GardenerA" method="_on_interact_area_interaction_ended"]
+[connection signal="interaction_started" from="OnTheGround/NPCs/GardenerA/InteractArea" to="OnTheGround/NPCs/GardenerA" method="_on_interact_area_interaction_started"]
+[connection signal="interaction_ended" from="OnTheGround/Tutorial/TutorialGuy/InteractArea" to="OnTheGround/Tutorial/TutorialGuy" method="_on_interact_area_interaction_ended"]
+[connection signal="interaction_started" from="OnTheGround/Tutorial/TutorialGuy/InteractArea" to="OnTheGround/Tutorial/TutorialGuy" method="_on_interact_area_interaction_started"]


### PR DESCRIPTION
Add a Node2D named OnTheGround with Y-sort enabled. Move all characters and props into it. This new node is right below the one with all TileMapLayers.

Disable Y-sort from the root node.

This makes the grappling hook rope appear on top of tiles, as expected.