### PR TITLE
GameState: Reduce initial lives to 2 ** 53

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -37,7 +37,7 @@ const GLOBAL_SECTION := "global"
 const GLOBAL_INCORPORATING_THREADS_KEY := "incorporating_threads"
 const COMPLETED_QUESTS_KEY := "completed_quests"
 const LIVES_KEY := "current_lives"
-const MAX_LIVES := 0x7fffffffffffffff
+const MAX_LIVES := 2 ** 53
 const DEBUG_LIVES := false
 
 ## Scenes to skip from saving.


### PR DESCRIPTION
Currently if you inspect the GameState (e.g. while running the game) you
get this warning:

> WARNING: editor/inspector/editor_properties.cpp:1574 - Cannot reliably
> represent '9223372036854775807' in the inspector, value is too large.

The issue is that the inspector represents numerical values as 64-bit
floating point values, with 52 bits of mantissa, so non-power-of-two
integers above 2 ** 53 cannot be represented exactly. (This may be
familiar to JavaScript fans because JavaScript traditionally represented
all numbers as doubles.)

The number is just meant to be "really big". Use 2 ** 53 instead. This
is 9,007,199,254,740,989 (9 quadrillion in the short scale). Good luck
being defeated that many times.
