### PR TITLE
Player: Revert wall min slide angle and safe margin

### DIFF
--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -523,7 +523,6 @@ _data = {
 [node name="Player" type="CharacterBody2D" unique_id=296354958 groups=["player"]]
 collision_mask = 531
 motion_mode = 1
-wall_min_slide_angle = 0.017453292
 script = ExtResource("1_g2els")
 
 [node name="HitBox" type="Area2D" parent="." unique_id=1910507610]


### PR DESCRIPTION
These values were changed for fixing the player getting stuck when colliding with tiles and props. Reset them to the defaults.