### PR TITLE
Credits updates

### DIFF
--- a/scenes/menus/credits/data/community.csv
+++ b/scenes/menus/credits/data/community.csv
@@ -1,5 +1,6 @@
 Name,GitHub Username,Team
 ,AlexanderV24,
+Alvaro Ivan Roldan Candiotti,Zer0LoL,
 Anderson Urrutia Moreyra Benonits,,
 Carlos Sebastian Angulo Diaz,,
 ,DonSeja06,

--- a/scenes/menus/credits/data/endless_access.csv
+++ b/scenes/menus/credits/data/endless_access.csv
@@ -2,14 +2,16 @@ Team,Name,GitHub Username
 Games,Sarah Spiers,saspiers
 Games,Manuel Quiñones,manuq
 Games,Will Thompson,wjt
-Learning,Stephen Reid,
-Learning,Heather Drolet,
-Learning,Joana Filizola,
+Learning,Stephen Reid,PlayMatters
+Learning,Heather Drolet,hydrolet
+Learning,Joana Filizola,jofilizola
 Learning,Alejandro Farfán,
-Learning,Andrea Victoria Pavón,
-Learning,Bernado Campos Freitas,
+Learning,Andrea Victoria Pavón,Stregoica777
+Learning,Bernado Campos Freitas,bcsfreitas
 Learning,Jess Boyce,
-Learning,Justin Bourque,
+Learning,Justin Bourque,jgbourque
+Learning,Laura Foglia,LauraFoglia
+Learning,Luis A. Sánchez,lasr21
 Marketing,Rodrigo Sánchez López,
 Marketing,Cassidy James Blaede,cassidyjames
 Marketing,Luke Schoonbrood,


### PR DESCRIPTION
Credit Alvaro Roldan for the repel+grapple test level. (He is already
credited on After the Tremor.)

Add new Endless Access Learning team members.

Add GitHub usernames for most of the rest of the Learning team.
