### PR TITLE
Debug Settings: Add game speed setting

### DIFF
--- a/scenes/menus/debug/components/debug_game_speed_slider.gd
+++ b/scenes/menus/debug/components/debug_game_speed_slider.gd
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends HSlider
+
+
+func _ready() -> void:
+	value = Engine.time_scale
+	value_changed.connect(_on_value_changed)
+
+
+func _on_value_changed(new_value: float) -> void:
+	Engine.time_scale = new_value

--- a/scenes/menus/debug/components/debug_game_speed_slider.gd.uid
+++ b/scenes/menus/debug/components/debug_game_speed_slider.gd.uid
@@ -1,0 +1,1 @@
+uid://ylb2ruainolu

--- a/scenes/menus/debug/debug_settings.tscn
+++ b/scenes/menus/debug/debug_settings.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="2_46px3"]
 [ext_resource type="PackedScene" uid="uid://cie2w455avmwm" path="res://scenes/menus/debug/debug_completed_quest_list.tscn" id="2_k06h7"]
 [ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="3_46px3"]
+[ext_resource type="Script" uid="uid://ylb2ruainolu" path="res://scenes/menus/debug/components/debug_game_speed_slider.gd" id="3_xtet4"]
 
 [node name="DebugSettings" type="PanelContainer" unique_id=35497477 node_paths=PackedStringArray("back_button")]
 custom_minimum_size = Vector2(800, 600)
@@ -15,6 +16,47 @@ back_button = NodePath("VBoxContainer/BackButton")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1670771472]
 layout_mode = 2
+
+[node name="GameSpeedPanel" type="PanelContainer" parent="VBoxContainer" unique_id=518398050]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_type_variation = &"PlayerRibbon"
+
+[node name="Label" type="Label" parent="VBoxContainer/GameSpeedPanel" unique_id=137906170]
+layout_mode = 2
+text = "Game Speed"
+
+[node name="GameSpeedSlider" type="HSlider" parent="VBoxContainer" unique_id=2014602239]
+layout_mode = 2
+min_value = 0.25
+max_value = 4.0
+step = 0.05
+value = 1.0
+script = ExtResource("3_xtet4")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer" unique_id=1062803006]
+layout_mode = 2
+
+[node name="HalfSpeedButton" type="Button" parent="VBoxContainer/HBoxContainer" unique_id=783255039]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"FlatButton"
+text = "Half"
+flat = true
+
+[node name="NormalSpeedButton" type="Button" parent="VBoxContainer/HBoxContainer" unique_id=1521106639]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"FlatButton"
+text = "Normal"
+flat = true
+
+[node name="DoubleSpeedButton" type="Button" parent="VBoxContainer/HBoxContainer" unique_id=2027577112]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"FlatButton"
+text = "Double"
+flat = true
 
 [node name="PanelContainer" type="PanelContainer" parent="VBoxContainer" unique_id=587878740]
 layout_mode = 2
@@ -42,3 +84,7 @@ theme_type_variation = &"FlatButton"
 text = "Back"
 icon = ExtResource("3_46px3")
 flat = true
+
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/HalfSpeedButton" to="VBoxContainer/GameSpeedSlider" method="set_value" binds= [0.5]]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/NormalSpeedButton" to="VBoxContainer/GameSpeedSlider" method="set_value" binds= [1.0]]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/DoubleSpeedButton" to="VBoxContainer/GameSpeedSlider" method="set_value" binds= [2.0]]


### PR DESCRIPTION
Changing the game speed through Engine.time_scale can be useful for debugging. And this is not something exposed in the editor (it could be a good addition to the Game tab).

Add a new section for this in the debug settings. With a slider that goes from 0.25 (slow motion) to 4 (four times the normal speed). Also add buttons for 3 common settings: half, normal, and double speed.