### PR TITLE
Add project setting to skip the sokobans

### DIFF
--- a/addons/threadbare_project_settings/threadbare_project_settings.gd
+++ b/addons/threadbare_project_settings/threadbare_project_settings.gd
@@ -1,16 +1,24 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 @tool
+class_name ThreadbareProjectSettings
 extends EditorPlugin
 
-## Debug aspect ratio while playing the game.
-const DEBUG_ASPECT_RATIO = "debugging/debug_aspect_ratio"
+const DEBUG_ASPECT_RATIO = "threadbare/debugging/debug_aspect_ratio"
+const SKIP_SOKOBANS = "threadbare/debugging/skip_sokobans"
 
 static var setttings_configuration = {
 	DEBUG_ASPECT_RATIO:
 	{
 		value = false,
 		type = TYPE_BOOL,
+		hint_string = "Display a letterbox overlay in the game, to debug aspect ratio issues.",
+	},
+	SKIP_SOKOBANS:
+	{
+		value = false,
+		type = TYPE_BOOL,
+		hint_string = "Skip the sokobans from the core game loop, and complete the quest directly.",
 	},
 }
 
@@ -20,9 +28,9 @@ func _enter_tree() -> void:
 
 
 static func setup_threadbare_settings() -> void:
-	for key: String in setttings_configuration:
-		var setting_config: Dictionary = setttings_configuration[key]
-		var setting_name: String = "threadbare/%s" % key
+	for setting_name: String in setttings_configuration:
+		var setting_config: Dictionary = setttings_configuration[setting_name]
+		assert(setting_name.begins_with("threadbare"))
 
 		if not ProjectSettings.has_setting(setting_name):
 			ProjectSettings.set_setting(setting_name, setting_config.value)

--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
@@ -56,11 +56,13 @@ func _find_elder(quest: Quest) -> Elder:
 
 func _on_interaction_ended() -> void:
 	if _have_threads:
-		# Hide interact label during scene transition
-		interact_area.disabled = true
-
-		GameState.set_incorporating_threads(true)
-		SceneSwitcher.change_to_file_with_transition(SOKOBANS.pick_random())
+		if not ProjectSettings.get_setting(ThreadbareProjectSettings.SKIP_SOKOBANS):
+			# Hide interact label during scene transition
+			interact_area.disabled = true
+			GameState.set_incorporating_threads(true)
+			SceneSwitcher.change_to_file_with_transition(SOKOBANS.pick_random())
+		else:
+			GameState.mark_quest_completed()
 
 
 func on_offering_succeeded() -> void:

--- a/scenes/globals/aspect_ratio_debugger/aspect_ratio_debugger.gd
+++ b/scenes/globals/aspect_ratio_debugger/aspect_ratio_debugger.gd
@@ -4,5 +4,5 @@ extends CanvasLayer
 
 
 func _ready() -> void:
-	if not ProjectSettings.get_setting("threadbare/debugging/debug_aspect_ratio"):
+	if not ProjectSettings.get_setting(ThreadbareProjectSettings.DEBUG_ASPECT_RATIO):
 		queue_free()


### PR DESCRIPTION
The Sokobans may be repurposed in the future. For now, add a setting so developers can skip them with a debug setting, in project.godot or in an override.cfg local file.

In the settings addon, add a class name so scripts can reference the settings by the constant. For that, move the "threadbare/" prefix to the constants and add an assertion for the prefix. Also move the comment to hint strings.