### PR TITLE
Grappling Hook: Use Line2D.set_point_position() for changing the points

### DIFF
--- a/scenes/game_elements/characters/player/components/player_hook.gd
+++ b/scenes/game_elements/characters/player/components/player_hook.gd
@@ -294,17 +294,19 @@ func _process_hook_string(delta: float) -> void:
 	# TODO: Only updates the endings. Connections are assumed static for now.
 
 	# Move last point to the player position.
-	hook_string.points[-1] = character.position + position
+	hook_string.set_point_position(hook_string.get_point_count() - 1, character.position + position)
 
 	var ending_area := get_ending_area()
 	if ending_area:
 		# Move first point to the hooked position.
-		hook_string.points[0] = ending_area.get_anchor_position()
+		hook_string.set_point_position(0, ending_area.get_anchor_position())
 
 	else:
 		# Not hooked, so a throw that hit air or wall.
 		# Progressively shorten the line.
-		hook_string.points[0] = hook_string.points[0].lerp(hook_string.points[1], 10.0 * delta)
+		hook_string.set_point_position(
+			0, hook_string.points[0].lerp(hook_string.points[1], 10.0 * delta)
+		)
 		# Remove the string when the line is short enough.
 		if (
 			(hook_string.points[1] - hook_string.points[0]).length_squared()


### PR DESCRIPTION
Changing the PackedVector2Array directly is not possible in Godot 4.7. And even if it worked in 4.6, it wasn't documented as so. As the Line2D.points documentation says:

> Note: The returned array is copied and any changes to it will not update the original property value. See PackedVector2Array for more
> details.

The change in Godot https://github.com/godotengine/godot/commit/6d06b3a7d6250cece1c21f7a44312cc97383d99c was added in pull request https://github.com/godotengine/godot/pull/113228 but is not considered a regression, because the previous behavior was a bug.