### PR TITLE
Player: Move and slide in physics process

### DIFF
--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -184,11 +184,11 @@ func is_running() -> bool:
 	return input_vector.length_squared() > (walk_speed * walk_speed) + 1.0
 
 
-func _process(delta: float) -> void:
+func _physics_process(delta: float) -> void:
 	if Engine.is_editor_hint():
 		return
 
-	# While pulling the grappling hook, the movement is handled in PlayerHook._process.
+	# While pulling the grappling hook, the movement is handled in PlayerHook._physics_process.
 	if player_hook.pulling:
 		return
 

--- a/scenes/game_elements/characters/player/components/player_hook.gd
+++ b/scenes/game_elements/characters/player/components/player_hook.gd
@@ -273,7 +273,7 @@ func get_ending_area() -> HookableArea:
 	return areas_hooked[-1]
 
 
-func _process(delta: float) -> void:
+func _physics_process(delta: float) -> void:
 	if not is_instance_valid(hook_string):
 		return
 	if pulling:


### PR DESCRIPTION
Change the player and player_hook scripts to move and slide the player in `_physics_process()`, rather than in `_process()`.

Fix https://github.com/endlessm/threadbare/issues/2025