### PR TITLE
GameState: Persist current scene in global, not scene, state

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -30,12 +30,12 @@ const INVENTORY_SECTION := "inventory"
 const INVENTORY_ITEMS_KEY := "items_collected"
 const QUEST_SECTION := "quest"
 const QUEST_PATH_KEY := "resource_path"
-const QUEST_CURRENTSCENE_KEY := "current_scene"
-const QUEST_SPAWNPOINT_KEY := "current_spawn_point"
 const QUEST_CHALLENGE_START_KEY := "challenge_start_scene"
 const GLOBAL_SECTION := "global"
 const GLOBAL_INCORPORATING_THREADS_KEY := "incorporating_threads"
 const COMPLETED_QUESTS_KEY := "completed_quests"
+const CURRENTSCENE_KEY := "current_scene"
+const SPAWNPOINT_KEY := "current_spawn_point"
 const LIVES_KEY := "current_lives"
 const MAX_LIVES := 2 ** 53
 const DEBUG_LIVES := false
@@ -156,7 +156,7 @@ func set_scene(scene_path: String, spawn_point: NodePath = ^"") -> void:
 ## Set the current spawn point and save it.
 func set_current_spawn_point(spawn_point: NodePath = ^"") -> void:
 	current_spawn_point = spawn_point
-	_state.set_value(QUEST_SECTION, QUEST_SPAWNPOINT_KEY, current_spawn_point)
+	_state.set_value(GLOBAL_SECTION, SPAWNPOINT_KEY, current_spawn_point)
 	_save()
 
 
@@ -215,8 +215,8 @@ func _do_set_scene(scene_path: String, spawn_point: NodePath = ^"") -> void:
 		intro_dialogue_shown = false
 
 	current_spawn_point = spawn_point
-	_state.set_value(QUEST_SECTION, QUEST_CURRENTSCENE_KEY, scene_path)
-	_state.set_value(QUEST_SECTION, QUEST_SPAWNPOINT_KEY, current_spawn_point)
+	_state.set_value(GLOBAL_SECTION, CURRENTSCENE_KEY, scene_path)
+	_state.set_value(GLOBAL_SECTION, SPAWNPOINT_KEY, current_spawn_point)
 
 
 ## Add the [InventoryItem] to the [member inventory].
@@ -341,12 +341,12 @@ func clear() -> void:
 
 ## Check if there is persisted state.
 func can_restore() -> bool:
-	return _state.get_sections().size()
+	return get_scene_to_restore() != ""
 
 
 ## If there is a scene to restore, return it.
 func get_scene_to_restore() -> String:
-	return _state.get_value(QUEST_SECTION, QUEST_CURRENTSCENE_KEY, "")
+	return _state.get_value(GLOBAL_SECTION, CURRENTSCENE_KEY, "")
 
 
 ## Restore the persisted state.
@@ -361,8 +361,8 @@ func restore() -> Dictionary:
 	if _state.has_section_key(QUEST_SECTION, QUEST_PATH_KEY):
 		current_quest = load(_state.get_value(QUEST_SECTION, QUEST_PATH_KEY)) as Quest
 
-	var scene_path: String = _state.get_value(QUEST_SECTION, QUEST_CURRENTSCENE_KEY, "")
-	current_spawn_point = _state.get_value(QUEST_SECTION, QUEST_SPAWNPOINT_KEY, ^"")
+	var scene_path: String = _state.get_value(GLOBAL_SECTION, CURRENTSCENE_KEY, "")
+	current_spawn_point = _state.get_value(GLOBAL_SECTION, SPAWNPOINT_KEY, ^"")
 	incorporating_threads = _state.get_value(
 		GLOBAL_SECTION, GLOBAL_INCORPORATING_THREADS_KEY, false
 	)

--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -104,6 +104,8 @@ func change_to_file_with_transition(
 	enter_transition: Transition.Effect = Transition.Effect.RIGHT_TO_LEFT_WIPE,
 	exit_transition: Transition.Effect = Transition.Effect.LEFT_TO_RIGHT_WIPE
 ) -> void:
+	assert(scene_path != "")
+
 	var err := ResourceLoader.load_threaded_request(scene_path)
 	if err != OK:
 		push_error("Failed to start loading %s: %s" % [scene_path, error_string(err)])
@@ -122,6 +124,8 @@ func change_to_packed_with_transition(
 	enter_transition: Transition.Effect = Transition.Effect.RIGHT_TO_LEFT_WIPE,
 	exit_transition: Transition.Effect = Transition.Effect.LEFT_TO_RIGHT_WIPE
 ) -> void:
+	assert(scene != null)
+
 	Transitions.do_transition(
 		change_to_packed.bind(scene, spawn_point), enter_transition, exit_transition
 	)
@@ -135,12 +139,16 @@ func reload_with_transition(
 
 
 func change_to_file(scene_path: String, spawn_point: NodePath = ^"") -> void:
+	assert(scene_path != "")
+
 	var scene: PackedScene = load(scene_path)
 	if scene:
 		change_to_packed(scene, spawn_point)
 
 
 func change_to_packed(scene: PackedScene, spawn_point: NodePath = ^"") -> void:
+	assert(scene != null)
+
 	GameState.clear_per_scene_state()
 
 	if get_tree().change_scene_to_packed(scene) == OK:


### PR DESCRIPTION
Previously the current scene was persisted as part of the quest state.
When you return to Fray's End after completing a trio of Sokobans, all
quest state is erased from the saved data, meaning that the current
scene path is lost.

As a result, if you:

- Complete a quest
- Complete all three Sokobans & return to Fray's End
- Exit the game
- Relaunch the game

then you were previously offered the chance to Continue. However this
would try to change scene to empty string, which fails and reloads the
title screen.

Fix this in two ways:

1. Persist the current scene as part of the global state, not as part of
   the quest state.
2. Only offer the chance to continue a saved game if the current scene
   is known.

Add some assertions at relevant points.

Resolves https://github.com/endlessm/threadbare/issues/1946
