### PR TITLE
SceneSwitcher: Add input to copy / paste current scene path

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -35,9 +35,9 @@ PauseOverlay="*res://scenes/globals/pause/pause_overlay.tscn"
 MusicPlayer="*res://scenes/globals/music_player/music_player.tscn"
 CameraShake="*res://scenes/globals/camera_shaker/camera_shake.tscn"
 InputHelper="*res://addons/input_helper/input_helper.gd"
-InputHud="uid://dfu3rocpande8"
 AspectRatioDebugger="*res://scenes/globals/aspect_ratio_debugger/aspect_ratio_debugger.tscn"
 MouseManager="*res://scenes/globals/mouse_manager/mouse_manager.tscn"
+InputHud="uid://dfu3rocpande8"
 
 [debug]
 
@@ -277,6 +277,16 @@ champ_blink={
 champ_walk_on_water={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)
+]
+}
+copy_current_scene={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":67,"key_label":0,"unicode":99,"location":0,"echo":false,"script":null)
+]
+}
+paste_current_scene={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":86,"key_label":0,"unicode":118,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -98,6 +98,20 @@ func _on_hash_changed(args: Array) -> void:
 		_restore_from_hash()
 
 
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed(&"copy_current_scene"):
+		var current_scene := get_tree().current_scene
+		if current_scene:
+			var scene_path := current_scene.scene_file_path
+			DisplayServer.clipboard_set(scene_path)
+	elif event.is_action_pressed(&"paste_current_scene"):
+		var scene_path := DisplayServer.clipboard_get()
+		if ResourceLoader.exists(scene_path):
+			SceneSwitcher.change_to_file_with_transition(
+				scene_path, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+			)
+
+
 func change_to_file_with_transition(
 	scene_path: String,
 	spawn_point: NodePath = ^"",


### PR DESCRIPTION
Rationale: Although the web build can load a specific scene by copying the scene path to the URL hash, people is not used to edit the URL.

With this change we could say: "Copy the following line that starts with res:// and then press Ctrl + V in the game".

In the future, two Copy / Paste buttons could be exposed in the Debug Settings.