### PR TITLE
Move interact verb/action to HUD

### DIFF
--- a/scenes/game_elements/characters/components/character_randomizer_test.tscn
+++ b/scenes/game_elements/characters/components/character_randomizer_test.tscn
@@ -707,12 +707,12 @@ position = Vector2(225, 152)
 character_seed = 138976455
 
 [node name="InteractArea" type="Area2D" parent="OnTheGround/Townie" unique_id=713209077]
-visible = false
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_p47ir")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Townie/InteractArea" unique_id=780074207]
+visible = false
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_22pcm")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
@@ -772,12 +772,12 @@ sprite_frames = SubResource("SpriteFrames_3lql5")
 sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_ft3li"), SubResource("SpriteFrames_3lql5"), SubResource("SpriteFrames_txqd1"), SubResource("SpriteFrames_7xna1"), SubResource("SpriteFrames_y1u7u")])
 
 [node name="InteractArea" type="Area2D" parent="OnTheGround/Townie2" unique_id=1760778420]
-visible = false
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_p47ir")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Townie2/InteractArea" unique_id=1656214821]
+visible = false
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_22pcm")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
@@ -806,12 +806,12 @@ character_seed = 1246173203
 look_at_side = 1
 
 [node name="InteractArea" type="Area2D" parent="OnTheGround/Townie4" unique_id=785629688]
-visible = false
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_p47ir")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Townie4/InteractArea" unique_id=36122957]
+visible = false
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_22pcm")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)

--- a/scenes/game_elements/characters/npcs/cat/cat.tscn
+++ b/scenes/game_elements/characters/npcs/cat/cat.tscn
@@ -46,6 +46,7 @@ action = "Pet the cat"
 metadata/_custom_type_script = "uid://du8wfijr35r35"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=1720455095]
+visible = false
 position = Vector2(5, -28)
 shape = SubResource("RectangleShape2D_t04tf")
 debug_color = Color(0.6290859, 0.52632225, 0.15803415, 0.41960785)

--- a/scenes/game_elements/characters/npcs/talker/talker.tscn
+++ b/scenes/game_elements/characters/npcs/talker/talker.tscn
@@ -33,7 +33,6 @@ unique_name_in_owner = true
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_c0xhn")
-interact_label_position = Vector2(0, -100)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=792948505]
 position = Vector2(0, -29)

--- a/scenes/game_elements/characters/player/components/player_interaction.gd
+++ b/scenes/game_elements/characters/player/components/player_interaction.gd
@@ -3,8 +3,9 @@
 class_name PlayerInteraction
 extends Node2D
 
-## Emitted when [method can_interact] will return a different value.
-signal can_interact_changed
+## Emitted when the entity the player is able to interact with changes (possibly
+## to nothing).
+signal interact_action_changed
 
 ## The character that gains interaction.
 ## [br][br]
@@ -14,8 +15,6 @@ signal can_interact_changed
 	set = _set_character
 
 @onready var character_sight: CharacterSight = %CharacterSight
-@onready var interact_marker: Marker2D = %InteractMarker
-@onready var interact_label: FixedSizeLabel = %InteractLabel
 
 @onready var player: Player = self.owner as Player
 
@@ -25,10 +24,15 @@ func _set_character(new_character: CharacterBody2D) -> void:
 	update_configuration_warnings()
 
 
-## Returns [code]true[/code] if the character is currently able to interact with
-## something in the environment.
-func can_interact() -> bool:
-	return character_sight.interact_area != null
+## Returns the human-readable text of [member character]'s current interact
+## action (e.g. [code]"Talk"[/code]), or [code]""[/code] (empty string) if
+## [member character] cannot currently interact with anything. Use [signal
+## interact_action_changed] to monitor for changes.
+func get_interact_action() -> String:
+	if character_sight.interact_area != null:
+		var action := character_sight.interact_area.action
+		return action if action else tr("Interact")
+	return ""
 
 
 func _is_interacting() -> bool:
@@ -47,14 +51,6 @@ func _ready() -> void:
 	_on_character_sight_interact_area_changed()
 
 
-func _process(_delta: float) -> void:
-	if not character_sight.interact_area:
-		return
-	interact_marker.global_position = (
-		character_sight.interact_area.get_global_interact_label_position()
-	)
-
-
 func _unhandled_input(_event: InputEvent) -> void:
 	if _is_interacting():
 		return
@@ -68,7 +64,6 @@ func _unhandled_input(_event: InputEvent) -> void:
 
 		get_viewport().set_input_as_handled()
 		character_sight.monitoring = false
-		interact_label.visible = false
 		interact_area.interaction_ended.connect(_on_interaction_ended, CONNECT_ONE_SHOT)
 		interact_area.start_interaction(player, character_sight.is_looking_from_right)
 
@@ -81,13 +76,4 @@ func _on_interaction_ended() -> void:
 
 
 func _on_character_sight_interact_area_changed() -> void:
-	if _is_interacting():
-		return
-
-	if not character_sight.interact_area:
-		interact_label.visible = false
-	else:
-		interact_label.visible = true
-		interact_label.label_text = character_sight.interact_area.action
-
-	can_interact_changed.emit()
+	interact_action_changed.emit()

--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -8,7 +8,6 @@
 [ext_resource type="Script" uid="uid://bpu6jo4kvehlg" path="res://scenes/game_elements/characters/player/components/player_interaction.gd" id="3_dqkch"]
 [ext_resource type="Script" uid="uid://qro4uo83ba8f" path="res://scenes/game_elements/characters/player/components/player_sprite.gd" id="3_qlg0r"]
 [ext_resource type="Script" uid="uid://necvar42rnih" path="res://scenes/game_elements/props/character_sight/character_sight.gd" id="6_3in67"]
-[ext_resource type="PackedScene" uid="uid://yfpfno276rol" path="res://scenes/game_elements/props/fixed_size_label/fixed_size_label.tscn" id="6_h17s1"]
 [ext_resource type="Script" uid="uid://e78f8iq448e1" path="res://scenes/game_elements/characters/player/components/animation_player.gd" id="7_0owmy"]
 [ext_resource type="AudioStream" uid="uid://cx6jv2cflrmqu" path="res://assets/third_party/sounds/characters/player/Foot.ogg" id="11_blfj0"]
 [ext_resource type="Texture2D" uid="uid://dxaq5piwxqnht" path="res://scenes/game_elements/characters/player/components/dust.png" id="12_3in67"]
@@ -419,22 +418,6 @@ character = NodePath("../..")
 position = Vector2(47, -30)
 shape = SubResource("RectangleShape2D_blfj0")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
-
-[node name="InteractMarker" type="Marker2D" parent="PlayerInteraction" unique_id=439387414]
-unique_name_in_owner = true
-position = Vector2(-1, -116)
-
-[node name="InteractLabel" parent="PlayerInteraction/InteractMarker" unique_id=554498577 instance=ExtResource("6_h17s1")]
-unique_name_in_owner = true
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 1.0
-offset_top = 11.0
-offset_right = 1.0
-offset_bottom = 11.0
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="PlayerRepel" parent="." unique_id=1324972992 instance=ExtResource("12_tnibl")]
 unique_name_in_owner = true

--- a/scenes/game_elements/props/character_sight/character_sight.gd
+++ b/scenes/game_elements/props/character_sight/character_sight.gd
@@ -76,10 +76,15 @@ func _process(_delta: float) -> void:
 
 
 func _on_area_entered(_area: Area2D) -> void:
-	interact_area = _get_best_interact_area()
-	interact_area_changed.emit()
+	_update_interact_area()
 
 
 func _on_area_exited(_area: Area2D) -> void:
-	interact_area = _get_best_interact_area()
-	interact_area_changed.emit()
+	_update_interact_area()
+
+
+func _update_interact_area() -> void:
+	var best := _get_best_interact_area()
+	if interact_area != best:
+		interact_area = best
+		interact_area_changed.emit()

--- a/scenes/game_elements/props/checkpoint/checkpoint.tscn
+++ b/scenes/game_elements/props/checkpoint/checkpoint.tscn
@@ -24,12 +24,12 @@ sprite_frames = ExtResource("4_3xcwf")
 animation = &"idle"
 autoplay = "idle"
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=2037902510]
+[node name="InteractArea" type="Area2D" parent="." unique_id=2037902510 node_paths=PackedStringArray("marker")]
 unique_name_in_owner = true
 collision_layer = 0
 collision_mask = 0
 script = ExtResource("4_bjlxs")
-interact_label_position = Vector2(0, -128)
+marker = NodePath("Marker")
 disabled = true
 action = "Admire"
 metadata/_custom_type_script = "uid://du8wfijr35r35"
@@ -38,6 +38,9 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 position = Vector2(1, -4)
 shape = SubResource("CircleShape2D_3xcwf")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=1178774098]
+position = Vector2(0, -128)
 
 [node name="TalkBehavior" type="Node" parent="." unique_id=487856562 node_paths=PackedStringArray("interact_area")]
 unique_name_in_owner = true

--- a/scenes/game_elements/props/collectible_item/collectible_item.tscn
+++ b/scenes/game_elements/props/collectible_item/collectible_item.tscn
@@ -94,6 +94,18 @@ tracks/6/keys = {
 "update": 0,
 "values": [0.0]
 }
+tracks/7/type = "value"
+tracks/7/imported = false
+tracks/7/enabled = true
+tracks/7/path = NodePath("InteractArea:disabled")
+tracks/7/interp = 1
+tracks/7/loop_wrap = true
+tracks/7/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
 
 [sub_resource type="Animation" id="Animation_7ff3m"]
 resource_name = "collected"
@@ -197,6 +209,18 @@ tracks/7/keys = {
 "update": 0,
 "values": [0.0, 0.0, -12.0]
 }
+tracks/8/type = "value"
+tracks/8/imported = false
+tracks/8/enabled = true
+tracks/8/path = NodePath("InteractArea:disabled")
+tracks/8/interp = 1
+tracks/8/loop_wrap = true
+tracks/8/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
 
 [sub_resource type="Animation" id="Animation_qy0vu"]
 resource_name = "reveal"
@@ -277,17 +301,20 @@ height = 28.0
 [node name="CollectibleItem" type="Node2D" unique_id=327991066]
 script = ExtResource("1_7ff3m")
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=1327503985]
+[node name="InteractArea" type="Area2D" parent="." unique_id=1327503985 node_paths=PackedStringArray("marker")]
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("2_1kegn")
-interact_label_position = Vector2(0, -71)
+marker = NodePath("Marker")
 action = "Collect"
 metadata/_custom_type_script = "uid://du8wfijr35r35"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=1121983883]
 shape = SubResource("CircleShape2D_ghwae")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=1961850851]
+position = Vector2(0, -48)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=1869284545]
 libraries/ = SubResource("AnimationLibrary_8dm1m")

--- a/scenes/game_elements/props/eternal_loom/eternal_loom.tscn
+++ b/scenes/game_elements/props/eternal_loom/eternal_loom.tscn
@@ -542,14 +542,13 @@ position = Vector2(-1.5, 32)
 shape = SubResource("RectangleShape2D_uojly")
 debug_color = Color(0, 0.588235, 0.698039, 0.419608)
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=1735004807]
+[node name="InteractArea" type="Area2D" parent="." unique_id=1735004807 node_paths=PackedStringArray("marker")]
 unique_name_in_owner = true
-visible = false
 position = Vector2(0, 55)
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_mjlja")
-interact_label_position = Vector2(0, 45)
+marker = NodePath("Marker")
 action = "Use Eternal Loom"
 metadata/_custom_type_script = "uid://du8wfijr35r35"
 
@@ -557,6 +556,9 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 position = Vector2(0, 120)
 shape = SubResource("RectangleShape2D_uhynt")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=556753843]
+position = Vector2(0, -152)
 
 [node name="TalkBehavior" type="Node" parent="." unique_id=562216088 node_paths=PackedStringArray("interact_area")]
 unique_name_in_owner = true

--- a/scenes/game_elements/props/interact_area/interact_area.gd
+++ b/scenes/game_elements/props/interact_area/interact_area.gd
@@ -20,20 +20,26 @@ signal interaction_ended
 ## Emitted when characters start or stop seeing this area for interaction.
 signal observers_changed
 
-const EXAMPLE_INTERACTION_FONT = preload("uid://c3bb7lmvdqc5e")
-const EXAMPLE_INTERACTION_FONT_SIZE = 34
+const INDICATOR_SCENE := preload("uid://d252j2mhya0kq")
 
-## Vector2 that approximates the position in which the interact label would
-## appear when a player is close.
-@export_custom(PROPERTY_HINT_RANGE, "-200,200,1,suffix:px,or_greater,or_less")
-var interact_label_position: Vector2:
+## Position at which to show an arrow when this area is being observed. This
+## should generally be centred, slightly above the visible extents of the parent
+## object. If not set, a default position will be used, which may be good enough.
+@export var marker: Marker2D:
 	set(new_value):
-		interact_label_position = new_value
-		queue_redraw()
+		if marker and _indicator:
+			marker.remove_child(_indicator)
+		marker = new_value
+		if marker and _indicator:
+			marker.add_child(_indicator)
+
 @export var disabled: bool = false:
 	set(new_value):
 		disabled = new_value
 		set_collision_layer_value(Enums.CollisionLayers.INTERACTABLE, not disabled)
+		if _indicator:
+			_indicator.visible = not disabled
+
 @export var action: String = "Talk"
 
 ## Whether this area is being observed by one or more characters.
@@ -43,6 +49,8 @@ var is_being_observed: bool:
 
 var _observers: Array[CharacterSight] = []
 
+var _indicator: Node2D
+
 
 func start_interaction(player: Player, from_right: bool) -> void:
 	interaction_started.emit(player, from_right)
@@ -50,10 +58,6 @@ func start_interaction(player: Player, from_right: bool) -> void:
 
 func end_interaction() -> void:
 	interaction_ended.emit()
-
-
-func get_global_interact_label_position() -> Vector2:
-	return to_global(interact_label_position)
 
 
 ## A [CharacterSight] calls this when it starts seeing this area.
@@ -78,32 +82,19 @@ func _ready() -> void:
 	# Initialise interactable bit in collision_layer
 	disabled = disabled
 
+	if not marker and not Engine.is_editor_hint():
+		marker = Marker2D.new()
+		marker.name = "Marker"
+		# Vaguely sensible default position
+		marker.position = Vector2(0, -64)
+		add_child(marker)
 
-func _draw() -> void:
-	if not Engine.is_editor_hint():
-		return
+	_indicator = INDICATOR_SCENE.instantiate()
+	if marker:
+		marker.add_child(_indicator)
 
-	var string_size := EXAMPLE_INTERACTION_FONT.get_string_size(
-		action, HORIZONTAL_ALIGNMENT_LEFT, -1, EXAMPLE_INTERACTION_FONT_SIZE
-	)
-	var draw_position := (
-		interact_label_position - Vector2(string_size.x, -string_size.y * 2.0) / 2.0
-	)
-	draw_string(
-		EXAMPLE_INTERACTION_FONT,
-		draw_position,
-		action,
-		HORIZONTAL_ALIGNMENT_LEFT,
-		-1,
-		EXAMPLE_INTERACTION_FONT_SIZE
-	)
-	draw_string_outline(
-		EXAMPLE_INTERACTION_FONT,
-		draw_position,
-		action,
-		HORIZONTAL_ALIGNMENT_LEFT,
-		-1,
-		EXAMPLE_INTERACTION_FONT_SIZE,
-		1,
-		Color.BLACK
-	)
+	observers_changed.connect(_on_observers_changed)
+
+
+func _on_observers_changed() -> void:
+	_indicator.bouncing = is_being_observed

--- a/scenes/game_elements/props/interact_area/interact_indicator.gd
+++ b/scenes/game_elements/props/interact_area/interact_indicator.gd
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Node2D
+
+var bouncing := false:
+	set = set_bouncing
+
+@onready var animation_player: AnimationPlayer = %AnimationPlayer
+
+
+func set_bouncing(new_value: bool) -> void:
+	bouncing = new_value
+	if animation_player:
+		animation_player.play(&"bounce" if new_value else &"idle")
+
+
+func _ready() -> void:
+	set_bouncing(bouncing)

--- a/scenes/game_elements/props/interact_area/interact_indicator.gd.uid
+++ b/scenes/game_elements/props/interact_area/interact_indicator.gd.uid
@@ -1,0 +1,1 @@
+uid://darg2a58q4hrn

--- a/scenes/game_elements/props/interact_area/interact_indicator.tscn
+++ b/scenes/game_elements/props/interact_area/interact_indicator.tscn
@@ -1,0 +1,106 @@
+[gd_scene format=3 uid="uid://d252j2mhya0kq"]
+
+[ext_resource type="Script" uid="uid://darg2a58q4hrn" path="res://scenes/game_elements/props/interact_area/interact_indicator.gd" id="1_45h81"]
+[ext_resource type="Texture2D" uid="uid://cheu0l1ap1r8y" path="res://assets/first_party/user_interface/indicator_down.png" id="1_ld861"]
+
+[sub_resource type="Animation" id="Animation_45h81"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("IndicatorDown:offset")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("IndicatorDown:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+
+[sub_resource type="Animation" id="Animation_o3oko"]
+resource_name = "bounce"
+length = 0.5
+loop_mode = 1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("IndicatorDown:offset")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.25, 0.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(0, 0), Vector2(0, -8), Vector2(0, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("IndicatorDown:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+
+[sub_resource type="Animation" id="Animation_sssui"]
+resource_name = "idle"
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("IndicatorDown:offset")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("IndicatorDown:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_sssui"]
+_data = {
+&"RESET": SubResource("Animation_45h81"),
+&"bounce": SubResource("Animation_o3oko"),
+&"idle": SubResource("Animation_sssui")
+}
+
+[node name="InteractIndicator" type="Node2D" unique_id=544003245]
+script = ExtResource("1_45h81")
+
+[node name="IndicatorDown" type="Sprite2D" parent="." unique_id=1137596536]
+z_index = 1
+texture = ExtResource("1_ld861")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=1940688738]
+unique_name_in_owner = true
+libraries/ = SubResource("AnimationLibrary_sssui")

--- a/scenes/game_elements/props/powerup/powerup.tscn
+++ b/scenes/game_elements/props/powerup/powerup.tscn
@@ -80,12 +80,12 @@ rotation = -1.5707964
 shape = SubResource("CapsuleShape2D_bq5to")
 debug_color = Color(0.976711, 0, 0.409753, 0.42)
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=1443651205]
+[node name="InteractArea" type="Area2D" parent="." unique_id=1443651205 node_paths=PackedStringArray("marker")]
 unique_name_in_owner = true
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("2_q7xhf")
-interact_label_position = Vector2(0, -142)
+marker = NodePath("Marker")
 action = "Collect Repel"
 
 [node name="InteractCollision" type="CollisionShape2D" parent="InteractArea" unique_id=1651676696]
@@ -97,6 +97,9 @@ debug_color = Color(0.600391, 0.54335, 0, 0.42)
 [node name="PowerupShadow" type="Sprite2D" parent="InteractArea" unique_id=1565501906]
 position = Vector2(0, -34)
 texture = ExtResource("6_sba0c")
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=824023387]
+position = Vector2(0, -96)
 
 [node name="HighlightEffect" type="AnimatedSprite2D" parent="." unique_id=1553184658]
 unique_name_in_owner = true

--- a/scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn
+++ b/scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn
@@ -25,18 +25,21 @@ position = Vector2(0, -2)
 rotation = 1.5708
 shape = SubResource("CapsuleShape2D_kw7av")
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=412224390]
+[node name="InteractArea" type="Area2D" parent="." unique_id=412224390 node_paths=PackedStringArray("marker")]
 unique_name_in_owner = true
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_55nmp")
-interact_label_position = Vector2(0, 30)
+marker = NodePath("Marker")
 action = "Tap"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=1667228689]
 position = Vector2(0, -16)
 shape = SubResource("RectangleShape2D_kw7av")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=858904951]
+position = Vector2(0, -64)
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="." unique_id=558184317]
 unique_name_in_owner = true

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock.tscn
@@ -26,18 +26,21 @@ position = Vector2(0, -4)
 rotation = 1.5708
 shape = SubResource("CapsuleShape2D_4t6fr")
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=1524388095]
+[node name="InteractArea" type="Area2D" parent="." unique_id=1524388095 node_paths=PackedStringArray("marker")]
 unique_name_in_owner = true
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_sbibg")
-interact_label_position = Vector2(0, 30)
+marker = NodePath("Marker")
 action = "Tap"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=1665980500]
 position = Vector2(0, -16)
 shape = SubResource("RectangleShape2D_kw7av")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=87544084]
+position = Vector2(0, -64)
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="." unique_id=2104104112]
 unique_name_in_owner = true

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.tscn
@@ -30,16 +30,19 @@ autoplay = "idle"
 rotation = -1.5708
 shape = SubResource("CapsuleShape2D_lutqc")
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=1339722026]
+[node name="InteractArea" type="Area2D" parent="." unique_id=1339722026 node_paths=PackedStringArray("marker")]
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_2wo0h")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=98094106]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_bqjp5")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=1186921933]
+position = Vector2(0, -100)
 
 [node name="TalkBehavior" type="Node" parent="." unique_id=412951492 node_paths=PackedStringArray("interact_area")]
 script = ExtResource("4_8g08d")

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/townie.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/townie.tscn
@@ -30,17 +30,20 @@ autoplay = "idle"
 rotation = -1.5708
 shape = SubResource("CapsuleShape2D_3vyb7")
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=1337421199]
+[node name="InteractArea" type="Area2D" parent="." unique_id=1337421199 node_paths=PackedStringArray("marker")]
 unique_name_in_owner = true
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_q6d64")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=2031162428]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=931129123]
+position = Vector2(0, -100)
 
 [node name="TalkBehavior" type="Node" parent="." unique_id=303476402 node_paths=PackedStringArray("interact_area")]
 unique_name_in_owner = true

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/buttons_collector.tscn
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/buttons_collector.tscn
@@ -27,16 +27,19 @@ autoplay = "idle"
 rotation = -1.5708
 shape = SubResource("CapsuleShape2D_vnm58")
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=1488513282]
+[node name="InteractArea" type="Area2D" parent="." unique_id=1488513282 node_paths=PackedStringArray("marker")]
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_bpxq8")
-interact_label_position = Vector2(0, -128)
+marker = NodePath("Marker")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=1253932590]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_vnm58")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=2111856598]
+position = Vector2(0, -128)
 
 [node name="TalkBehavior" type="Node" parent="." unique_id=1124185946 node_paths=PackedStringArray("interact_area")]
 script = ExtResource("4_tv1as")

--- a/scenes/quests/lore_quests/quest_002/4_closing_transition/closing_transition.tscn
+++ b/scenes/quests/lore_quests/quest_002/4_closing_transition/closing_transition.tscn
@@ -466,21 +466,23 @@ script = ExtResource("14_pditp")
 interact_area = NodePath("../InteractArea")
 metadata/_custom_type_script = "uid://edcifob4jc4s"
 
-[node name="InteractArea" type="Area2D" parent="OnTheGround" unique_id=248145530]
-visible = false
+[node name="InteractArea" type="Area2D" parent="OnTheGround" unique_id=248145530 node_paths=PackedStringArray("marker")]
 position = Vector2(928, 424)
 rotation = 3.1415927
 scale = Vector2(1, -1)
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("14_5uden")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 metadata/_custom_type_script = "uid://du8wfijr35r35"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/InteractArea" unique_id=153059657]
 position = Vector2(-19, -11)
 shape = SubResource("RectangleShape2D_e2p5u")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="OnTheGround/InteractArea" unique_id=1764721366]
+position = Vector2(0, -100)
 
 [node name="Houses" type="Node2D" parent="OnTheGround" unique_id=1300750032]
 y_sort_enabled = true

--- a/scenes/quests/story_quests/champ/2_sequence_puzzle/champ_sequence_puzzle_object.tscn
+++ b/scenes/quests/story_quests/champ/2_sequence_puzzle/champ_sequence_puzzle_object.tscn
@@ -28,18 +28,21 @@ position = Vector2(3, 7)
 rotation = 1.5708
 shape = SubResource("RectangleShape2D_flhem")
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=560626341]
+[node name="InteractArea" type="Area2D" parent="." unique_id=560626341 node_paths=PackedStringArray("marker")]
 unique_name_in_owner = true
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("4_g5jna")
-interact_label_position = Vector2(0, 30)
+marker = NodePath("Marker")
 action = "Tap"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=1674431163]
 position = Vector2(3, -11)
 shape = SubResource("RectangleShape2D_kw7av")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=626671535]
+position = Vector2(0, -30)
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="." unique_id=661787463]
 unique_name_in_owner = true

--- a/scenes/quests/story_quests/champ/3_stealth/champ_stealth.tscn
+++ b/scenes/quests/story_quests/champ/3_stealth/champ_stealth.tscn
@@ -2033,81 +2033,96 @@ position = Vector2(420, 332)
 dialogue = ExtResource("17_8qkne")
 sprite_frames = ExtResource("17_ol5cv")
 
-[node name="InteractArea2" type="Area2D" parent="Hints/Hint NPC" unique_id=361224625]
+[node name="InteractArea2" type="Area2D" parent="Hints/Hint NPC" unique_id=361224625 node_paths=PackedStringArray("marker")]
 unique_name_in_owner = true
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("23_g11k1")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hints/Hint NPC/InteractArea2" unique_id=1465528784]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
+[node name="Marker" type="Marker2D" parent="Hints/Hint NPC/InteractArea2" unique_id=1321770066]
+position = Vector2(0, -100)
+
 [node name="Hint NPC2" parent="Hints" unique_id=1943896578 instance=ExtResource("16_ol5cv")]
 position = Vector2(905, -247)
 dialogue = ExtResource("27_oswsn")
 sprite_frames = ExtResource("17_ol5cv")
 
-[node name="InteractArea2" type="Area2D" parent="Hints/Hint NPC2" unique_id=1366808935]
+[node name="InteractArea2" type="Area2D" parent="Hints/Hint NPC2" unique_id=1366808935 node_paths=PackedStringArray("marker")]
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("23_g11k1")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hints/Hint NPC2/InteractArea2" unique_id=1365930728]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
+[node name="Marker" type="Marker2D" parent="Hints/Hint NPC2/InteractArea2" unique_id=749163149]
+position = Vector2(0, -100)
+
 [node name="Hint NPC3" parent="Hints" unique_id=773804935 instance=ExtResource("16_ol5cv")]
 position = Vector2(550, 499)
 dialogue = ExtResource("28_fqjr6")
 sprite_frames = ExtResource("17_ol5cv")
 
-[node name="InteractArea2" type="Area2D" parent="Hints/Hint NPC3" unique_id=1866041881]
+[node name="InteractArea2" type="Area2D" parent="Hints/Hint NPC3" unique_id=1866041881 node_paths=PackedStringArray("marker")]
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("23_g11k1")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hints/Hint NPC3/InteractArea2" unique_id=179206779]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
+[node name="Marker" type="Marker2D" parent="Hints/Hint NPC3/InteractArea2" unique_id=2011078540]
+position = Vector2(0, -100)
+
 [node name="Hint NPC4 - Blink" parent="Hints" unique_id=1086241914 instance=ExtResource("16_ol5cv")]
 position = Vector2(531, 8)
 dialogue = ExtResource("34_g76pt")
 sprite_frames = ExtResource("17_ol5cv")
 
-[node name="InteractArea2" type="Area2D" parent="Hints/Hint NPC4 - Blink" unique_id=1459826347]
+[node name="InteractArea2" type="Area2D" parent="Hints/Hint NPC4 - Blink" unique_id=1459826347 node_paths=PackedStringArray("marker")]
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("23_g11k1")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hints/Hint NPC4 - Blink/InteractArea2" unique_id=1414287729]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
+[node name="Marker" type="Marker2D" parent="Hints/Hint NPC4 - Blink/InteractArea2" unique_id=1202881832]
+position = Vector2(0, -100)
+
 [node name="Hint NPC5 - Water_walking" parent="Hints" unique_id=989809667 instance=ExtResource("16_ol5cv")]
 position = Vector2(65, 195)
 dialogue = ExtResource("55_rosy4")
 sprite_frames = ExtResource("17_ol5cv")
 
-[node name="InteractArea2" type="Area2D" parent="Hints/Hint NPC5 - Water_walking" unique_id=726533834]
+[node name="InteractArea2" type="Area2D" parent="Hints/Hint NPC5 - Water_walking" unique_id=726533834 node_paths=PackedStringArray("marker")]
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("23_g11k1")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hints/Hint NPC5 - Water_walking/InteractArea2" unique_id=1379546799]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="Hints/Hint NPC5 - Water_walking/InteractArea2" unique_id=804980487]
+position = Vector2(0, -100)
 
 [node name="Bounds" type="StaticBody2D" parent="." unique_id=1900412124]
 collision_layer = 8208

--- a/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise.tscn
+++ b/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise.tscn
@@ -32,105 +32,105 @@ polygon = PackedVector2Array(-47, -75, -76, -69, -71, -42, -59, -28, -72, 22, -6
 [node name="Gem 1" parent="." unique_id=258730506 instance=ExtResource("2_ohnjq")]
 audio_stream = ExtResource("3_1ig7o")
 
-[node name="InteractArea" parent="Gem 1" index="1"]
-interact_label_position = Vector2(-50, -64)
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 1/InteractArea" index="0" unique_id=151105060]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 1/InteractArea" parent_id_path=PackedInt32Array(258730506, 600627691) index="0" unique_id=151105060]
 position = Vector2(-60, -64.5)
 shape = SubResource("RectangleShape2D_4sftv")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
-[node name="AudioStreamPlayer2D" parent="Gem 1" index="2"]
+[node name="Marker" parent="Gem 1/InteractArea" parent_id_path=PackedInt32Array(258730506, 600627691) index="1" unique_id=1868145125]
+position = Vector2(-30, -57)
+
+[node name="AudioStreamPlayer2D" parent="Gem 1" index="2" unique_id=80765450]
 stream = ExtResource("3_1ig7o")
 
 [node name="Gem 2" parent="." unique_id=1055701984 instance=ExtResource("2_ohnjq")]
 sprite_frames = ExtResource("4_c23wd")
 audio_stream = ExtResource("5_2w8tf")
 
-[node name="AnimatedSprite2D" parent="Gem 2" index="0"]
+[node name="AnimatedSprite2D" parent="Gem 2" index="0" unique_id=394248375]
 sprite_frames = ExtResource("4_c23wd")
 
-[node name="InteractArea" parent="Gem 2" index="1"]
-interact_label_position = Vector2(50, -66)
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 2/InteractArea" index="0" unique_id=638900854]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 2/InteractArea" parent_id_path=PackedInt32Array(1055701984, 600627691) index="0" unique_id=638900854]
 position = Vector2(71, -65)
 shape = SubResource("RectangleShape2D_4sftv")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
-[node name="AudioStreamPlayer2D" parent="Gem 2" index="2"]
+[node name="Marker" parent="Gem 2/InteractArea" parent_id_path=PackedInt32Array(1055701984, 600627691) index="1" unique_id=1868145125]
+position = Vector2(22, -59)
+
+[node name="AudioStreamPlayer2D" parent="Gem 2" index="2" unique_id=80765450]
 stream = ExtResource("5_2w8tf")
 
 [node name="Gem 3" parent="." unique_id=2138779555 instance=ExtResource("2_ohnjq")]
 sprite_frames = ExtResource("6_0gbug")
 audio_stream = ExtResource("7_mmng5")
 
-[node name="AnimatedSprite2D" parent="Gem 3" index="0"]
+[node name="AnimatedSprite2D" parent="Gem 3" index="0" unique_id=394248375]
 sprite_frames = ExtResource("6_0gbug")
 
-[node name="InteractArea" parent="Gem 3" index="1"]
-interact_label_position = Vector2(67, -9)
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 3/InteractArea" index="0" unique_id=552092954]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 3/InteractArea" parent_id_path=PackedInt32Array(2138779555, 600627691) index="0" unique_id=552092954]
 position = Vector2(91, 17)
 shape = SubResource("RectangleShape2D_4sftv")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
-[node name="AudioStreamPlayer2D" parent="Gem 3" index="2"]
+[node name="Marker" parent="Gem 3/InteractArea" parent_id_path=PackedInt32Array(2138779555, 600627691) index="1" unique_id=1868145125]
+position = Vector2(45, -20)
+
+[node name="AudioStreamPlayer2D" parent="Gem 3" index="2" unique_id=80765450]
 stream = ExtResource("7_mmng5")
 
 [node name="Gem 4" parent="." unique_id=1768612363 instance=ExtResource("2_ohnjq")]
 sprite_frames = ExtResource("8_4sftv")
 audio_stream = ExtResource("9_lsn5i")
 
-[node name="AnimatedSprite2D" parent="Gem 4" index="0"]
+[node name="AnimatedSprite2D" parent="Gem 4" index="0" unique_id=394248375]
 sprite_frames = ExtResource("8_4sftv")
 
-[node name="InteractArea" parent="Gem 4" index="1"]
-interact_label_position = Vector2(52, 49)
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 4/InteractArea" index="0" unique_id=1647526025]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 4/InteractArea" parent_id_path=PackedInt32Array(1768612363, 600627691) index="0" unique_id=1647526025]
 position = Vector2(61, 90)
 shape = SubResource("RectangleShape2D_4sftv")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
-[node name="AudioStreamPlayer2D" parent="Gem 4" index="2"]
+[node name="Marker" parent="Gem 4/InteractArea" parent_id_path=PackedInt32Array(1768612363, 600627691) index="1" unique_id=1868145125]
+position = Vector2(14, 27)
+
+[node name="AudioStreamPlayer2D" parent="Gem 4" index="2" unique_id=80765450]
 stream = ExtResource("9_lsn5i")
 
 [node name="Gem 5" parent="." unique_id=956843827 instance=ExtResource("2_ohnjq")]
 sprite_frames = ExtResource("10_lgrp6")
 audio_stream = ExtResource("11_21pp6")
 
-[node name="AnimatedSprite2D" parent="Gem 5" index="0"]
+[node name="AnimatedSprite2D" parent="Gem 5" index="0" unique_id=394248375]
 sprite_frames = ExtResource("10_lgrp6")
 
-[node name="InteractArea" parent="Gem 5" index="1"]
-interact_label_position = Vector2(-52, 51)
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 5/InteractArea" index="0" unique_id=870763098]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 5/InteractArea" parent_id_path=PackedInt32Array(956843827, 600627691) index="0" unique_id=870763098]
 position = Vector2(-61, 91)
 shape = SubResource("RectangleShape2D_4sftv")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
-[node name="AudioStreamPlayer2D" parent="Gem 5" index="2"]
+[node name="Marker" parent="Gem 5/InteractArea" parent_id_path=PackedInt32Array(956843827, 600627691) index="1" unique_id=1868145125]
+position = Vector2(-20, 26)
+
+[node name="AudioStreamPlayer2D" parent="Gem 5" index="2" unique_id=80765450]
 stream = ExtResource("11_21pp6")
 
 [node name="Gem 6" parent="." unique_id=1546822710 instance=ExtResource("2_ohnjq")]
 sprite_frames = ExtResource("12_ejecx")
 audio_stream = ExtResource("13_m5xp2")
 
-[node name="AnimatedSprite2D" parent="Gem 6" index="0"]
+[node name="AnimatedSprite2D" parent="Gem 6" index="0" unique_id=394248375]
 sprite_frames = ExtResource("12_ejecx")
 
-[node name="InteractArea" parent="Gem 6" index="1"]
-interact_label_position = Vector2(-78, -9)
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 6/InteractArea" index="0" unique_id=782843500]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Gem 6/InteractArea" parent_id_path=PackedInt32Array(1546822710, 600627691) index="0" unique_id=782843500]
 position = Vector2(-87, 16)
 shape = SubResource("RectangleShape2D_4sftv")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
-[node name="AudioStreamPlayer2D" parent="Gem 6" index="2"]
+[node name="Marker" parent="Gem 6/InteractArea" parent_id_path=PackedInt32Array(1546822710, 600627691) index="1" unique_id=1868145125]
+position = Vector2(-45, -20)
+
+[node name="AudioStreamPlayer2D" parent="Gem 6" index="2" unique_id=80765450]
 stream = ExtResource("13_m5xp2")
 
 [editable path="Gem 1"]

--- a/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise_shell_gem.tscn
+++ b/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_tortoise_shell_gem.tscn
@@ -14,13 +14,16 @@ unique_name_in_owner = true
 scale = Vector2(2, 2)
 sprite_frames = ExtResource("2_dwqaf")
 
-[node name="InteractArea" type="Area2D" parent="." unique_id=600627691]
+[node name="InteractArea" type="Area2D" parent="." unique_id=600627691 node_paths=PackedStringArray("marker")]
 unique_name_in_owner = true
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("3_wah4k")
+marker = NodePath("Marker")
 action = "Tap"
 metadata/_custom_type_script = "uid://du8wfijr35r35"
+
+[node name="Marker" type="Marker2D" parent="InteractArea" unique_id=1868145125]
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="." unique_id=80765450]
 unique_name_in_owner = true

--- a/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_puzzle.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=4 uid="uid://b7j5em2h1m2j7"]
 
 [ext_resource type="TileSet" uid="uid://oynx002hv8tl" path="res://tiles/water.tres" id="1_koksn"]
+[ext_resource type="Script" uid="uid://pk3ucq7e2eah" path="res://scenes/game_logic/player_mode.gd" id="1_pm1er"]
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="2_g4uwj"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="2_sl1lr"]
 [ext_resource type="Script" uid="uid://c68oh8dtr21ti" path="res://scenes/game_logic/sequence_puzzle.gd" id="3_an7xq"]
@@ -19,7 +20,6 @@
 [ext_resource type="SpriteFrames" uid="uid://2ek86nvw6y28" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_yellow.tres" id="31_xd6u5"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="32_7w21t"]
 [ext_resource type="Resource" uid="uid://wpifv4dfofm2" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_sequence_puzzle.dialogue" id="33_g4uwj"]
-[ext_resource type="Script" uid="uid://pk3ucq7e2eah" path="res://scenes/game_logic/player_mode.gd" id="1_pm1er"]
 
 [sub_resource type="Resource" id="Resource_u8qfb"]
 script = ExtResource("15_2p35u")

--- a/scenes/ui_elements/input_hints/components/input_hud.gd
+++ b/scenes/ui_elements/input_hints/components/input_hud.gd
@@ -10,7 +10,7 @@ var player_hook: PlayerHook
 var sokoban_ruleset: RuleEngine
 
 @onready var normal_controls := %NormalControls
-@onready var interact_input_hint := %InteractInputHint
+@onready var interact_input_hint: LabeledInputHint = %InteractInputHint
 @onready var aim_input_hint := %AimInputHint
 @onready var throw_input_hint := %ThrowInputHint
 @onready var repel_input_hint := %RepelInputHint
@@ -45,7 +45,7 @@ func _on_scene_changed() -> void:
 
 		player_interaction = player.get("player_interaction") as PlayerInteraction
 		if player_interaction:
-			player_interaction.can_interact_changed.connect(_update_player_state)
+			player_interaction.interact_action_changed.connect(_update_player_state)
 
 		player_repel = player.get("player_repel") as PlayerRepel
 		if player_repel:
@@ -78,7 +78,12 @@ func _notification(what: int) -> void:
 
 
 func _update_player_state() -> void:
-	interact_input_hint.visible = player_interaction and player_interaction.can_interact()
+	if player_interaction:
+		var action := player_interaction.get_interact_action()
+		interact_input_hint.visible = not action.is_empty()
+		interact_input_hint.text = action
+	else:
+		interact_input_hint.visible = false
 
 	repel_input_hint.visible = player_repel and player_repel.visible
 

--- a/scenes/ui_elements/input_hints/components/labeled_input_hint.gd
+++ b/scenes/ui_elements/input_hints/components/labeled_input_hint.gd
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name LabeledInputHint
+extends Control
+
+## The text shown to the user for this hint.
+var text: String:
+	get = get_text,
+	set = set_text
+
+@onready var label: Label = %Label
+
+
+func get_text() -> String:
+	return label.text
+
+
+func set_text(new_value: String) -> void:
+	label.text = new_value

--- a/scenes/ui_elements/input_hints/components/labeled_input_hint.gd.uid
+++ b/scenes/ui_elements/input_hints/components/labeled_input_hint.gd.uid
@@ -1,0 +1,1 @@
+uid://ntkyy7hnkwh7

--- a/scenes/ui_elements/input_hints/interact_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/interact_input_hint.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_txh2t"]
 [ext_resource type="Texture2D" uid="uid://c6fggds355rko" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_space_outline.tres" id="2_vvpol"]
+[ext_resource type="Script" uid="uid://ntkyy7hnkwh7" path="res://scenes/ui_elements/input_hints/components/labeled_input_hint.gd" id="2_y4ddx"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="3_y4ddx"]
 [ext_resource type="Texture2D" uid="uid://cxnx628qkf1br" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_color_a.tres" id="4_6mrrw"]
 [ext_resource type="Texture2D" uid="uid://da6qvcr5sq71n" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_color_cross_outline.tres" id="5_8u7s0"]
@@ -10,6 +11,7 @@
 
 [node name="InteractInputHint" type="HBoxContainer" unique_id=1438993105]
 theme = ExtResource("1_txh2t")
+script = ExtResource("2_y4ddx")
 
 [node name="RepelHint" type="TextureRect" parent="." unique_id=492172300]
 layout_mode = 2
@@ -24,6 +26,7 @@ nintendo_controller_texture = ExtResource("6_6csox")
 steam_controller_texture = ExtResource("7_73850")
 
 [node name="Label" type="Label" parent="." unique_id=2095697003]
+unique_name_in_owner = true
 layout_mode = 2
 theme_type_variation = &"HintLabel"
 theme_override_font_sizes/font_size = 25

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -370,14 +370,13 @@ interact_area = NodePath("../InteractArea")
 metadata/_custom_type_script = "uid://edcifob4jc4s"
 
 [node name="InteractArea" type="Area2D" parent="OnTheGround/NPCs/Farmer" unique_id=248145530]
-visible = false
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("37_f3823")
-interact_label_position = Vector2(0, -100)
 metadata/_custom_type_script = "uid://du8wfijr35r35"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/NPCs/Farmer/InteractArea" unique_id=1727136394]
+visible = false
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_duxxr")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
@@ -400,15 +399,14 @@ extra_context = [NodePath("../../../WestPath/Unlocker")]
 metadata/_custom_type_script = "uid://edcifob4jc4s"
 
 [node name="InteractArea" type="Area2D" parent="OnTheGround/NPCs/GardenerA" unique_id=1100609138]
-visible = false
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("37_f3823")
-interact_label_position = Vector2(0, -100)
 action = "Talk to Marie"
 metadata/_custom_type_script = "uid://du8wfijr35r35"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/NPCs/GardenerA/InteractArea" unique_id=1159647598]
+visible = false
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_duxxr")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
@@ -1064,18 +1062,20 @@ scale = Vector2(-1, 1)
 character_seed = 2433932515
 look_at_side = 1
 
-[node name="InteractArea" type="Area2D" parent="OnTheGround/Tutorial/TutorialGuy" unique_id=226800588]
-visible = false
+[node name="InteractArea" type="Area2D" parent="OnTheGround/Tutorial/TutorialGuy" unique_id=226800588 node_paths=PackedStringArray("marker")]
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("37_f3823")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 metadata/_custom_type_script = "uid://du8wfijr35r35"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Tutorial/TutorialGuy/InteractArea" unique_id=1652917244]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_2vvub")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="OnTheGround/Tutorial/TutorialGuy/InteractArea" unique_id=1432505873]
+position = Vector2(0, -100)
 
 [node name="TalkBehavior" type="Node" parent="OnTheGround/Tutorial/TutorialGuy" unique_id=283277394 node_paths=PackedStringArray("interact_area")]
 script = ExtResource("56_ojao8")

--- a/scenes/world_map/frays_end_west.tscn
+++ b/scenes/world_map/frays_end_west.tscn
@@ -113,12 +113,11 @@ dialogue = ExtResource("12_otyi0")
 interact_area = NodePath("../InteractArea")
 metadata/_custom_type_script = "uid://edcifob4jc4s"
 
-[node name="InteractArea" type="Area2D" parent="OnTheGround/Oscar" unique_id=248145530]
-visible = false
+[node name="InteractArea" type="Area2D" parent="OnTheGround/Oscar" unique_id=248145530 node_paths=PackedStringArray("marker")]
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("13_otyi0")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 action = "Talk to Óscar"
 metadata/_custom_type_script = "uid://du8wfijr35r35"
 
@@ -126,6 +125,9 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_kxo1k")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="OnTheGround/Oscar/InteractArea" unique_id=1409355159]
+position = Vector2(0, -72)
 
 [node name="Sigurd" parent="OnTheGround" unique_id=1735084916 instance=ExtResource("5_wf3xu")]
 position = Vector2(429, 271)
@@ -139,12 +141,11 @@ dialogue = ExtResource("14_otyi0")
 interact_area = NodePath("../InteractArea")
 metadata/_custom_type_script = "uid://edcifob4jc4s"
 
-[node name="InteractArea" type="Area2D" parent="OnTheGround/Sigurd" unique_id=113255734]
-visible = false
+[node name="InteractArea" type="Area2D" parent="OnTheGround/Sigurd" unique_id=113255734 node_paths=PackedStringArray("marker")]
 collision_layer = 32
 collision_mask = 0
 script = ExtResource("13_otyi0")
-interact_label_position = Vector2(0, -100)
+marker = NodePath("Marker")
 action = "Talk to Sigurd"
 metadata/_custom_type_script = "uid://du8wfijr35r35"
 
@@ -152,6 +153,9 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_kxo1k")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
+
+[node name="Marker" type="Marker2D" parent="OnTheGround/Sigurd/InteractArea" unique_id=2031504100]
+position = Vector2(0, -100)
 
 [node name="Sign" parent="OnTheGround" unique_id=1579530966 instance=ExtResource("6_eitnf")]
 position = Vector2(1171, 621)


### PR DESCRIPTION
Instead of showing text over the object in the world, show it on the HUD
at the bottom of the screen, in place of the "Interact" label.

Show a bouncing red arrow above the currently-targetted interactable
entity. Show nothing above interactable entities that are not currently
targetted, but define an "idle" animation for this case so that we could
in theory change this later just by adjusting the animation.

Define the arrow position with a Marker2D attached to the InteractArea.
Migrate all existing interact_label_position values to a new Marker2D
node on each - these will not all be correct, but some of them might be.
Manually adjust some, including the tricky case of the Stella tortoise.
(Doing this by moving a Marker2D around in the editor is so much easier
than when I did it by editing Vector2 values by hand!) For some cases
where the default position - 64px above the InteractArea - is good
enough, I removed the Marker2D for a simpler scene & smaller diff.

Make all InteractArea nodes visible. (In a number of cases we previously
hid them to reduce the visual clutter, but this would hide the arrow.) I
may have missed some but we can fix them as we find them.

At runtime, if no Marker2D is provided, place one 64px
above the InteractArea node - better than nothing.

Adjust the logic in character_sight.gd to only emit
interact_area_changed if it actually does change, rather than just
because the player moved so that a second object is in range without
changing the "best" object. (This has no visible effect but was
necessary to add a sound effect on change, which I tried then removed.)

Resolves https://github.com/endlessm/threadbare/issues/2114

