### PR TITLE
Music puzzle: Remove 1.2× scaling on altars

### DIFF
--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1420,28 +1420,24 @@ y_sort_enabled = true
 
 [node name="BonfireSign1" parent="OnTheGround/SequencePuzzle/Bonfires" unique_id=186153333 instance=ExtResource("9_evicy")]
 position = Vector2(-1057, -212)
-scale = Vector2(1.2, 1.2)
 sprite_frames = ExtResource("29_crvxf")
 solved_sound_effect = ExtResource("30_55bav")
 solved_ambient_sound = ExtResource("31_ink4c")
 
 [node name="BonfireSign2" parent="OnTheGround/SequencePuzzle/Bonfires" unique_id=179875505 instance=ExtResource("9_evicy")]
 position = Vector2(-931, -237)
-scale = Vector2(1.2, 1.2)
 sprite_frames = ExtResource("30_0wfv2")
 solved_sound_effect = ExtResource("30_55bav")
 solved_ambient_sound = ExtResource("31_ink4c")
 
 [node name="BonfireSign3" parent="OnTheGround/SequencePuzzle/Bonfires" unique_id=1821063880 instance=ExtResource("9_evicy")]
 position = Vector2(-803, -239)
-scale = Vector2(1.2, 1.2)
 sprite_frames = ExtResource("31_55bav")
 solved_sound_effect = ExtResource("30_55bav")
 solved_ambient_sound = ExtResource("31_ink4c")
 
 [node name="BonfireSign4" parent="OnTheGround/SequencePuzzle/Bonfires" unique_id=1680483058 instance=ExtResource("9_evicy")]
 position = Vector2(-672, -212)
-scale = Vector2(1.2, 1.2)
 sprite_frames = ExtResource("32_0wfv2")
 solved_sound_effect = ExtResource("30_55bav")
 solved_ambient_sound = ExtResource("31_ink4c")


### PR DESCRIPTION
I think it looks better at 1× scale; and, I generally think it's better
practice to have the assets be the size we want rather than drawing them
at one size and scaling them to another.
