### PR TITLE
Void music: Tweak Bloom -> Still transition again

### DIFF
--- a/scenes/quests/lore_quests/quest_002/components/void_music.tres
+++ b/scenes/quests/lore_quests/quest_002/components/void_music.tres
@@ -74,13 +74,13 @@ Vector2i(3, 0): {
 Vector2i(4, 0): {
 "fade_beats": 2.0,
 "fade_mode": 4,
-"from_time": 2,
+"from_time": 1,
 "to_time": 2
 },
 Vector2i(5, 0): {
 "fade_beats": 2.0,
 "fade_mode": 4,
-"from_time": 2,
+"from_time": 1,
 "to_time": 2
 }
 }


### PR DESCRIPTION
Previously this was set to "transition at next bar for 2 beats". Godot
assumes that the number of beats in a bar is constant, but in this piece
a beat is dropped every 8 bars in the bulk of the piece, so Godot's
notion of "end of bar" doesn't line up.

If we change this to "transition at next *beat* for 2 beats", that's
between 2 and 3 beats, or (at 140bpm) between 0.86 and 1.29 seconds. The
transition is triggered at the start of the fade-in, and is 1 second, so
this lines up nicely with the fade.

Helps https://github.com/endlessm/threadbare/issues/1974