### PR TITLE
SequencePuzzleObject: Add sprite_modulate property

### DIFF
--- a/scenes/game_elements/props/sequence_puzzle_object/components/sequence_puzzle_object.gd
+++ b/scenes/game_elements/props/sequence_puzzle_object/components/sequence_puzzle_object.gd
@@ -19,6 +19,12 @@ const REQUIRED_ANIMATIONS: Array[StringName] = [&"default", &"struck"]
 @export var sprite_frames: SpriteFrames = DEFAULT_SPRITE_FRAMES:
 	set = _set_sprite_frames
 
+## Color to apply to the object's sprites. Use this rather than
+## [Node2D.modulate] to avoid tinting any other visible children of this node,
+## such as particles.
+@export var sprite_modulate: Color = Color.WHITE:
+	set = _set_sprite_modulate
+
 ## Sound to play when the player strikes this object.
 @export var audio_stream: AudioStream
 
@@ -44,6 +50,12 @@ func _set_sprite_frames(new_sprite_frames: SpriteFrames) -> void:
 	update_configuration_warnings()
 
 
+func _set_sprite_modulate(new_value: Color) -> void:
+	sprite_modulate = new_value
+	if animated_sprite:
+		animated_sprite.modulate = new_value
+
+
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 	for animation in REQUIRED_ANIMATIONS:
@@ -54,6 +66,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 func _ready() -> void:
 	_set_sprite_frames(sprite_frames)
+	_set_sprite_modulate(sprite_modulate)
 	audio_stream_player_2d.stream = audio_stream
 
 

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1387,32 +1387,32 @@ y_sort_enabled = true
 position = Vector2(-1069, -33)
 
 [node name="C" parent="OnTheGround/SequencePuzzle/Rocks" unique_id=224048554 instance=ExtResource("22_0awvw")]
-modulate = Color(0.2937, 0.634442, 0.89, 1)
+sprite_modulate = Color(0.2937, 0.634442, 0.89, 1)
 audio_stream = ExtResource("24_fgtmq")
 
 [node name="D" parent="OnTheGround/SequencePuzzle/Rocks" unique_id=2145263970 instance=ExtResource("22_0awvw")]
-modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(80, -8)
+sprite_modulate = Color(0.89, 0.2937, 0.804817, 1)
 audio_stream = ExtResource("25_jdge0")
 
 [node name="E" parent="OnTheGround/SequencePuzzle/Rocks" unique_id=654636490 instance=ExtResource("22_0awvw")]
-modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(160, -16)
+sprite_modulate = Color(0.89, 0.804817, 0.2937, 1)
 audio_stream = ExtResource("26_pjyxn")
 
 [node name="F" parent="OnTheGround/SequencePuzzle/Rocks" unique_id=1823554115 instance=ExtResource("22_0awvw")]
-modulate = Color(0.2937, 0.89, 0.634451, 1)
 position = Vector2(240, -24)
+sprite_modulate = Color(0.2937, 0.89, 0.634451, 1)
 audio_stream = ExtResource("27_ftljy")
 
 [node name="G" parent="OnTheGround/SequencePuzzle/Rocks" unique_id=1942800513 instance=ExtResource("22_0awvw")]
-modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(320, -32)
+sprite_modulate = Color(0.464066, 0.2937, 0.89, 1)
 audio_stream = ExtResource("28_orlow")
 
 [node name="A" parent="OnTheGround/SequencePuzzle/Rocks" unique_id=707462418 instance=ExtResource("22_0awvw")]
-modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(400, -40)
+sprite_modulate = Color(0.89, 0.2937, 0.2937, 1)
 audio_stream = ExtResource("29_lbjl7")
 
 [node name="Bonfires" type="Node2D" parent="OnTheGround/SequencePuzzle" unique_id=954791934]

--- a/scenes/quests/lore_quests/quest_003/1_stealth_sequence_combo/stealth_sequence_combo.tscn
+++ b/scenes/quests/lore_quests/quest_003/1_stealth_sequence_combo/stealth_sequence_combo.tscn
@@ -117,23 +117,23 @@ metadata/_custom_type_script = "uid://ccc78coj2b1li"
 y_sort_enabled = true
 
 [node name="Rock1" parent="SequencePuzzle/Objects" unique_id=1453563311 instance=ExtResource("15_lxyj7")]
-modulate = Color(1, 0.139475, 0.64391, 1)
 position = Vector2(352, 1597)
+sprite_modulate = Color(1, 0.139475, 0.64391, 1)
 audio_stream = ExtResource("17_qhjva")
 
 [node name="Rock2" parent="SequencePuzzle/Objects" unique_id=2009407394 instance=ExtResource("15_lxyj7")]
-modulate = Color(0.168667, 0.14, 1, 1)
 position = Vector2(672, 1597)
+sprite_modulate = Color(0.168667, 0.14, 1, 1)
 audio_stream = ExtResource("20_46vvk")
 
 [node name="Rock3" parent="SequencePuzzle/Objects" unique_id=1849358100 instance=ExtResource("15_lxyj7")]
-modulate = Color(0.14, 0.971333, 1, 1)
 position = Vector2(992, 1592)
+sprite_modulate = Color(0.14, 0.971333, 1, 1)
 audio_stream = ExtResource("18_0cbql")
 
 [node name="Rock4" parent="SequencePuzzle/Objects" unique_id=346315264 instance=ExtResource("15_lxyj7")]
-modulate = Color(0.670333, 1, 0.14, 1)
 position = Vector2(1315, 1593)
+sprite_modulate = Color(0.670333, 1, 0.14, 1)
 audio_stream = ExtResource("20_lxyj7")
 
 [node name="Hints" type="Node2D" parent="SequencePuzzle" unique_id=1225714164]

--- a/scenes/quests/story_quests/el_abrigo/1_el_abrigo_sequence_puzzle/el_abrigo_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/el_abrigo/1_el_abrigo_sequence_puzzle/el_abrigo_sequence_puzzle.tscn
@@ -219,33 +219,33 @@ y_sort_enabled = true
 position = Vector2(183, 987)
 
 [node name="Blue" parent="OnTheGround/SequencePuzzle/Objects" unique_id=984965369 instance=ExtResource("5_cuqvo")]
-modulate = Color(0, 0.4, 0.6, 1)
 position = Vector2(-79, -215)
+sprite_modulate = Color(0, 0.4, 0.6, 1)
 audio_stream = ExtResource("7_661lj")
 
 [node name="Pink" parent="OnTheGround/SequencePuzzle/Objects" unique_id=102221486 instance=ExtResource("5_cuqvo")]
-modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(200, -320)
+sprite_modulate = Color(0.89, 0.2937, 0.804817, 1)
 audio_stream = ExtResource("8_jlwkv")
 
 [node name="Yellow" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1591554924 instance=ExtResource("5_cuqvo")]
-modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(481, -209)
+sprite_modulate = Color(0.89, 0.804817, 0.2937, 1)
 audio_stream = ExtResource("9_hl6ap")
 
 [node name="Green" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1191614102 instance=ExtResource("5_cuqvo")]
-modulate = Color(0.188235, 0.717647, 0, 1)
 position = Vector2(-81, -16)
+sprite_modulate = Color(0.188235, 0.717647, 0, 1)
 audio_stream = ExtResource("10_vlj61")
 
 [node name="Purple" parent="OnTheGround/SequencePuzzle/Objects" unique_id=2112479200 instance=ExtResource("5_cuqvo")]
-modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(206, 90)
+sprite_modulate = Color(0.464066, 0.2937, 0.89, 1)
 audio_stream = ExtResource("11_kni54")
 
 [node name="Red" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1598962089 instance=ExtResource("5_cuqvo")]
-modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(484, -11)
+sprite_modulate = Color(0.89, 0.2937, 0.2937, 1)
 audio_stream = ExtResource("12_lnhun")
 
 [node name="Signs" type="Node2D" parent="OnTheGround/SequencePuzzle" unique_id=487683127]

--- a/scenes/quests/story_quests/eldrune/3_sequence_puzzle/eldrune_puzzle_2.tscn
+++ b/scenes/quests/story_quests/eldrune/3_sequence_puzzle/eldrune_puzzle_2.tscn
@@ -131,39 +131,39 @@ y_sort_enabled = true
 position = Vector2(356, 453)
 
 [node name="Blue" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1714110091 instance=ExtResource("5_a4p44")]
-modulate = Color(0, 0.4, 0.6, 1)
 position = Vector2(417, 364)
 sprite_frames = ExtResource("6_ex0e8")
+sprite_modulate = Color(0, 0.4, 0.6, 1)
 audio_stream = ExtResource("7_laaar")
 
 [node name="Pink" parent="OnTheGround/SequencePuzzle/Objects" unique_id=26079988 instance=ExtResource("5_a4p44")]
-modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(636, 370)
 sprite_frames = ExtResource("6_ex0e8")
+sprite_modulate = Color(0.89, 0.2937, 0.804817, 1)
 audio_stream = ExtResource("8_usl7p")
 
 [node name="Yellow" parent="OnTheGround/SequencePuzzle/Objects" unique_id=4576570 instance=ExtResource("5_a4p44")]
-modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(815, 368)
 sprite_frames = ExtResource("6_ex0e8")
+sprite_modulate = Color(0.89, 0.804817, 0.2937, 1)
 audio_stream = ExtResource("9_thq1a")
 
 [node name="Green" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1858198744 instance=ExtResource("5_a4p44")]
-modulate = Color(0.8774063, 0, 0.009362971, 1)
 position = Vector2(627, 167)
 sprite_frames = ExtResource("6_ex0e8")
+sprite_modulate = Color(0.8774063, 0, 0.009362971, 1)
 audio_stream = ExtResource("11_vel5v")
 
 [node name="Purple" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1368268198 instance=ExtResource("5_a4p44")]
-modulate = Color(0.26699603, 0.6539098, 0.40640903, 1)
 position = Vector2(817, 170)
 sprite_frames = ExtResource("6_ex0e8")
+sprite_modulate = Color(0.26699603, 0.6539098, 0.40640903, 1)
 audio_stream = ExtResource("11_1leum")
 
 [node name="Red" parent="OnTheGround/SequencePuzzle/Objects" unique_id=870925294 instance=ExtResource("5_a4p44")]
-modulate = Color(0.87539595, 0.60444057, 0.5018247, 1)
 position = Vector2(414, 171)
 sprite_frames = ExtResource("6_ex0e8")
+sprite_modulate = Color(0.87539595, 0.60444057, 0.5018247, 1)
 audio_stream = ExtResource("12_2bc3v")
 
 [node name="Signs" type="Node2D" parent="OnTheGround/SequencePuzzle" unique_id=632013650]

--- a/scenes/quests/story_quests/renya_beyond_sorrow/2_sequence_puzzle/renya_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/2_sequence_puzzle/renya_sequence_puzzle.tscn
@@ -88,37 +88,36 @@ y_sort_enabled = true
 position = Vector2(523, 1183)
 
 [node name="Blue" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1375771381 instance=ExtResource("5_jo4hc")]
-modulate = Color(0, 0.4, 0.6, 1)
 position = Vector2(-126, -315)
 sprite_frames = ExtResource("6_aircv")
+sprite_modulate = Color(0, 0.4, 0.6, 1)
 audio_stream = ExtResource("7_nwtka")
 
 [node name="Pink" parent="OnTheGround/SequencePuzzle/Objects" unique_id=241389614 instance=ExtResource("5_jo4hc")]
-modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(338, -89)
 sprite_frames = ExtResource("6_s3vv2")
+sprite_modulate = Color(0.89, 0.2937, 0.804817, 1)
 audio_stream = ExtResource("8_yw2dt")
 
 [node name="Yellow" parent="OnTheGround/SequencePuzzle/Objects" unique_id=878136001 instance=ExtResource("5_jo4hc")]
-modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(-370, -84)
 sprite_frames = ExtResource("6_aircv")
+sprite_modulate = Color(0.89, 0.804817, 0.2937, 1)
 audio_stream = ExtResource("9_63qpu")
 
 [node name="Green" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1601100548 instance=ExtResource("5_jo4hc")]
-modulate = Color(0.188235, 0.717647, 0, 1)
 position = Vector2(248, -221)
 sprite_frames = ExtResource("6_aircv")
+sprite_modulate = Color(0.188235, 0.717647, 0, 1)
 audio_stream = ExtResource("10_ytm8d")
 
 [node name="Purple" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1865130574 instance=ExtResource("5_jo4hc")]
-modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(94, -318)
 sprite_frames = ExtResource("6_s3vv2")
+sprite_modulate = Color(0.464066, 0.2937, 0.89, 1)
 audio_stream = ExtResource("11_wejiw")
 
 [node name="Red" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1539764264 instance=ExtResource("5_jo4hc")]
-modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(-298, -218)
 sprite_frames = ExtResource("6_s3vv2")
 audio_stream = ExtResource("12_kcyae")

--- a/scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_puzzle.tscn
@@ -266,40 +266,40 @@ y_sort_enabled = true
 position = Vector2(356, 453)
 
 [node name="Blue" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1946621471 instance=ExtResource("4_8l7t1")]
-modulate = Color(0, 0.4, 0.6, 1)
 position = Vector2(123, -320)
 sprite_frames = ExtResource("6_m6vwj")
+sprite_modulate = Color(0, 0.4, 0.6, 1)
 audio_stream = ExtResource("12_at0ry")
 
 [node name="Orange" parent="OnTheGround/SequencePuzzle/Objects" unique_id=901852933 instance=ExtResource("4_8l7t1")]
-modulate = Color(0.917454, 0.399473, 0.227027, 1)
 texture_filter = 1
 position = Vector2(117, -213)
 sprite_frames = ExtResource("8_rijqc")
+sprite_modulate = Color(0.917454, 0.399473, 0.227027, 1)
 audio_stream = ExtResource("14_it68j")
 
 [node name="Yellow" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1303985235 instance=ExtResource("4_8l7t1")]
-modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(193, -153)
 sprite_frames = ExtResource("10_m0770")
+sprite_modulate = Color(0.89, 0.804817, 0.2937, 1)
 audio_stream = ExtResource("16_at0ry")
 
 [node name="Green" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1089572290 instance=ExtResource("4_8l7t1")]
-modulate = Color(0.188235, 0.717647, 0, 1)
 position = Vector2(298, -136)
 sprite_frames = ExtResource("12_vpkld")
+sprite_modulate = Color(0.188235, 0.717647, 0, 1)
 audio_stream = ExtResource("18_it68j")
 
 [node name="Purple" parent="OnTheGround/SequencePuzzle/Objects" unique_id=756329808 instance=ExtResource("4_8l7t1")]
-modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(383, -65)
 sprite_frames = ExtResource("6_0qchv")
+sprite_modulate = Color(0.464066, 0.2937, 0.89, 1)
 audio_stream = ExtResource("20_8ckgm")
 
 [node name="Red" parent="OnTheGround/SequencePuzzle/Objects" unique_id=10023335 instance=ExtResource("4_8l7t1")]
-modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(483, -67)
 sprite_frames = ExtResource("16_hvqie")
+sprite_modulate = Color(0.89, 0.2937, 0.2937, 1)
 audio_stream = ExtResource("22_het1f")
 
 [node name="Signs" type="Node2D" parent="OnTheGround/SequencePuzzle" unique_id=2064854387]

--- a/scenes/quests/story_quests/verso/3_verso_sequence_puzzle_happiness/verso_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/verso/3_verso_sequence_puzzle_happiness/verso_sequence_puzzle.tscn
@@ -133,163 +133,163 @@ y_sort_enabled = true
 position = Vector2(356, 477)
 
 [node name="Blue-A" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1413748821 instance=ExtResource("4_xjexm")]
-modulate = Color(0, 0.4, 0.6, 1)
 position = Vector2(-203, -255)
+sprite_modulate = Color(0, 0.4, 0.6, 1)
 audio_stream = ExtResource("6_s6j3y")
 
 [node name="Blue-B" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1054074109 instance=ExtResource("4_xjexm")]
-modulate = Color(0, 0.4, 0.6, 1)
 position = Vector2(-132, -256)
+sprite_modulate = Color(0, 0.4, 0.6, 1)
 audio_stream = ExtResource("6_s6j3y")
 
 [node name="Blue-C" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1123751243 instance=ExtResource("4_xjexm")]
-modulate = Color(0, 0.4, 0.6, 1)
 position = Vector2(-64, -255)
+sprite_modulate = Color(0, 0.4, 0.6, 1)
 audio_stream = ExtResource("6_s6j3y")
 
 [node name="Blue-D" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1678232760 instance=ExtResource("4_xjexm")]
-modulate = Color(0, 0.4, 0.6, 1)
 position = Vector2(3, -255)
+sprite_modulate = Color(0, 0.4, 0.6, 1)
 audio_stream = ExtResource("6_s6j3y")
 
 [node name="Orange-A" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1933845443 instance=ExtResource("4_xjexm")]
-modulate = Color(0.921569, 0.376471, 0.054902, 1)
 position = Vector2(308, 1)
+sprite_modulate = Color(0.921569, 0.376471, 0.054902, 1)
 audio_stream = ExtResource("6_s6j3y")
 
 [node name="Orange-B" parent="OnTheGround/SequencePuzzle/Objects" unique_id=929685039 instance=ExtResource("4_xjexm")]
-modulate = Color(0.921569, 0.376471, 0.054902, 1)
 position = Vector2(383, 1)
+sprite_modulate = Color(0.921569, 0.376471, 0.054902, 1)
 audio_stream = ExtResource("6_s6j3y")
 
 [node name="Orange-C" parent="OnTheGround/SequencePuzzle/Objects" unique_id=2066541135 instance=ExtResource("4_xjexm")]
-modulate = Color(0.921569, 0.376471, 0.054902, 1)
 position = Vector2(449, 1)
+sprite_modulate = Color(0.921569, 0.376471, 0.054902, 1)
 audio_stream = ExtResource("6_s6j3y")
 
 [node name="Orange-D" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1747611984 instance=ExtResource("4_xjexm")]
-modulate = Color(0.921569, 0.376471, 0.054902, 1)
 position = Vector2(517, 1)
+sprite_modulate = Color(0.921569, 0.376471, 0.054902, 1)
 audio_stream = ExtResource("6_s6j3y")
 
 [node name="Pink-A" parent="OnTheGround/SequencePuzzle/Objects" unique_id=534635230 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(309, -255)
+sprite_modulate = Color(0.89, 0.2937, 0.804817, 1)
 audio_stream = ExtResource("7_x86hm")
 
 [node name="Pink-B" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1563306123 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(382, -255)
+sprite_modulate = Color(0.89, 0.2937, 0.804817, 1)
 audio_stream = ExtResource("7_x86hm")
 
 [node name="Pink-C" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1117287534 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(448, -255)
+sprite_modulate = Color(0.89, 0.2937, 0.804817, 1)
 audio_stream = ExtResource("7_x86hm")
 
 [node name="Pink-D" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1988271274 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(515, -254)
+sprite_modulate = Color(0.89, 0.2937, 0.804817, 1)
 audio_stream = ExtResource("7_x86hm")
 
 [node name="Yellow-A" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1473069242 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(-203, 513)
+sprite_modulate = Color(0.89, 0.804817, 0.2937, 1)
 audio_stream = ExtResource("8_wnk0x")
 
 [node name="Yellow-B" parent="OnTheGround/SequencePuzzle/Objects" unique_id=840892090 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(-129, 513)
+sprite_modulate = Color(0.89, 0.804817, 0.2937, 1)
 audio_stream = ExtResource("8_wnk0x")
 
 [node name="Yellow-C" parent="OnTheGround/SequencePuzzle/Objects" unique_id=574464313 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(-62, 513)
+sprite_modulate = Color(0.89, 0.804817, 0.2937, 1)
 audio_stream = ExtResource("8_wnk0x")
 
 [node name="Yellow-D" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1546738903 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(7, 512)
+sprite_modulate = Color(0.89, 0.804817, 0.2937, 1)
 audio_stream = ExtResource("8_wnk0x")
 
 [node name="Green-A" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1020679212 instance=ExtResource("4_xjexm")]
-modulate = Color(0.188235, 0.717647, 0, 1)
 position = Vector2(-200, 257)
+sprite_modulate = Color(0.188235, 0.717647, 0, 1)
 audio_stream = ExtResource("9_85rm0")
 
 [node name="Green-B" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1954061251 instance=ExtResource("4_xjexm")]
-modulate = Color(0.188235, 0.717647, 0, 1)
 position = Vector2(-130, 257)
+sprite_modulate = Color(0.188235, 0.717647, 0, 1)
 audio_stream = ExtResource("9_85rm0")
 
 [node name="Green-C" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1809163742 instance=ExtResource("4_xjexm")]
-modulate = Color(0.188235, 0.717647, 0, 1)
 position = Vector2(-61, 257)
+sprite_modulate = Color(0.188235, 0.717647, 0, 1)
 audio_stream = ExtResource("9_85rm0")
 
 [node name="Green-D" parent="OnTheGround/SequencePuzzle/Objects" unique_id=601733256 instance=ExtResource("4_xjexm")]
-modulate = Color(0.188235, 0.717647, 0, 1)
 position = Vector2(2, 257)
+sprite_modulate = Color(0.188235, 0.717647, 0, 1)
 audio_stream = ExtResource("9_85rm0")
 
 [node name="Purple-A" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1020630675 instance=ExtResource("4_xjexm")]
-modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(310, 322)
+sprite_modulate = Color(0.464066, 0.2937, 0.89, 1)
 audio_stream = ExtResource("10_6bstu")
 
 [node name="Purple-B" parent="OnTheGround/SequencePuzzle/Objects" unique_id=2122563024 instance=ExtResource("4_xjexm")]
-modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(382, 322)
+sprite_modulate = Color(0.464066, 0.2937, 0.89, 1)
 audio_stream = ExtResource("10_6bstu")
 
 [node name="Purple-C" parent="OnTheGround/SequencePuzzle/Objects" unique_id=145104056 instance=ExtResource("4_xjexm")]
-modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(447, 321)
+sprite_modulate = Color(0.464066, 0.2937, 0.89, 1)
 audio_stream = ExtResource("10_6bstu")
 
 [node name="Purple-D" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1545623190 instance=ExtResource("4_xjexm")]
-modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(517, 321)
+sprite_modulate = Color(0.464066, 0.2937, 0.89, 1)
 audio_stream = ExtResource("10_6bstu")
 
 [node name="Red-A" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1596166043 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(-203, 1)
+sprite_modulate = Color(0.89, 0.2937, 0.2937, 1)
 audio_stream = ExtResource("11_oxk7y")
 
 [node name="Red-B" parent="OnTheGround/SequencePuzzle/Objects" unique_id=2026812242 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(-130, 1)
+sprite_modulate = Color(0.89, 0.2937, 0.2937, 1)
 audio_stream = ExtResource("11_oxk7y")
 
 [node name="Red-C" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1855725487 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(-64, 1)
+sprite_modulate = Color(0.89, 0.2937, 0.2937, 1)
 audio_stream = ExtResource("11_oxk7y")
 
 [node name="Red-D" parent="OnTheGround/SequencePuzzle/Objects" unique_id=581412990 instance=ExtResource("4_xjexm")]
-modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(3, 1)
+sprite_modulate = Color(0.89, 0.2937, 0.2937, 1)
 audio_stream = ExtResource("11_oxk7y")
 
 [node name="Aqua-A" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1566301102 instance=ExtResource("4_xjexm")]
-modulate = Color(0.157524, 0.609595, 0.547946, 1)
 position = Vector2(310, 514)
+sprite_modulate = Color(0.157524, 0.609595, 0.547946, 1)
 audio_stream = ExtResource("11_oxk7y")
 
 [node name="Aqua-B" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1935404781 instance=ExtResource("4_xjexm")]
-modulate = Color(0.157524, 0.609595, 0.547946, 1)
 position = Vector2(384, 514)
+sprite_modulate = Color(0.157524, 0.609595, 0.547946, 1)
 audio_stream = ExtResource("11_oxk7y")
 
 [node name="Aqua-C" parent="OnTheGround/SequencePuzzle/Objects" unique_id=1993277622 instance=ExtResource("4_xjexm")]
-modulate = Color(0.157524, 0.609595, 0.547946, 1)
 position = Vector2(451, 514)
+sprite_modulate = Color(0.157524, 0.609595, 0.547946, 1)
 audio_stream = ExtResource("11_oxk7y")
 
 [node name="Aqua-D" parent="OnTheGround/SequencePuzzle/Objects" unique_id=2121565449 instance=ExtResource("4_xjexm")]
-modulate = Color(0.157524, 0.609595, 0.547946, 1)
 position = Vector2(517, 514)
+sprite_modulate = Color(0.157524, 0.609595, 0.547946, 1)
 audio_stream = ExtResource("11_oxk7y")
 
 [node name="Signs" type="Node2D" parent="OnTheGround/SequencePuzzle" unique_id=1266414709]

--- a/scenes/quests/template_quests/NO_EDIT/3_NO_EDIT_sequence_puzzle/NO_EDIT_sequence_puzzle.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/3_NO_EDIT_sequence_puzzle/NO_EDIT_sequence_puzzle.tscn
@@ -74,32 +74,32 @@ y_sort_enabled = true
 position = Vector2(326, 489)
 
 [node name="Blue" parent="OnTheGround/SequencePuzzle/Objects" unique_id=288264421 instance=ExtResource("4_886p4")]
-modulate = Color(0, 0.4, 0.6, 1)
+sprite_modulate = Color(0, 0.4, 0.6, 1)
 audio_stream = ExtResource("5_5gydq")
 
 [node name="Pink" parent="OnTheGround/SequencePuzzle/Objects" unique_id=947200111 instance=ExtResource("4_886p4")]
-modulate = Color(0.89, 0.2937, 0.804817, 1)
 position = Vector2(88, -10)
+sprite_modulate = Color(0.89, 0.2937, 0.804817, 1)
 audio_stream = ExtResource("6_fpg8s")
 
 [node name="Yellow" parent="OnTheGround/SequencePuzzle/Objects" unique_id=883789242 instance=ExtResource("4_886p4")]
-modulate = Color(0.89, 0.804817, 0.2937, 1)
 position = Vector2(176, -20)
+sprite_modulate = Color(0.89, 0.804817, 0.2937, 1)
 audio_stream = ExtResource("7_abdni")
 
 [node name="Green" parent="OnTheGround/SequencePuzzle/Objects" unique_id=472811334 instance=ExtResource("4_886p4")]
-modulate = Color(0.188235, 0.717647, 0, 1)
 position = Vector2(264, -30)
+sprite_modulate = Color(0.188235, 0.717647, 0, 1)
 audio_stream = ExtResource("8_mka24")
 
 [node name="Purple" parent="OnTheGround/SequencePuzzle/Objects" unique_id=699569316 instance=ExtResource("4_886p4")]
-modulate = Color(0.464066, 0.2937, 0.89, 1)
 position = Vector2(352, -40)
+sprite_modulate = Color(0.464066, 0.2937, 0.89, 1)
 audio_stream = ExtResource("9_mmoxj")
 
 [node name="Red" parent="OnTheGround/SequencePuzzle/Objects" unique_id=141148153 instance=ExtResource("4_886p4")]
-modulate = Color(0.89, 0.2937, 0.2937, 1)
 position = Vector2(440, -50)
+sprite_modulate = Color(0.89, 0.2937, 0.2937, 1)
 audio_stream = ExtResource("10_ka56f")
 
 [node name="Signs" type="Node2D" parent="OnTheGround/SequencePuzzle" unique_id=1795857144]


### PR DESCRIPTION
Most instances of the sequence puzzle use the same sprite for all the
objects, with their colour adjusted using `modulate`. But we modulate
the entire tree of nodes (rooted at a StaticBody2D) rather than just the
AnimatedSprite2D.

Back when the puzzle was first prototyped, modulate was applied just to
the AnimatedSprite2D, based on the pitch of the note. I removed this in
commit ffd20d011aeaa275247e8d9c9cb0dda6c4a37016
("MusicalRock: Remove automatic modulation by note") which has this note:

> This looks a bit weird in the editor because the rock's collision shapes
> and "kick" interaction label also get modulated. But at runtime the
> collision shapes are invisible, and the label is not actually used – it
> just sets the position where the label belonging to the player will be
> positioned. And I consider modulating the sprite to be a temporary
> measure; it would be better to recolour the rocks.

The great thing about temporary measures is they tend not to be temporary!

I am working on replacing the interaction label (not used at runtime)
with an indicator floating above each interactable object, which *is*
visible at runtime, and so modulating the whole scene will no longer
suffice.

Add a `sprite_modulate` property which proxies through to the
`AnimatedSprite2D` within. Update every scene to use it. (Not all
sequence puzzles use this approach: special mention to After the Tremor
which has per-object sprites.)

In effect, this is a manual version of the approach I rejected in commit
ffd20d0:

> (I tried using PropertyUtils to export the modulate property of the
> AnimatedSprite2D. It solved this problem but in my opinion the cure was
> worse than the disease: it added more complexity to what is otherwise a
> very simple scene, and the resulting "Sprite Modulate" property in the
> inspector had no documentation.)

If only Godot had a built-in way for a scene to expose properties of its
children without going all the way to editable children!
