### PR TITLE
void_chromakey: Make the starfield scale-independent

### DIFF
--- a/scenes/game_elements/props/void/components/void_chromakey.gdshader
+++ b/scenes/game_elements/props/void/components/void_chromakey.gdshader
@@ -5,12 +5,6 @@
  */
 shader_type canvas_item;
 
-// TODO: Can we get this from SCREEN_PIXEL_SIZE?
-/**
- * Viewport size.
- */
-uniform vec2 resolution = vec2(1920.0, 1080.0);
-
 /**
  * For best results, use Simplex noise.
  */
@@ -36,20 +30,16 @@ uniform vec4 chroma_key: source_color = vec4(1.0, 0.0, 0.0, 1.0);
  */
 uniform vec4 background_color: source_color = vec4(0.086, 0.11, 0.18, 1.0);
 
-// The origin is the upper-left corner of the screen and coordinates ranging from (0.0, 0.0) to viewport size.
-varying vec2 screen_pos;
-
 varying vec4 modulate;
 
 void vertex() {
-	screen_pos = (CANVAS_MATRIX * MODEL_MATRIX * vec4(VERTEX, 0.0, 1.0)).xy;
 	modulate = COLOR;
 }
 
 void fragment() {
 	if (texture(TEXTURE, UV) == chroma_key) {
-		vec2 uv = screen_pos / resolution;
-		uv.x *= resolution.x / resolution.y;
+		vec2 uv = SCREEN_UV;
+		uv.x *= SCREEN_PIXEL_SIZE.y / SCREEN_PIXEL_SIZE.x;
 
 		float stars = 0.0;
 

--- a/scenes/game_elements/props/void/void_chromakey_material.tres
+++ b/scenes/game_elements/props/void/void_chromakey_material.tres
@@ -11,7 +11,6 @@ noise = SubResource("FastNoiseLite_ebh07")
 
 [resource]
 shader = ExtResource("1_nktdb")
-shader_parameter/resolution = Vector2(1920, 1080)
 shader_parameter/noise_texture = SubResource("NoiseTexture2D_bmckr")
 shader_parameter/sparsity = 20.0
 shader_parameter/flicker_rate = 7.0


### PR DESCRIPTION
Previously the starfield was drawn differently in a 1280×720 viewport
(the base resolution) compared to a 3840x2160 viewport (300% scale,
fullscreen on a 4K monitor). This is because we calculated the position
of each vertex in screen pixel coordinates (i.e. ranging from (0, 0) to
(1280x720) in the first case, and (0, 0) to (3840, 2160) in the second,
and then divided element-wise by a constant (1920, 1080) (not updated
for the resolution change) to get a texture coordinate. So the
bottom-right pixel of the viewport corresponded to (1, 1) in the first
case and (3, 3) in the second.

Instead we can use SCREEN_UV to get, as the name suggests, a UV
coordinate for the pixel on the screen (or rather, the viewport, but
when fullscreened these are the same) ranging from (0, 0) in the
top-left corner and (1, 1) in the bottom-right.

The other use of the `resolution` uniform was to scale the x coordinate
so that stars appear square. This previously gave the wrong effect if
the viewport is not 16:9 aspect ratio: the stars would be stretched with
the aspect ratio. Happily Godot provides SCREEN_PIXEL_SIZE which is
defined to be the inverse of the screen resolution, so we can get the
true aspect ratio from this and scale by that instead. (In fact I had
left a comment to this effect...)

Resolves https://github.com/endlessm/threadbare/issues/1189
