### PR TITLE
Townies: Apply shader to the group of sprites

### DIFF
--- a/scenes/game_elements/characters/components/character_randomizer.gd
+++ b/scenes/game_elements/characters/components/character_randomizer.gd
@@ -28,14 +28,17 @@ extends CharacterBody2D
 @export var look_at_side: Enums.LookAtSide = Enums.LookAtSide.LEFT:
 	set = _set_look_at_side
 
+## The root sprite of the hierarchy. Usually the legs.
+@export var root_sprite: AnimatedSprite2D
+
+## The node that recolors the character.
+@export var cel_shading_recolor: CelShadingRecolor
+
 ## Click this button to create a random character.
 @export_tool_button("Randomize") var randomize_character_button: Callable = randomize_character
 
 ## The inner AnimatedSprite2D nodes.
 var animated_sprites: Array[AnimatedSprite2D] = []
-
-## The inner nodes that recolor the character skin.
-var skin_recolor_nodes: Array[CelShadingRecolor] = []
 
 ## The inner nodes that randomize sprites textures.
 var random_texture_nodes: Array[RandomTextureSpriteBehavior] = []
@@ -54,13 +57,8 @@ var _previous_look_at_side: Enums.LookAtSide = Enums.LookAtSide.UNSPECIFIED
 func apply_character_randomizations() -> void:
 	_random_number_generator.seed = character_seed
 
-	if skin_recolor_nodes:
-		var new_skin_medium_color: Color
-		skin_recolor_nodes[-1].set_random_skin_color(_random_number_generator)
-		new_skin_medium_color = skin_recolor_nodes[-1].medium_color
-		for n in skin_recolor_nodes:
-			n.automatic_shades = true
-			n.medium_color = new_skin_medium_color
+	if cel_shading_recolor:
+		cel_shading_recolor.set_random_skin_color(_random_number_generator)
 
 	for n in random_texture_nodes:
 		n.randomize_texture(_random_number_generator)
@@ -109,18 +107,14 @@ func _traverse(node: Node) -> void:
 		animated_sprites.append(node)
 		for child in node.get_children():
 			_traverse(child)
-	elif node is CelShadingRecolor:
-		skin_recolor_nodes.append(node)
 	elif node is RandomTextureSpriteBehavior:
 		random_texture_nodes.append(node)
 
 
 func _setup_nodes() -> void:
 	animated_sprites = []
-	skin_recolor_nodes = []
 	random_texture_nodes = []
-	for child in get_children():
-		_traverse(child)
+	_traverse(root_sprite)
 
 
 func _randomize_all_sprites_progress() -> void:

--- a/scenes/game_elements/characters/components/character_randomizer_test.tscn
+++ b/scenes/game_elements/characters/components/character_randomizer_test.tscn
@@ -16,51 +16,16 @@
 [ext_resource type="Texture2D" uid="uid://bucvumn3fkygf" path="res://scenes/game_elements/characters/npcs/components/townie-idle-hair_001.png" id="9_htwo5"]
 [ext_resource type="Texture2D" uid="uid://dlvcbntsncg18" path="res://scenes/game_elements/characters/npcs/components/townie-idle-body_002.png" id="11_1uba5"]
 [ext_resource type="Texture2D" uid="uid://iq21xkckyvi1" path="res://scenes/game_elements/characters/npcs/components/townie-idle-body_003.dx_-4.dy_-16.png" id="12_n5uef"]
+[ext_resource type="Texture2D" uid="uid://dktchu38pxnxl" path="res://scenes/game_elements/characters/npcs/components/townie-idle-head_001.png" id="13_1uba5"]
 [ext_resource type="Texture2D" uid="uid://b5o2dw3xj2uus" path="res://scenes/game_elements/characters/npcs/components/townie-idle-head_002.png" id="14_7wp2w"]
 [ext_resource type="Texture2D" uid="uid://bfothmxms5oo7" path="res://scenes/game_elements/characters/npcs/components/townie-idle-head_003.png" id="15_7qyur"]
 [ext_resource type="Texture2D" uid="uid://iqvjulny3uri" path="res://scenes/game_elements/characters/npcs/components/townie-idle-hair_003.png" id="17_fe8ke"]
+[ext_resource type="Texture2D" uid="uid://b4y4gg7xukeeg" path="res://scenes/game_elements/characters/npcs/components/townie-idle-hair_002.png" id="17_n5uef"]
 [ext_resource type="Texture2D" uid="uid://bjmcvluico8dg" path="res://scenes/game_elements/characters/npcs/components/townie-idle-hair_005.png" id="18_ahibj"]
 [ext_resource type="Script" uid="uid://cwoclmik3db2" path="res://scenes/game_logic/walk_behaviors/follow_walk_behavior.gd" id="19_e0ffc"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_22pcm"]
 size = Vector2(52, 50)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_jsa2b"]
-atlas = ExtResource("6_bonk8")
-region = Rect2(0, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_kpq1x"]
-atlas = ExtResource("6_bonk8")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_y666u"]
-atlas = ExtResource("6_bonk8")
-region = Rect2(192, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_l7t43"]
-atlas = ExtResource("6_bonk8")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_04pia"]
-resource_local_to_scene = true
-animations = [{
-"frames": [{
-"duration": 10.0,
-"texture": SubResource("AtlasTexture_jsa2b")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_kpq1x")
-}, {
-"duration": 8.0,
-"texture": SubResource("AtlasTexture_y666u")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_l7t43")
-}],
-"loop": true,
-"name": &"idle",
-"speed": 10.0
-}]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_covlx"]
 atlas = ExtResource("7_ny4dp")
@@ -214,20 +179,20 @@ animations = [{
 "speed": 10.0
 }]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_ny4dp"]
-atlas = ExtResource("7_22pcm")
+[sub_resource type="AtlasTexture" id="AtlasTexture_jsa2b"]
+atlas = ExtResource("6_bonk8")
 region = Rect2(0, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_e0ffc"]
-atlas = ExtResource("7_22pcm")
+[sub_resource type="AtlasTexture" id="AtlasTexture_kpq1x"]
+atlas = ExtResource("6_bonk8")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_04pia"]
-atlas = ExtResource("7_22pcm")
+[sub_resource type="AtlasTexture" id="AtlasTexture_y666u"]
+atlas = ExtResource("6_bonk8")
 region = Rect2(192, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_1uba5"]
-atlas = ExtResource("7_22pcm")
+[sub_resource type="AtlasTexture" id="AtlasTexture_l7t43"]
+atlas = ExtResource("6_bonk8")
 region = Rect2(96, 0, 96, 96)
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_7wp2w"]
@@ -235,16 +200,53 @@ resource_local_to_scene = true
 animations = [{
 "frames": [{
 "duration": 10.0,
-"texture": SubResource("AtlasTexture_ny4dp")
+"texture": SubResource("AtlasTexture_jsa2b")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_e0ffc")
+"texture": SubResource("AtlasTexture_kpq1x")
 }, {
 "duration": 8.0,
-"texture": SubResource("AtlasTexture_04pia")
+"texture": SubResource("AtlasTexture_y666u")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_1uba5")
+"texture": SubResource("AtlasTexture_l7t43")
+}],
+"loop": true,
+"name": &"idle",
+"speed": 10.0
+}]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_beu7u"]
+atlas = ExtResource("7_22pcm")
+region = Rect2(0, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_m2wva"]
+atlas = ExtResource("7_22pcm")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_u5ew7"]
+atlas = ExtResource("7_22pcm")
+region = Rect2(192, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_1in01"]
+atlas = ExtResource("7_22pcm")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_7qyur"]
+resource_local_to_scene = true
+animations = [{
+"frames": [{
+"duration": 10.0,
+"texture": SubResource("AtlasTexture_beu7u")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_m2wva")
+}, {
+"duration": 8.0,
+"texture": SubResource("AtlasTexture_u5ew7")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_1in01")
 }],
 "loop": true,
 "name": &"idle",
@@ -263,7 +265,7 @@ region = Rect2(96, 0, 96, 96)
 atlas = ExtResource("11_1uba5")
 region = Rect2(192, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_7qyur"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_fe8ke"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -296,7 +298,7 @@ region = Rect2(96, 0, 96, 96)
 atlas = ExtResource("12_n5uef")
 region = Rect2(192, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_fe8ke"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_ahibj"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -317,37 +319,74 @@ animations = [{
 "speed": 10.0
 }]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_7wp2w"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_6mf2i"]
 atlas = ExtResource("8_tokus")
 region = Rect2(0, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_7qyur"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_it16u"]
 atlas = ExtResource("8_tokus")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_fe8ke"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_wjc0t"]
 atlas = ExtResource("8_tokus")
 region = Rect2(192, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_ahibj"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_wvpu8"]
 atlas = ExtResource("8_tokus")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_ahibj"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_05rux"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
 "duration": 10.0,
-"texture": SubResource("AtlasTexture_7wp2w")
+"texture": SubResource("AtlasTexture_6mf2i")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_7qyur")
+"texture": SubResource("AtlasTexture_it16u")
 }, {
 "duration": 8.0,
-"texture": SubResource("AtlasTexture_fe8ke")
+"texture": SubResource("AtlasTexture_wjc0t")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_ahibj")
+"texture": SubResource("AtlasTexture_wvpu8")
+}],
+"loop": true,
+"name": &"idle",
+"speed": 10.0
+}]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_8swe7"]
+atlas = ExtResource("13_1uba5")
+region = Rect2(0, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_l3irc"]
+atlas = ExtResource("13_1uba5")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_eereg"]
+atlas = ExtResource("13_1uba5")
+region = Rect2(192, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_qc4c2"]
+atlas = ExtResource("13_1uba5")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_ue7og"]
+resource_local_to_scene = true
+animations = [{
+"frames": [{
+"duration": 10.0,
+"texture": SubResource("AtlasTexture_8swe7")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_l3irc")
+}, {
+"duration": 8.0,
+"texture": SubResource("AtlasTexture_eereg")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_qc4c2")
 }],
 "loop": true,
 "name": &"idle",
@@ -370,7 +409,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("14_7wp2w")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_05rux"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_aqb5i"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -407,7 +446,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("15_7qyur")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_ue7og"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_fj012"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -422,43 +461,6 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_ig0ma")
-}],
-"loop": true,
-"name": &"idle",
-"speed": 10.0
-}]
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6mf2i"]
-atlas = ExtResource("8_tokus")
-region = Rect2(0, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_it16u"]
-atlas = ExtResource("8_tokus")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_wjc0t"]
-atlas = ExtResource("8_tokus")
-region = Rect2(192, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_wvpu8"]
-atlas = ExtResource("8_tokus")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_aqb5i"]
-resource_local_to_scene = true
-animations = [{
-"frames": [{
-"duration": 10.0,
-"texture": SubResource("AtlasTexture_6mf2i")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_it16u")
-}, {
-"duration": 8.0,
-"texture": SubResource("AtlasTexture_wjc0t")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_wvpu8")
 }],
 "loop": true,
 "name": &"idle",
@@ -481,7 +483,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("15_7qyur")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_fj012"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_3lql5"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -496,43 +498,6 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_sh2mb")
-}],
-"loop": true,
-"name": &"idle",
-"speed": 10.0
-}]
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_ue7og"]
-atlas = ExtResource("9_htwo5")
-region = Rect2(0, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_aqb5i"]
-atlas = ExtResource("9_htwo5")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_fj012"]
-atlas = ExtResource("9_htwo5")
-region = Rect2(192, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_3lql5"]
-atlas = ExtResource("9_htwo5")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_3lql5"]
-resource_local_to_scene = true
-animations = [{
-"frames": [{
-"duration": 10.0,
-"texture": SubResource("AtlasTexture_ue7og")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_aqb5i")
-}, {
-"duration": 8.0,
-"texture": SubResource("AtlasTexture_fj012")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_3lql5")
 }],
 "loop": true,
 "name": &"idle",
@@ -576,6 +541,43 @@ animations = [{
 "speed": 10.0
 }]
 
+[sub_resource type="AtlasTexture" id="AtlasTexture_17egh"]
+atlas = ExtResource("17_n5uef")
+region = Rect2(0, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_kuuqr"]
+atlas = ExtResource("17_n5uef")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_g7sa3"]
+atlas = ExtResource("17_n5uef")
+region = Rect2(192, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_klm8j"]
+atlas = ExtResource("17_n5uef")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_txqd1"]
+resource_local_to_scene = true
+animations = [{
+"frames": [{
+"duration": 10.0,
+"texture": SubResource("AtlasTexture_17egh")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_kuuqr")
+}, {
+"duration": 8.0,
+"texture": SubResource("AtlasTexture_g7sa3")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_klm8j")
+}],
+"loop": true,
+"name": &"idle",
+"speed": 10.0
+}]
+
 [sub_resource type="AtlasTexture" id="AtlasTexture_6vcs2"]
 atlas = ExtResource("17_fe8ke")
 region = Rect2(0, 0, 96, 96)
@@ -592,7 +594,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("17_fe8ke")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_txqd1"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_7xna1"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -629,7 +631,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("17_fe8ke")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_7xna1"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_y1u7u"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -666,7 +668,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("18_ahibj")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_y1u7u"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_6bjll"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -704,7 +706,7 @@ y_sort_enabled = true
 
 [node name="Townie" parent="OnTheGround" unique_id=632242166 instance=ExtResource("2_2g5xe")]
 position = Vector2(225, 152)
-character_seed = 138976455
+character_seed = 2851606334
 
 [node name="InteractArea" type="Area2D" parent="OnTheGround/Townie" unique_id=713209077]
 collision_layer = 32
@@ -730,46 +732,40 @@ autostart = true
 [node name="Townie2" parent="OnTheGround" unique_id=645401180 instance=ExtResource("2_2g5xe")]
 position = Vector2(415, 233)
 
-[node name="AnimatedSprite2DLegs" parent="OnTheGround/Townie2" index="1" unique_id=385222684]
-sprite_frames = SubResource("SpriteFrames_04pia")
+[node name="CanvasGroup" parent="OnTheGround/Townie2" index="1" unique_id=235759707]
+instance_shader_parameters/shade_high_new = Color(0.20000032, 0.8192208, 0.987125, 1)
+instance_shader_parameters/shade_low_new = Color(3.0803682e-07, 0.6192208, 0.787125, 1)
+instance_shader_parameters/shade_medium_new = Color(3.85046e-07, 0.774026, 0.9839062, 1)
 
-[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/AnimatedSprite2DLegs" index="0" unique_id=471097323]
-sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_1uba5"), SubResource("SpriteFrames_n5uef"), SubResource("SpriteFrames_04pia")])
+[node name="AnimatedSprite2DLegs" parent="OnTheGround/Townie2/CanvasGroup" index="0" unique_id=385222684]
+sprite_frames = SubResource("SpriteFrames_1uba5")
 
-[node name="AnimatedSprite2DBody" parent="OnTheGround/Townie2/AnimatedSprite2DLegs" index="2" unique_id=2098127821]
-instance_shader_parameters/shade_high_new = Color(0.21403402, 0.75751436, 0.9589514, 1)
-instance_shader_parameters/shade_low_new = Color(0.014034003, 0.55751437, 0.7589514, 1)
-instance_shader_parameters/shade_medium_new = Color(0.017542504, 0.6968929, 0.9486893, 1)
+[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/CanvasGroup/AnimatedSprite2DLegs" index="0" unique_id=471097323]
+sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_1uba5"), SubResource("SpriteFrames_n5uef"), SubResource("SpriteFrames_7wp2w")])
+
+[node name="AnimatedSprite2DBody" parent="OnTheGround/Townie2/CanvasGroup/AnimatedSprite2DLegs" index="2" unique_id=2098127821]
 position = Vector2(0, 0)
-sprite_frames = SubResource("SpriteFrames_7wp2w")
+sprite_frames = SubResource("SpriteFrames_7qyur")
 
-[node name="CelShadingRecolor" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody" index="0" unique_id=1327679537]
-medium_color = Color(0.017542504, 0.6968929, 0.9486893, 1)
-high_color = Color(0.21403402, 0.75751436, 0.9589514, 1)
-low_color = Color(0.014034003, 0.55751437, 0.7589514, 1)
+[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody" index="0" unique_id=1733667753]
+sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_7qyur"), SubResource("SpriteFrames_fe8ke"), SubResource("SpriteFrames_ahibj")])
 
-[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody" index="1" unique_id=1733667753]
-sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_7wp2w"), SubResource("SpriteFrames_7qyur"), SubResource("SpriteFrames_fe8ke")])
+[node name="AnimatedSprite2DHead" parent="OnTheGround/Townie2/CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody" index="2" unique_id=421503015]
+sprite_frames = SubResource("SpriteFrames_05rux")
 
-[node name="AnimatedSprite2DHead" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody" index="3" unique_id=421503015]
-instance_shader_parameters/shade_high_new = Color(0.21403402, 0.75751436, 0.9589514, 1)
-instance_shader_parameters/shade_low_new = Color(0.014034003, 0.55751437, 0.7589514, 1)
-instance_shader_parameters/shade_medium_new = Color(0.017542504, 0.6968929, 0.9486893, 1)
-sprite_frames = SubResource("SpriteFrames_ahibj")
+[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" index="0" unique_id=592927150]
+sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_ue7og"), SubResource("SpriteFrames_aqb5i"), SubResource("SpriteFrames_fj012"), SubResource("SpriteFrames_05rux"), SubResource("SpriteFrames_3lql5")])
 
-[node name="CelShadingRecolor" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" index="0" unique_id=2000765677]
-medium_color = Color(0.017542504, 0.6968929, 0.9486893, 1)
-high_color = Color(0.21403402, 0.75751436, 0.9589514, 1)
-low_color = Color(0.014034003, 0.55751437, 0.7589514, 1)
+[node name="AnimatedSprite2DHair" parent="OnTheGround/Townie2/CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" index="2" unique_id=2123781958]
+sprite_frames = SubResource("SpriteFrames_ft3li")
 
-[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" index="1" unique_id=592927150]
-sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_ahibj"), SubResource("SpriteFrames_05rux"), SubResource("SpriteFrames_ue7og"), SubResource("SpriteFrames_aqb5i"), SubResource("SpriteFrames_fj012")])
+[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead/AnimatedSprite2DHair" index="0" unique_id=358939124]
+sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_ft3li"), SubResource("SpriteFrames_txqd1"), SubResource("SpriteFrames_7xna1"), SubResource("SpriteFrames_y1u7u"), SubResource("SpriteFrames_6bjll")])
 
-[node name="AnimatedSprite2DHair" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" index="3" unique_id=2123781958]
-sprite_frames = SubResource("SpriteFrames_3lql5")
-
-[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead/AnimatedSprite2DHair" index="0" unique_id=358939124]
-sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_ft3li"), SubResource("SpriteFrames_3lql5"), SubResource("SpriteFrames_txqd1"), SubResource("SpriteFrames_7xna1"), SubResource("SpriteFrames_y1u7u")])
+[node name="CelShadingRecolor" parent="OnTheGround/Townie2/CanvasGroup" index="1" unique_id=1327679537]
+medium_color = Color(3.85046e-07, 0.774026, 0.9839062, 1)
+high_color = Color(0.20000032, 0.8192208, 0.987125, 1)
+low_color = Color(3.0803682e-07, 0.6192208, 0.787125, 1)
 
 [node name="InteractArea" type="Area2D" parent="OnTheGround/Townie2" unique_id=1760778420]
 collision_layer = 32

--- a/scenes/game_elements/characters/npcs/townie.tscn
+++ b/scenes/game_elements/characters/npcs/townie.tscn
@@ -24,7 +24,7 @@
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_qs15o"]
 
-[node name="Townie" type="CharacterBody2D" unique_id=1098678013]
+[node name="Townie" type="CharacterBody2D" unique_id=1098678013 node_paths=PackedStringArray("root_sprite", "cel_shading_recolor")]
 material = ExtResource("1_nj51j")
 instance_shader_parameters/shade_high_new = Color(0.9056, 0.7616, 0.7928, 1)
 instance_shader_parameters/shade_low_new = Color(0.7056, 0.5616, 0.5928, 1)
@@ -32,99 +32,92 @@ instance_shader_parameters/shade_medium_new = Color(0.882, 0.702, 0.741, 1)
 collision_layer = 2
 collision_mask = 0
 script = ExtResource("2_xf1o5")
+root_sprite = NodePath("CanvasGroup/AnimatedSprite2DLegs")
+cel_shading_recolor = NodePath("CanvasGroup/CelShadingRecolor")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=128596675]
 rotation = -1.5707964
 shape = SubResource("CapsuleShape2D_qs15o")
 
-[node name="AnimatedSprite2DLegs" type="AnimatedSprite2D" parent="." unique_id=385222684]
+[node name="CanvasGroup" type="CanvasGroup" parent="." unique_id=235759707]
+material = ExtResource("1_nj51j")
+instance_shader_parameters/shade_high_new = Color(0.91999996, 0.91999996, 0.2, 1)
+instance_shader_parameters/shade_low_new = Color(0.71999997, 0.71999997, 0, 1)
+instance_shader_parameters/shade_medium_new = Color(0.9, 0.9, 0, 1)
+
+[node name="AnimatedSprite2DLegs" type="AnimatedSprite2D" parent="CanvasGroup" unique_id=385222684]
 position = Vector2(-3, -31)
 sprite_frames = ExtResource("3_4rgc5")
 animation = &"idle"
 
-[node name="RandomTextureSpriteBehavior" type="Node2D" parent="AnimatedSprite2DLegs" unique_id=471097323 node_paths=PackedStringArray("sprite")]
+[node name="RandomTextureSpriteBehavior" type="Node2D" parent="CanvasGroup/AnimatedSprite2DLegs" unique_id=471097323 node_paths=PackedStringArray("sprite")]
 script = ExtResource("5_8nfuc")
 sprite_frames = Array[SpriteFrames]([ExtResource("5_r7ycj"), ExtResource("6_hbfaq"), ExtResource("3_4rgc5")])
 sprite = NodePath("..")
 metadata/_custom_type_script = "uid://boyesrjdix688"
 
-[node name="CharacterSpriteBehavior" type="Node2D" parent="AnimatedSprite2DLegs" unique_id=1671495161 node_paths=PackedStringArray("character", "sprite")]
+[node name="CharacterSpriteBehavior" type="Node2D" parent="CanvasGroup/AnimatedSprite2DLegs" unique_id=1671495161 node_paths=PackedStringArray("character", "sprite")]
 position = Vector2(3, 30)
-script = ExtResource("10_syy7w")
-character = NodePath("../..")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://dy68p7gf07pi3"
-
-[node name="AnimatedSprite2DBody" type="AnimatedSprite2D" parent="AnimatedSprite2DLegs" unique_id=2098127821]
-material = ExtResource("1_nj51j")
-instance_shader_parameters/shade_high_new = Color(0.91999996, 0.91999996, 0.2, 1)
-instance_shader_parameters/shade_low_new = Color(0.71999997, 0.71999997, 0, 1)
-instance_shader_parameters/shade_medium_new = Color(0.9, 0.9, 0, 1)
-position = Vector2(0, -12)
-sprite_frames = ExtResource("16_5y6le")
-animation = &"idle"
-autoplay = "idle"
-
-[node name="CelShadingRecolor" type="Node" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody" unique_id=1327679537 node_paths=PackedStringArray("node_to_recolor")]
-script = ExtResource("2_nj51j")
-node_to_recolor = NodePath("..")
-high_color = Color(0.91999996, 0.91999996, 0.2, 1)
-low_color = Color(0.71999997, 0.71999997, 0, 1)
-metadata/_custom_type_script = "uid://c0a7xf5qx8p4y"
-
-[node name="RandomTextureSpriteBehavior" type="Node2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody" unique_id=1733667753 node_paths=PackedStringArray("sprite")]
-script = ExtResource("5_8nfuc")
-sprite_frames = Array[SpriteFrames]([ExtResource("16_5y6le"), ExtResource("11_tidpj"), ExtResource("12_hurny")])
-sprite = NodePath("..")
-
-[node name="CharacterSpriteBehavior" type="Node2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody" unique_id=273990310 node_paths=PackedStringArray("character", "sprite")]
 script = ExtResource("10_syy7w")
 character = NodePath("../../..")
 sprite = NodePath("..")
 metadata/_custom_type_script = "uid://dy68p7gf07pi3"
 
-[node name="AnimatedSprite2DHead" type="AnimatedSprite2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody" unique_id=421503015]
-material = ExtResource("1_nj51j")
-instance_shader_parameters/shade_high_new = Color(0.91999996, 0.91999996, 0.2, 1)
-instance_shader_parameters/shade_low_new = Color(0.71999997, 0.71999997, 0, 1)
-instance_shader_parameters/shade_medium_new = Color(0.9, 0.9, 0, 1)
-sprite_frames = ExtResource("22_8wbfo")
+[node name="AnimatedSprite2DBody" type="AnimatedSprite2D" parent="CanvasGroup/AnimatedSprite2DLegs" unique_id=2098127821]
+position = Vector2(0, -12)
+sprite_frames = ExtResource("16_5y6le")
 animation = &"idle"
 autoplay = "idle"
 
-[node name="CelShadingRecolor" type="Node" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" unique_id=2000765677 node_paths=PackedStringArray("node_to_recolor")]
-script = ExtResource("2_nj51j")
-node_to_recolor = NodePath("..")
-high_color = Color(0.91999996, 0.91999996, 0.2, 1)
-low_color = Color(0.71999997, 0.71999997, 0, 1)
-metadata/_custom_type_script = "uid://c0a7xf5qx8p4y"
-
-[node name="RandomTextureSpriteBehavior" type="Node2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" unique_id=592927150 node_paths=PackedStringArray("sprite")]
+[node name="RandomTextureSpriteBehavior" type="Node2D" parent="CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody" unique_id=1733667753 node_paths=PackedStringArray("sprite")]
 script = ExtResource("5_8nfuc")
-sprite_frames = Array[SpriteFrames]([ExtResource("22_8wbfo"), ExtResource("15_byt3c"), ExtResource("16_kccyr"), ExtResource("17_syy7w"), ExtResource("18_4rgc5")])
+sprite_frames = Array[SpriteFrames]([ExtResource("16_5y6le"), ExtResource("11_tidpj"), ExtResource("12_hurny")])
 sprite = NodePath("..")
-metadata/_custom_type_script = "uid://boyesrjdix688"
 
-[node name="CharacterSpriteBehavior" type="Node2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" unique_id=1897959413 node_paths=PackedStringArray("character", "sprite")]
+[node name="CharacterSpriteBehavior" type="Node2D" parent="CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody" unique_id=273990310 node_paths=PackedStringArray("character", "sprite")]
 script = ExtResource("10_syy7w")
 character = NodePath("../../../..")
 sprite = NodePath("..")
 metadata/_custom_type_script = "uid://dy68p7gf07pi3"
 
-[node name="AnimatedSprite2DHair" type="AnimatedSprite2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" unique_id=2123781958]
+[node name="AnimatedSprite2DHead" type="AnimatedSprite2D" parent="CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody" unique_id=421503015]
+sprite_frames = ExtResource("22_8wbfo")
+animation = &"idle"
+autoplay = "idle"
+
+[node name="RandomTextureSpriteBehavior" type="Node2D" parent="CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" unique_id=592927150 node_paths=PackedStringArray("sprite")]
+script = ExtResource("5_8nfuc")
+sprite_frames = Array[SpriteFrames]([ExtResource("22_8wbfo"), ExtResource("15_byt3c"), ExtResource("16_kccyr"), ExtResource("17_syy7w"), ExtResource("18_4rgc5")])
+sprite = NodePath("..")
+metadata/_custom_type_script = "uid://boyesrjdix688"
+
+[node name="CharacterSpriteBehavior" type="Node2D" parent="CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" unique_id=1897959413 node_paths=PackedStringArray("character", "sprite")]
+script = ExtResource("10_syy7w")
+character = NodePath("../../../../..")
+sprite = NodePath("..")
+metadata/_custom_type_script = "uid://dy68p7gf07pi3"
+
+[node name="AnimatedSprite2DHair" type="AnimatedSprite2D" parent="CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" unique_id=2123781958]
 sprite_frames = ExtResource("33_m1eb2")
 animation = &"idle"
 autoplay = "idle"
 metadata/_edit_lock_ = true
 
-[node name="RandomTextureSpriteBehavior" type="Node2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead/AnimatedSprite2DHair" unique_id=358939124 node_paths=PackedStringArray("sprite")]
+[node name="RandomTextureSpriteBehavior" type="Node2D" parent="CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead/AnimatedSprite2DHair" unique_id=358939124 node_paths=PackedStringArray("sprite")]
 script = ExtResource("5_8nfuc")
 sprite_frames = Array[SpriteFrames]([ExtResource("20_syy7w"), ExtResource("33_m1eb2"), ExtResource("22_4rgc5"), ExtResource("23_umw6f"), ExtResource("24_hskxo")])
 sprite = NodePath("..")
 metadata/_custom_type_script = "uid://boyesrjdix688"
 
-[node name="CharacterSpriteBehavior" type="Node2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead/AnimatedSprite2DHair" unique_id=280440134 node_paths=PackedStringArray("character", "sprite")]
+[node name="CharacterSpriteBehavior" type="Node2D" parent="CanvasGroup/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead/AnimatedSprite2DHair" unique_id=280440134 node_paths=PackedStringArray("character", "sprite")]
 script = ExtResource("10_syy7w")
-character = NodePath("../../../../..")
+character = NodePath("../../../../../..")
 sprite = NodePath("..")
 metadata/_custom_type_script = "uid://dy68p7gf07pi3"
+
+[node name="CelShadingRecolor" type="Node" parent="CanvasGroup" unique_id=1327679537 node_paths=PackedStringArray("node_to_recolor")]
+script = ExtResource("2_nj51j")
+node_to_recolor = NodePath("..")
+high_color = Color(0.91999996, 0.91999996, 0.2, 1)
+low_color = Color(0.71999997, 0.71999997, 0, 1)
+metadata/_custom_type_script = "uid://c0a7xf5qx8p4y"

--- a/scenes/game_elements/components/cel_shading_recolor.gdshader
+++ b/scenes/game_elements/components/cel_shading_recolor.gdshader
@@ -9,6 +9,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 shader_type canvas_item;
+render_mode unshaded;
+
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
 
 // Note: key colors are intentionally vec3 because they don't need alpha channel.
 // This is unlike the new colors which are of type vec4.
@@ -51,7 +54,13 @@ instance uniform vec4 shade_high_new : source_color = vec4(0.91, 0.91, 0.2, 1);
 instance uniform vec4 shade_low_new : source_color = vec4(0.71, 0.71, 0, 1);
 
 void fragment() {
-	ivec3 colori = ivec3(round(COLOR.rgb * 255.0));
+	vec4 color = textureLod(screen_texture, SCREEN_UV, 0.0);
+
+	if (color.a > 0.0001) {
+		color.rgb /= color.a;
+	}
+
+	ivec3 colori = ivec3(round(color.rgb * 255.0));
 	if (colori == shade_medium_key) {
 		COLOR = shade_medium_new;
 	}
@@ -60,5 +69,8 @@ void fragment() {
 	}
 	else if (colori == shade_low_key) {
 		COLOR = shade_low_new;
+	}
+	else {
+		COLOR = color;
 	}
 }


### PR DESCRIPTION
Add a CanvasGroup node for applying the same shader to all the canvas nodes at once.

Adapt the shader to the builtin shader of CanvasGroup.

Export properties for passing the root sprite, the one that is traversed to find other nodes to randomize. And another one for passing the single CelShaderRecolor node.

Update the test scene.