### PR TITLE
ci: Fix attaching web build to release

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -136,7 +136,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          mv web/index.pck '${{ env.PCK_NAME }}-${{ github.ref_name }}.pck'
+          cp web/index.pck '${{ env.PCK_NAME }}-${{ github.ref_name }}.pck'
           gh release upload '${{ github.ref_name }}' '${{ env.PCK_NAME }}-${{ github.ref_name }}.pck' --repo '${{ github.repository }}'
 
       - name: Download Flatpak bundle


### PR DESCRIPTION
I broke this in commit 01429b10604949b5100c190d0e839362ca390423. The
`-web.zip` attached to releases has no `index.pck` so is unusable.
