### PR TITLE
github: Add version & scene to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -10,6 +10,28 @@ body:
         Thanks for taking the time to file an issue! **Please provide as much
         detail as you can** so we can properly confirm, triage, and fix your bug.
 
+  - type: input
+    id: version
+    attributes:
+      label: Threadbare version
+      placeholder: e.g. v0.1.11
+      description: >
+        This is shown on the title screen. If you're not sure, leave it blank.
+    validations:
+      required: false
+
+  - type: input
+    id: scene
+    attributes:
+      label: Affected scene
+      placeholder: e.g. Fray's End, quests/lore_quests/quest_002/3_void_grappling/void_grappling_round_2.tscn
+      description: >
+        In which scene in the game is the problem? If it affects multiple
+        scenes, give an example. If you're not sure, describe the scene
+        visually, or leave it blank.
+    validations:
+      required: false
+
   - type: textarea
     id: about
     attributes:


### PR DESCRIPTION
As well as being useful information to add, by making these into form
fields we can have a button in the game that launches the "new bug" form
with the fields pre-filled.
