### PR TITLE
gitignore: Add Patchwork addon, launcher & files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,13 @@ __MACOSX
 
 # LibreOffice lock files, created while editing credits CSV files
 .~lock.*#
+
+# Godot Patchwork addon, bundled editor build, launcher, updater, and
+# config/state files
+.patchwork
+.patchwork_version
+/addons/patchwork/
+/godot_editor/
+launch-patchwork.exe
+patchwork.cfg
+update-patchwork.exe


### PR DESCRIPTION
This is a superset of
https://github.com/LilithSilver/patchwork-update-script/blob/main/.gitignore.template
with a few extra bits from
https://github.com/LilithSilver/patchwork-update-script/pull/6.
