### PR TITLE
verso: Fix UID in references to verso_projectile.tscn

### DIFF
--- a/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/ThrowingEnemyHealth.tscn
+++ b/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/ThrowingEnemyHealth.tscn
@@ -1,7 +1,7 @@
 [gd_scene format=3 uid="uid://dcoas3imo10p5"]
 
 [ext_resource type="Script" uid="uid://djmphyxuypgn1" path="res://scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/throwing_enemy_health.gd" id="1_88n2w"]
-[ext_resource type="PackedScene" uid="uid://gonywq78u3xd" path="res://scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/verso_projectile.tscn" id="2_1njs3"]
+[ext_resource type="PackedScene" uid="uid://cwfsydjtknnsn" path="res://scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/verso_projectile.tscn" id="2_1njs3"]
 [ext_resource type="SpriteFrames" uid="uid://deosvk5k4su5f" path="res://scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat_components/NO_EDIT_throwing_enemy.tres" id="2_88n2w"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_3vyb7"]


### PR DESCRIPTION
> WARNING: scene/resources/resource_format_text.cpp:500 -
> res://scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/ThrowingEnemyHealth.tscn:4 -
> ext_resource, invalid UID: uid://gonywq78u3xd -
> using text path instead:
> res://scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/verso_projectile.tscn

I caused this in commit 8633b43c70cea850298783b145a5295d3aa64630
somehow.
