### PR TITLE
grappling_hook_start: Switch to Creep Outro when returning from powerup

### DIFF
--- a/scenes/game_elements/props/background_music/components/background_music.gd
+++ b/scenes/game_elements/props/background_music/components/background_music.gd
@@ -10,7 +10,7 @@ extends Node
 ## [br][br]
 ## If [member stream] is an [AudioStreamInteractive], you can control the clip
 ## to play at different points in the scene using [member clip], [method
-## switch_to_clip], and [ClipSwitcher] child nodes.
+## set_clip], and [ClipSwitcher] child nodes.
 ## [br][br]
 ## There should be at most one BackgroundMusic component in a scene.
 
@@ -32,16 +32,17 @@ extends Node
 
 ## If [member stream] is an [AudioStreamInteractive], switch to the named clip
 ## (rather than [member stream]'s [member AudioStreamInteractive.initial_clip])
-## when entering (or restarting) this scene.
+## when entering (or restarting) this scene. If the music is already playing,
+## switch to this clip.
 ## [br][br]
 ## If not set, the behaviour depends on what was playing in the previous scene.
 ## If a different stream was playing, [member stream]'s
 ## [member AudioStreamInteractive.initial_clip] will play. If [member stream]
 ## was already playing, whatever clip it happened to be playing will continue.
 @export var clip: StringName:
-	set(new_value):
-		clip = new_value
-		update_configuration_warnings()
+	set = set_clip
+
+var _playing := false
 
 
 func _get_clip_names() -> Array[String]:
@@ -91,16 +92,19 @@ func _exit_tree() -> void:
 ## Start playing [member stream], if it is not already playing. Does nothing if
 ## [member stream] is already playing.
 func play() -> void:
+	_playing = true
 	MusicPlayer.play_stream(stream, clip)
 
 
 ## Stop playing background music.
 func stop() -> void:
+	_playing = false
 	MusicPlayer.play_stream(null)
 
 
 ## If [member stream] is an [AudioStreamInteractive], and is playing,
 ## switch to [param clip_name].
-func switch_to_clip(clip_name: StringName) -> void:
-	# TODO: remove this wrapper?
-	MusicPlayer.switch_to_clip(clip_name)
+func set_clip(clip_name: StringName) -> void:
+	clip = clip_name
+	if _playing:
+		MusicPlayer.switch_to_clip(clip_name)

--- a/scenes/game_elements/props/background_music/components/clip_switcher.gd
+++ b/scenes/game_elements/props/background_music/components/clip_switcher.gd
@@ -95,4 +95,4 @@ func _on_body_entered(_body: Node2D) -> void:
 ## Tell the parent [BackgroundMusic] to switch to [member clip].
 func switch() -> void:
 	assert(_bgm)
-	_bgm.switch_to_clip(clip)
+	_bgm.set_clip(clip)

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_start.tscn
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_start.tscn
@@ -9,6 +9,7 @@
 [ext_resource type="Script" uid="uid://d1ly6uhh500xu" path="res://scenes/quests/lore_quests/quest_002/1_void_runner/components/tile_map_cover.gd" id="3_upilw"]
 [ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/components/sprite_frames/storyweaver_blue.tres" id="4_10ahs"]
 [ext_resource type="Resource" uid="uid://1jkpxbyl7bqk" path="res://scenes/quests/lore_quests/quest_002/2_grappling_hook/intro_start.dialogue" id="4_aiq76"]
+[ext_resource type="Script" uid="uid://c2lx7gvkonxaa" path="res://scenes/game_elements/props/background_music/components/clip_switcher.gd" id="4_wv4km"]
 [ext_resource type="PackedScene" uid="uid://evb46lm6ssu2" path="res://scenes/game_elements/props/hookable_pin/hookable_pin.tscn" id="5_cspw2"]
 [ext_resource type="TileSet" uid="uid://ciq5guijvlyb0" path="res://tiles/void_chromakey.tres" id="5_w67qe"]
 [ext_resource type="PackedScene" uid="uid://dvj15pnuqr2ua" path="res://scenes/game_elements/props/hookable_button_item/hookable_button_item.tscn" id="6_3g3x4"]
@@ -88,6 +89,11 @@ script = ExtResource("1_6n4qp")
 [node name="BackgroundMusic" parent="." unique_id=936481265 instance=ExtResource("1_wxpj0")]
 stream = ExtResource("2_wv4km")
 clip = &"Creep Intro"
+
+[node name="ClipSwitcher" type="Node" parent="BackgroundMusic" unique_id=485319442]
+script = ExtResource("4_wv4km")
+clip = &"Creep Outro"
+metadata/_custom_type_script = "uid://c2lx7gvkonxaa"
 
 [node name="Cinematic" type="Node2D" parent="." unique_id=419582141 node_paths=PackedStringArray("animation_player")]
 script = ExtResource("3_p44d7")
@@ -323,5 +329,6 @@ metadata/_custom_type_script = "uid://0enyu5v4ra34"
 [node name="HUD" parent="." unique_id=1590862536 instance=ExtResource("11_p44d7")]
 
 [connection signal="player_teleported" from="SpawnPointFromPowerup" to="." method="_on_spawn_point_from_powerup_player_teleported"]
+[connection signal="player_teleported" from="SpawnPointFromPowerup" to="BackgroundMusic/ClipSwitcher" method="switch"]
 
 [editable path="OnTheGround/VoidPatrolling"]

--- a/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_6.tscn
+++ b/scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/ink_combat_round_6.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="2_g1en3"]
 [ext_resource type="TileSet" uid="uid://dfp36ffpanjq2" path="res://tiles/elevation.tres" id="2_s2t2y"]
 [ext_resource type="Script" uid="uid://cp54mgi54nywo" path="res://scenes/game_logic/fill_game_logic.gd" id="3_1a5yo"]
+[ext_resource type="Script" uid="uid://c2lx7gvkonxaa" path="res://scenes/game_elements/props/background_music/components/clip_switcher.gd" id="3_4co4a"]
 [ext_resource type="Script" uid="uid://en37d2lad0px" path="res://scenes/quests/lore_quests/quest_003/2_ink_drinker_levels/components/barrel_unlock_sequence.gd" id="3_ihx08"]
 [ext_resource type="TileSet" uid="uid://bjx3gvah0ycl1" path="res://tiles/foam_2.tres" id="5_4co4a"]
 [ext_resource type="TileSet" uid="uid://do0ffypatd77h" path="res://tiles/bridges.tres" id="5_bl3l0"]
@@ -60,6 +61,11 @@ metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="BackgroundMusic" parent="." unique_id=1117240436 instance=ExtResource("1_7y6db")]
 stream = ExtResource("2_1a5yo")
+
+[node name="ClipSwitcher" type="Node" parent="BackgroundMusic" unique_id=184046629]
+script = ExtResource("3_4co4a")
+clip = &"cozy"
+metadata/_custom_type_script = "uid://c2lx7gvkonxaa"
 
 [node name="BarrelUnlockSequence" type="Node" parent="." unique_id=961449658 node_paths=PackedStringArray("barrels")]
 script = ExtResource("3_ihx08")
@@ -244,5 +250,5 @@ editor_draw_limits = true
 [node name="Mothsache" parent="." unique_id=1695758163 instance=ExtResource("30_4co4a")]
 position = Vector2(800, 362)
 
-[connection signal="goal_reached" from="FillGameLogic" to="BackgroundMusic" method="switch_to_clip" binds= [&"cozy"]]
+[connection signal="goal_reached" from="FillGameLogic" to="BackgroundMusic/ClipSwitcher" method="switch"]
 [connection signal="goal_reached" from="FillGameLogic" to="FillGameLogic/LevelCompletedAnimation" method="play" binds= ["goal_completed"]]


### PR DESCRIPTION
The desired behaviour is that when the player returns to this scene
after collecting the powerup, a music transition to Creep Outro is
triggered. Creep Loop will be playing, so this allows it to reach its
natural end, then play an outro, and transition to Still in preparation
for the next scene, void_grappling.

Previously this was achieved by having a second copy of this scene,
grappling_hook_end, which set BackgroundMusic.clip to "Creep Outro".
However since commit b86ea32df3ff7638049ccf3ac6af7d55392f7f19 this scene
was removed. As a result the music was switched to Creep Intro when
returning to this scene.

Change BackgroundMusic.switch_to_clip() into a setter for
BackgroundMusic.clip, so that it can be used before
BackgroundMusic.play() has been called (from _ready()). (This has the
nice side-benefit that you can now test AudioStreamInteractive
transitions in the editor by hitting Play in the inspector then
adjusting the Clip property!)

In grappling_hook_start, add a ClipSwitcher, triggered by the player
being teleported, in the same way that we disable the opening dialogue
in that case.

Update ink_combat_round_6 to use ClipSwitcher, matching
ink_combat_round_3.

Resolves https://github.com/endlessm/threadbare/issues/2110
