### PR TITLE
checkpoint: Make player spawn in front, not behind

### DIFF
--- a/scenes/game_elements/props/checkpoint/checkpoint.tscn
+++ b/scenes/game_elements/props/checkpoint/checkpoint.tscn
@@ -15,11 +15,12 @@ script = ExtResource("1_kkoqv")
 
 [node name="SpawnPoint" type="Marker2D" parent="." unique_id=118546798 groups=["spawn_point"]]
 unique_name_in_owner = true
+position = Vector2(0, 1)
 script = ExtResource("2_s5d1s")
 
 [node name="Sprite" type="AnimatedSprite2D" parent="." unique_id=422090831]
 unique_name_in_owner = true
-position = Vector2(0, -40)
+position = Vector2(0, -64)
 sprite_frames = ExtResource("4_3xcwf")
 animation = &"idle"
 autoplay = "idle"


### PR DESCRIPTION
The player spawns at the position of the SpawnPoint inside this node,
previously identical to the Checkpoint node itself.

As a result, on respawn the player and the checkpoint have the same
y-sort level, and their position in the scene tree determines which one
is displayed in front of the other. The player is earlier in the scene
tree in most scenes, so the later-in-tree checkpoint wins.

Move the SpawnPoint one pixel downwards, so that the player "wins".

Also offset the sprite a little more. This breaks our normal model where
the origin of the scene is aligned with the middle of the sprite's
shadow. However the witch is a bit of a strange shape - the yarn is way
below it - and I think that sorting behind the witch as soon as you walk
above the yarn (as with this change) looks better.

Resolves https://github.com/endlessm/threadbare/issues/1332
