### PR TITLE
ci: Export with Godot 4.6.2

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Export web build
         uses: endlessm/godot-export-action@v1
         with:
-          godot_version: "4.6.1"
+          godot_version: "4.6.2"
 
       - name: Check GDScript diagnostics
         run: |


### PR DESCRIPTION
This is a new maintenance release of Godot 4.6.

https://godotengine.org/article/maintenance-release-godot-4-6-2/