### PR TITLE
Storybook: Hide navigation arrows at page boundaries

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -84,6 +84,9 @@ func _ready() -> void:
 
 ## Show/hide index or detail pages
 func _update_page_visibility() -> void:
+	left_button.visible = _current_spread_index > 0
+	right_button.visible = _current_spread_index < _quests.size()
+
 	if _current_spread_index == 0:
 		quest_container.visible = true
 		storybook_page.visible = false
@@ -117,10 +120,8 @@ func _switch_to_page(spread_index: int) -> void:
 	if total_spreads <= 1:
 		return
 
-	if spread_index < 0:
-		spread_index = total_spreads - 1
-	if spread_index >= total_spreads:
-		spread_index = 0
+	if spread_index < 0 or spread_index >= total_spreads:
+		return
 
 	if spread_index == _current_spread_index:
 		return


### PR DESCRIPTION
Hide the left arrow when on the first page of the storybook, and the right arrow when on the last page.

Previously, the arrows were always visible and navigating past the boundaries would wrap around to the other end of the book, which is not how books work.

Resolves https://github.com/endlessm/threadbare/issues/1815