### PR TITLE
character_randomizer_test.tscn: Fix dialogues

### DIFF
--- a/scenes/game_elements/characters/components/character_randomizer_test.tscn
+++ b/scenes/game_elements/characters/components/character_randomizer_test.tscn
@@ -792,17 +792,6 @@ interact_area = NodePath("../InteractArea")
 position = Vector2(481, 101)
 character_seed = 2207560013
 
-[node name="InteractArea" type="Area2D" parent="OnTheGround/Townie3" unique_id=1419890767]
-visible = false
-collision_layer = 32
-collision_mask = 0
-script = ExtResource("3_p47ir")
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Townie3/InteractArea" unique_id=1138240117]
-position = Vector2(0, -29)
-shape = SubResource("RectangleShape2D_22pcm")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
-
 [node name="FollowWalkBehavior" type="Node2D" parent="OnTheGround/Townie3" unique_id=1949852425 node_paths=PackedStringArray("target", "character")]
 script = ExtResource("19_e0ffc")
 target = NodePath("../../Player")
@@ -849,8 +838,6 @@ position_smoothing_enabled = true
 [connection signal="timeout" from="OnTheGround/Townie/Timer" to="OnTheGround/Townie" method="randomize_character"]
 [connection signal="interaction_ended" from="OnTheGround/Townie2/InteractArea" to="OnTheGround/Townie2" method="_on_interact_area_interaction_ended"]
 [connection signal="interaction_started" from="OnTheGround/Townie2/InteractArea" to="OnTheGround/Townie2" method="_on_interact_area_interaction_started"]
-[connection signal="interaction_ended" from="OnTheGround/Townie3/InteractArea" to="OnTheGround/Townie3" method="_on_interact_area_interaction_ended"]
-[connection signal="interaction_started" from="OnTheGround/Townie3/InteractArea" to="OnTheGround/Townie3" method="_on_interact_area_interaction_started"]
 [connection signal="interaction_ended" from="OnTheGround/Townie4/InteractArea" to="OnTheGround/Townie4" method="_on_interact_area_interaction_ended"]
 [connection signal="interaction_started" from="OnTheGround/Townie4/InteractArea" to="OnTheGround/Townie4" method="_on_interact_area_interaction_started"]
 


### PR DESCRIPTION
Regression added in commit 754e68ef when adding a FollowWalkBehavior to a townie and removing the TalkBehavior, but not the InteractArea.

Co-authored-by: Will Thompson <wjt@endlessaccess.org>

Fix https://github.com/endlessm/threadbare/issues/2151