### PR TITLE
ci: Unbreak building Flatpak locally

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -96,6 +96,10 @@ jobs:
           name: web
           path: build
 
+      - name: Rename pck file
+        run: |
+          mv build/index.pck build/threadbare.pck
+
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: threadbare.flatpak

--- a/linux/org.endlessaccess.threadbare.yml
+++ b/linux/org.endlessaccess.threadbare.yml
@@ -25,6 +25,6 @@ modules:
   # PCK file automatically exported in CI; if building locally, in Godot go to
   # "Project" → "Export…" → "Linux (Runnable)" → "Export PCK/ZIP" and export to
   # "build/threadbare.pck"
-  - install -Dm644 build/index.pck ${FLATPAK_DEST}/bin/godot-runner.pck
+  - install -Dm644 build/threadbare.pck ${FLATPAK_DEST}/bin/godot-runner.pck
 
   - linux/install-metadata


### PR DESCRIPTION
Previously the workflow would place the prebuilt .pck file at the same
path that the built-in Linux export preset would do.

Restore this so that the Flatpak manifest can be tested locally.
