### PR TITLE
project: Refer to InputHud global scene by path

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -35,7 +35,7 @@ PauseOverlay="*res://scenes/globals/pause/pause_overlay.tscn"
 MusicPlayer="*res://scenes/globals/music_player/music_player.tscn"
 CameraShake="*res://scenes/globals/camera_shaker/camera_shake.tscn"
 InputHelper="*res://addons/input_helper/input_helper.gd"
-InputHud="uid://dfu3rocpande8"
+InputHud="res://scenes/ui_elements/input_hints/input_hud.tscn"
 AspectRatioDebugger="*res://scenes/globals/aspect_ratio_debugger/aspect_ratio_debugger.tscn"
 MouseManager="*res://scenes/globals/mouse_manager/mouse_manager.tscn"
 


### PR DESCRIPTION
project: Refer to InputHud global scene by path

This is consistent with the other scenes and scripts listed here.
Without this the following error is emitted when the project is first
imported:

    ERROR: Unrecognized UID: "uid://dfu3rocpande8".
       at: get_id_path (core/io/resource_uid.cpp:208)
