### PR TITLE
CharacterRandomizer: Use own random number generator

### DIFF
--- a/scenes/game_elements/characters/components/character_randomizer.gd
+++ b/scenes/game_elements/characters/components/character_randomizer.gd
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 @tool
-extends Node2D
+class_name CharacterRandomizer
+extends CharacterBody2D
 ## @experimental
 ##
 ## Provide a single button to randomize various aspects of a character.
@@ -41,6 +42,8 @@ var random_texture_nodes: Array[RandomTextureSpriteBehavior] = []
 
 var _undoredo: Object  # EditorUndoRedoManager
 
+var _random_number_generator := RandomNumberGenerator.new()
+
 var _previous_look_at_side: Enums.LookAtSide = Enums.LookAtSide.UNSPECIFIED
 
 
@@ -49,18 +52,18 @@ var _previous_look_at_side: Enums.LookAtSide = Enums.LookAtSide.UNSPECIFIED
 ## Do it in a consistent way by first seeding the default random number generator
 ## with the [member character_seed].
 func apply_character_randomizations() -> void:
-	seed(character_seed)
+	_random_number_generator.seed = character_seed
 
 	if skin_recolor_nodes:
 		var new_skin_medium_color: Color
-		skin_recolor_nodes[-1].set_random_skin_color()
+		skin_recolor_nodes[-1].set_random_skin_color(_random_number_generator)
 		new_skin_medium_color = skin_recolor_nodes[-1].medium_color
 		for n in skin_recolor_nodes:
 			n.automatic_shades = true
 			n.medium_color = new_skin_medium_color
 
 	for n in random_texture_nodes:
-		n.randomize_texture()
+		n.randomize_texture(_random_number_generator)
 
 
 ## Set a random seed and randomize the character.

--- a/scenes/game_elements/components/cel_shading_recolor.gd
+++ b/scenes/game_elements/components/cel_shading_recolor.gd
@@ -159,9 +159,11 @@ func colorize() -> void:
 
 
 ## Pick a random color from [constant SKIN_COLORS] and automatically set all shades from it.
-func set_random_skin_color() -> void:
+func set_random_skin_color(rng: RandomNumberGenerator = null) -> void:
 	automatic_shades = true
-	medium_color = SKIN_COLORS.values().pick_random()
+	var random_int: int = rng.randi() if rng else randi()
+	var index := random_int % SKIN_COLORS.size()
+	medium_color = SKIN_COLORS.values()[index]
 
 
 func _get_configuration_warnings() -> PackedStringArray:

--- a/scenes/game_logic/sprite_behaviors/random_texture_sprite_behavior.gd
+++ b/scenes/game_logic/sprite_behaviors/random_texture_sprite_behavior.gd
@@ -45,8 +45,11 @@ func _offset_child_sprites(offset: Vector2) -> void:
 
 
 ## Pick a random texture from [member textures] and set it to the sprite.
-func randomize_texture() -> void:
-	var new_texture: Texture2D = textures.pick_random()
+func randomize_texture(rng: RandomNumberGenerator = null) -> void:
+	var random_int: int = rng.randi() if rng else randi()
+	var index := random_int % textures.size()
+	var new_texture := textures[index]
+
 	var offset := _get_offset_from_texture_filename(new_texture)
 	_offset_child_sprites(offset)
 	SpriteFramesHelper.replace_texture(null, new_texture, sprite.sprite_frames)


### PR DESCRIPTION
Avoid changing the seed of the base random number generator, which makes the rest of the game predictable. Instead, using its own RNG in this class.

Pass the RNG as argument to the CelShadingRecolor and RandomTextureSpriteBehavior, which now accept one, while still falling back to use the base RNG by default. This way, the character is consistent with its character_seed.

Luckly, characters randomized this way stay the same, because textures and skin colors are immediately called with the same seed as before.

Also: Add a class name and make it inherit from CharacterBody2D. The script is attached to CharacterBody2D nodes in all cases.

Fix https://github.com/endlessm/threadbare/issues/2130