### PR TITLE
ci: Fix attaching linux metadata to release

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -125,50 +125,37 @@ jobs:
     needs: [build, flatpak]
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Download web bundle
         uses: actions/download-artifact@v8
         with:
           name: web
-          path: web
-
-      - name: Attach PCK
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          cp web/index.pck '${{ env.PCK_NAME }}-${{ github.ref_name }}.pck'
-          gh release upload '${{ github.ref_name }}' '${{ env.PCK_NAME }}-${{ github.ref_name }}.pck' --repo '${{ github.repository }}'
+          skip-decompress: true
 
       - name: Download Flatpak bundle
         uses: actions/download-artifact@v8
         with:
           name: threadbare-x86_64.flatpak
 
-      - name: Attach Flatpak bundle to release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          mv threadbare.flatpak 'threadbare-${{ github.ref_name }}-x86_64.flatpak'
-          gh release upload '${{ github.ref_name }}' 'threadbare-${{ github.ref_name }}-x86_64.flatpak' --repo '${{ github.repository }}'
-
-      - name: Attach web bundle to release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          pushd web
-          zip -r "../threadbare-${{ github.ref_name }}-web.zip" .
-          popd
-
-          gh release upload '${{ github.ref_name }}' 'threadbare-${{ github.ref_name }}-web.zip' --repo '${{ github.repository }}'
-
       - name: Download Linux metadata bundle
         uses: actions/download-artifact@v8
         with:
-          name: threadbare-linux-metadata
+          name: threadbare-linux-metadata.tar.gz
 
-      - name: Attach Linux metadata bundle to release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Attach assets to release
+        shell: bash
         run: |
+          set -ex
+          unzip web.zip index.pck
+          mv index.pck 'threadbare-${{ github.ref_name }}.pck'
+
+          mv web.zip 'threadbare-${{ github.ref_name }}-web.zip'
+
+          mv threadbare.flatpak 'threadbare-${{ github.ref_name }}-x86_64.flatpak'
           mv threadbare-linux-metadata.tar.gz 'threadbare-${{ github.ref_name }}-linux-metadata.tar.gz'
-          gh release upload '${{ github.ref_name }}' 'threadbare-${{ github.ref_name }}-linux-metadata.tar.gz' --repo '${{ github.repository }}'
+
+          for file in threadbare-${{ github.ref_name }}*; do
+            gh release upload '${{ github.ref_name }}' "$file" --repo '${{ github.repository }}'
+          done


### PR DESCRIPTION
In commit 01429b10604949b5100c190d0e839362ca390423 I took advantage of a
new feature in actions/upload-artifact to upload the .tar.gz file
without wrapping it in a .zip file.

However I did not update the release step to match. Fix this.

Rework the release step so that it downloads everything first,
then uploads. Don't unpack the whole web artifact and re-pack it: use
the new skip-decompress flag to get the .zip file, and attach that
directly to the release.

Factor out setting GITHUB_TOKEN in the environment.

Resolves https://github.com/endlessm/threadbare/issues/2062
