### PR TITLE
storybook_page: Fix shadowing warning

### DIFF
--- a/scenes/menus/storybook/components/storybook_page.gd
+++ b/scenes/menus/storybook/components/storybook_page.gd
@@ -19,12 +19,12 @@ var quest: Quest = preload("uid://dwl8letaanhhi"):
 
 
 # This is an in-joke/Easter egg for the Endless Access team
-func _chadify(name: String) -> String:
-	if name != "Justin Bourque":
-		return name
+static func _chadify(author_name: String) -> String:
+	if author_name != "Justin Bourque":
+		return author_name
 
 	var options := [
-		name,
+		author_name,
 		"Chad Bourque",
 		"Eric Bourque",
 	]


### PR DESCRIPTION
    W 0:00:00:472 GDScript::reload: The local function parameter "name"
    is shadowing an already-declared property in the base class "Node".
      <GDScript Error>SHADOWED_VARIABLE_BASE_CLASS
      <GDScript Source>storybook_page.gd:22 @ GDScript::reload()

Quite embarrassing to add a warning as part of an Easter egg.

I was surprised to discover that making the function `static` does not
prevent the warning, even though `name` is an instance property so is
not accessible in static methods. Make it static anyway.
