### PR TITLE
Add project settings to skip the splash + title screens

### DIFF
--- a/addons/threadbare_project_settings/threadbare_project_settings.gd
+++ b/addons/threadbare_project_settings/threadbare_project_settings.gd
@@ -6,6 +6,7 @@ extends EditorPlugin
 
 const DEBUG_ASPECT_RATIO = "threadbare/debugging/debug_aspect_ratio"
 const SKIP_SOKOBANS = "threadbare/debugging/skip_sokobans"
+const SKIP_SPLASH = "threadbare/debugging/skip_splash"
 
 static var setttings_configuration = {
 	DEBUG_ASPECT_RATIO:
@@ -19,6 +20,13 @@ static var setttings_configuration = {
 		value = false,
 		type = TYPE_BOOL,
 		hint_string = "Skip the sokobans from the core game loop, and complete the quest directly.",
+	},
+	SKIP_SPLASH:
+	{
+		value = false,
+		type = TYPE_BOOL,
+		hint_string =
+		"Skip the splash screen and title menu, and resume the game state. Like when clicking Continue.",
 	},
 }
 

--- a/scenes/menus/splash/components/splash.gd
+++ b/scenes/menus/splash/components/splash.gd
@@ -10,7 +10,7 @@ extends Control
 
 func _ready() -> void:
 	if ProjectSettings.get_setting(ThreadbareProjectSettings.SKIP_SPLASH):
-		SceneSwitcher.change_to_file(next_scene)
+		SceneSwitcher.change_to_file.call_deferred(next_scene)
 		return
 	logo_stitcher.finished.connect(scene_switch_timer.start)
 	scene_switch_timer.timeout.connect(switch_to_intro)

--- a/scenes/menus/splash/components/splash.gd
+++ b/scenes/menus/splash/components/splash.gd
@@ -9,6 +9,9 @@ extends Control
 
 
 func _ready() -> void:
+	if ProjectSettings.get_setting(ThreadbareProjectSettings.SKIP_SPLASH):
+		SceneSwitcher.change_to_file(next_scene)
+		return
 	logo_stitcher.finished.connect(scene_switch_timer.start)
 	scene_switch_timer.timeout.connect(switch_to_intro)
 

--- a/scenes/menus/title/components/title_screen.gd
+++ b/scenes/menus/title/components/title_screen.gd
@@ -9,6 +9,18 @@ extends Control
 @onready var credits: Control = %Credits
 
 
+func _ready() -> void:
+	if ProjectSettings.get_setting(ThreadbareProjectSettings.SKIP_SPLASH):
+		var saved_scene: Dictionary = GameState.restore()
+		(
+			SceneSwitcher
+			. change_to_file(
+				saved_scene["scene_path"],
+				saved_scene["spawn_point"],
+			)
+		)
+
+
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed(&"pause"):
 		get_viewport().set_input_as_handled()

--- a/scenes/menus/title/components/title_screen.gd
+++ b/scenes/menus/title/components/title_screen.gd
@@ -12,13 +12,10 @@ extends Control
 func _ready() -> void:
 	if ProjectSettings.get_setting(ThreadbareProjectSettings.SKIP_SPLASH):
 		var saved_scene: Dictionary = GameState.restore()
-		(
-			SceneSwitcher
-			. change_to_file(
-				saved_scene["scene_path"],
-				saved_scene["spawn_point"],
-			)
-		)
+		if saved_scene["scene_path"]:
+			SceneSwitcher.change_to_file(saved_scene["scene_path"], saved_scene["spawn_point"])
+		else:
+			SceneSwitcher.change_to_file(intro_scene)
 
 
 func _input(event: InputEvent) -> void:


### PR DESCRIPTION
And directly resume the persisted state.

When developing, it becomes a bit tedious to reach the persisted state by pressing keys and waiting for the transitions to happen. And starting the game from the main scene (splash) is the only way to debug saved state.

