### PR TITLE
Cel shading shader: Switch to regular shader parameters

### DIFF
--- a/scenes/game_elements/characters/components/character_randomizer.gd
+++ b/scenes/game_elements/characters/components/character_randomizer.gd
@@ -20,22 +20,28 @@ extends CharacterBody2D
 ## Also can look at sides. Defaults to look at left, and scales everything by -1 to look
 ## at right.
 
+const CEL_SHADING_RECOLOR_MATERIAL = preload("uid://b7kf0suo0sc7k")
+
 ## The random seed of this character. Setting another character to the same seed
 ## will make them identical. Setting it to zero will reset the skin color.
 @export var character_seed: int
 
+## The recoloring behavior to use in all sprites.
+@export var cel_shading_recolor: CelShadingRecolor
+
 ## Where is the character facing. Relative to the character.
 @export var look_at_side: Enums.LookAtSide = Enums.LookAtSide.LEFT:
 	set = _set_look_at_side
+
+## The shader material that will be set to all the sprites, the parts that conform the character.
+## If none, a duplicate of the corresponding material will be set.
+@export var shader_material: ShaderMaterial
 
 ## Click this button to create a random character.
 @export_tool_button("Randomize") var randomize_character_button: Callable = randomize_character
 
 ## The inner AnimatedSprite2D nodes.
 var animated_sprites: Array[AnimatedSprite2D] = []
-
-## The inner nodes that recolor the character skin.
-var skin_recolor_nodes: Array[CelShadingRecolor] = []
 
 ## The inner nodes that randomize sprites textures.
 var random_texture_nodes: Array[RandomTextureSpriteBehavior] = []
@@ -54,13 +60,8 @@ var _previous_look_at_side: Enums.LookAtSide = Enums.LookAtSide.UNSPECIFIED
 func apply_character_randomizations() -> void:
 	_random_number_generator.seed = character_seed
 
-	if skin_recolor_nodes:
-		var new_skin_medium_color: Color
-		skin_recolor_nodes[-1].set_random_skin_color(_random_number_generator)
-		new_skin_medium_color = skin_recolor_nodes[-1].medium_color
-		for n in skin_recolor_nodes:
-			n.automatic_shades = true
-			n.medium_color = new_skin_medium_color
+	if cel_shading_recolor:
+		cel_shading_recolor.set_random_skin_color(_random_number_generator)
 
 	for n in random_texture_nodes:
 		n.randomize_texture(_random_number_generator)
@@ -86,6 +87,14 @@ func randomize_character() -> void:
 func _ready() -> void:
 	_setup_nodes()
 
+	if not shader_material:
+		shader_material = (CEL_SHADING_RECOLOR_MATERIAL as ShaderMaterial).duplicate()
+
+	for node in animated_sprites:
+		node.material = shader_material
+
+	cel_shading_recolor.shader_material = shader_material
+
 	if character_seed:
 		apply_character_randomizations()
 
@@ -109,15 +118,12 @@ func _traverse(node: Node) -> void:
 		animated_sprites.append(node)
 		for child in node.get_children():
 			_traverse(child)
-	elif node is CelShadingRecolor:
-		skin_recolor_nodes.append(node)
 	elif node is RandomTextureSpriteBehavior:
 		random_texture_nodes.append(node)
 
 
 func _setup_nodes() -> void:
 	animated_sprites = []
-	skin_recolor_nodes = []
 	random_texture_nodes = []
 	for child in get_children():
 		_traverse(child)

--- a/scenes/game_elements/characters/components/character_randomizer_test.tscn
+++ b/scenes/game_elements/characters/components/character_randomizer_test.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="1_ea78s"]
 [ext_resource type="PackedScene" uid="uid://dgrrudegturnw" path="res://scenes/game_elements/characters/npcs/townie.tscn" id="2_2g5xe"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/interact_area.gd" id="3_p47ir"]
+[ext_resource type="Shader" uid="uid://bs1yj5q1vidgx" path="res://scenes/game_elements/components/cel_shading_recolor.gdshader" id="3_qr3fq"]
 [ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="4_qr3fq"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="5_jsubs"]
 [ext_resource type="Texture2D" uid="uid://y3xp5d8timm0" path="res://scenes/game_elements/characters/npcs/components/townie-idle-legs_002.dy_-6.png" id="6_bonk8"]
@@ -15,136 +16,37 @@
 [ext_resource type="Texture2D" uid="uid://bxmhj36273qdl" path="res://scenes/game_elements/characters/npcs/components/townie-walk-legs_002.dy_-6.png" id="9_04pia"]
 [ext_resource type="Texture2D" uid="uid://bucvumn3fkygf" path="res://scenes/game_elements/characters/npcs/components/townie-idle-hair_001.png" id="9_htwo5"]
 [ext_resource type="Texture2D" uid="uid://dlvcbntsncg18" path="res://scenes/game_elements/characters/npcs/components/townie-idle-body_002.png" id="11_1uba5"]
+[ext_resource type="Texture2D" uid="uid://daymgmvarx2ew" path="res://scenes/game_elements/characters/npcs/components/townie-idle-legs_003.dy_-12.png" id="11_7qyur"]
+[ext_resource type="Texture2D" uid="uid://47367qxj6u04" path="res://scenes/game_elements/characters/npcs/components/townie-walk-legs_003.dy_-12.png" id="12_fe8ke"]
 [ext_resource type="Texture2D" uid="uid://iq21xkckyvi1" path="res://scenes/game_elements/characters/npcs/components/townie-idle-body_003.dx_-4.dy_-16.png" id="12_n5uef"]
 [ext_resource type="Texture2D" uid="uid://b5o2dw3xj2uus" path="res://scenes/game_elements/characters/npcs/components/townie-idle-head_002.png" id="14_7wp2w"]
 [ext_resource type="Texture2D" uid="uid://bfothmxms5oo7" path="res://scenes/game_elements/characters/npcs/components/townie-idle-head_003.png" id="15_7qyur"]
+[ext_resource type="Texture2D" uid="uid://dktchu38pxnxl" path="res://scenes/game_elements/characters/npcs/components/townie-idle-head_001.png" id="17_ahibj"]
 [ext_resource type="Texture2D" uid="uid://iqvjulny3uri" path="res://scenes/game_elements/characters/npcs/components/townie-idle-hair_003.png" id="17_fe8ke"]
 [ext_resource type="Texture2D" uid="uid://bjmcvluico8dg" path="res://scenes/game_elements/characters/npcs/components/townie-idle-hair_005.png" id="18_ahibj"]
 [ext_resource type="Script" uid="uid://cwoclmik3db2" path="res://scenes/game_logic/walk_behaviors/follow_walk_behavior.gd" id="19_e0ffc"]
+[ext_resource type="Texture2D" uid="uid://b4y4gg7xukeeg" path="res://scenes/game_elements/characters/npcs/components/townie-idle-hair_002.png" id="21_05rux"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_bonk8"]
+shader = ExtResource("3_qr3fq")
+shader_parameter/shade_medium_key = Vector3i(0, 255, 0)
+shader_parameter/shade_high_key = Vector3i(160, 255, 160)
+shader_parameter/shade_low_key = Vector3i(0, 160, 0)
+shader_parameter/shade_medium_new = Color(0.808, 0.596, 0.655, 1)
+shader_parameter/shade_high_new = Color(0.8464, 0.6768, 0.724, 1)
+shader_parameter/shade_low_new = Color(0.64640003, 0.47680002, 0.524, 1)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_22pcm"]
 size = Vector2(52, 50)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_jsa2b"]
-atlas = ExtResource("6_bonk8")
-region = Rect2(0, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_kpq1x"]
-atlas = ExtResource("6_bonk8")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_y666u"]
-atlas = ExtResource("6_bonk8")
-region = Rect2(192, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_l7t43"]
-atlas = ExtResource("6_bonk8")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_04pia"]
-resource_local_to_scene = true
-animations = [{
-"frames": [{
-"duration": 10.0,
-"texture": SubResource("AtlasTexture_jsa2b")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_kpq1x")
-}, {
-"duration": 8.0,
-"texture": SubResource("AtlasTexture_y666u")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_l7t43")
-}],
-"loop": true,
-"name": &"idle",
-"speed": 10.0
-}]
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_covlx"]
-atlas = ExtResource("7_ny4dp")
-region = Rect2(0, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_r7g0f"]
-atlas = ExtResource("7_ny4dp")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_wocpn"]
-atlas = ExtResource("7_ny4dp")
-region = Rect2(192, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_xcd2m"]
-atlas = ExtResource("7_ny4dp")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_282bi"]
-atlas = ExtResource("8_e0ffc")
-region = Rect2(0, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_4v8h1"]
-atlas = ExtResource("8_e0ffc")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_rfti1"]
-atlas = ExtResource("8_e0ffc")
-region = Rect2(192, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_esail"]
-atlas = ExtResource("8_e0ffc")
-region = Rect2(0, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6pxfc"]
-atlas = ExtResource("8_e0ffc")
-region = Rect2(192, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_tpolt"]
-atlas = ExtResource("8_e0ffc")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_1uba5"]
-resource_local_to_scene = true
-animations = [{
-"frames": [{
-"duration": 10.0,
-"texture": SubResource("AtlasTexture_covlx")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_r7g0f")
-}, {
-"duration": 8.0,
-"texture": SubResource("AtlasTexture_wocpn")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_xcd2m")
-}],
-"loop": true,
-"name": &"idle",
-"speed": 10.0
-}, {
-"frames": [{
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_282bi")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_4v8h1")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_rfti1")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_esail")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_6pxfc")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_tpolt")
-}],
-"loop": true,
-"name": &"walk",
-"speed": 10.0
-}]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_22pcm"]
+shader = ExtResource("3_qr3fq")
+shader_parameter/shade_medium_key = Vector3i(0, 255, 0)
+shader_parameter/shade_high_key = Vector3i(160, 255, 160)
+shader_parameter/shade_low_key = Vector3i(0, 160, 0)
+shader_parameter/shade_medium_new = Color(0.19466418, 0.61424816, 0.8675251, 1)
+shader_parameter/shade_high_new = Color(0.35573137, 0.6913985, 0.8940201, 1)
+shader_parameter/shade_low_new = Color(0.15573135, 0.49139854, 0.6940201, 1)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_s8pun"]
 atlas = ExtResource("6_bonk8")
@@ -170,7 +72,7 @@ region = Rect2(96, 0, 96, 96)
 atlas = ExtResource("9_04pia")
 region = Rect2(192, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_n5uef"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_ue7og"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -214,73 +116,155 @@ animations = [{
 "speed": 10.0
 }]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_ny4dp"]
-atlas = ExtResource("7_22pcm")
+[sub_resource type="AtlasTexture" id="AtlasTexture_covlx"]
+atlas = ExtResource("7_ny4dp")
 region = Rect2(0, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_e0ffc"]
-atlas = ExtResource("7_22pcm")
+[sub_resource type="AtlasTexture" id="AtlasTexture_r7g0f"]
+atlas = ExtResource("7_ny4dp")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_04pia"]
-atlas = ExtResource("7_22pcm")
+[sub_resource type="AtlasTexture" id="AtlasTexture_wocpn"]
+atlas = ExtResource("7_ny4dp")
 region = Rect2(192, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_1uba5"]
-atlas = ExtResource("7_22pcm")
+[sub_resource type="AtlasTexture" id="AtlasTexture_xcd2m"]
+atlas = ExtResource("7_ny4dp")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_7wp2w"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_282bi"]
+atlas = ExtResource("8_e0ffc")
+region = Rect2(0, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_4v8h1"]
+atlas = ExtResource("8_e0ffc")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_rfti1"]
+atlas = ExtResource("8_e0ffc")
+region = Rect2(192, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_esail"]
+atlas = ExtResource("8_e0ffc")
+region = Rect2(0, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_6pxfc"]
+atlas = ExtResource("8_e0ffc")
+region = Rect2(192, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_tpolt"]
+atlas = ExtResource("8_e0ffc")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_aqb5i"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
 "duration": 10.0,
-"texture": SubResource("AtlasTexture_ny4dp")
+"texture": SubResource("AtlasTexture_covlx")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_e0ffc")
+"texture": SubResource("AtlasTexture_r7g0f")
 }, {
 "duration": 8.0,
-"texture": SubResource("AtlasTexture_04pia")
+"texture": SubResource("AtlasTexture_wocpn")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_1uba5")
+"texture": SubResource("AtlasTexture_xcd2m")
 }],
 "loop": true,
 "name": &"idle",
 "speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_282bi")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_4v8h1")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_rfti1")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_esail")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_6pxfc")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_tpolt")
+}],
+"loop": true,
+"name": &"walk",
+"speed": 10.0
 }]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_kbgar"]
-atlas = ExtResource("11_1uba5")
+[sub_resource type="AtlasTexture" id="AtlasTexture_tynsv"]
+atlas = ExtResource("11_7qyur")
 region = Rect2(0, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_w7k6m"]
-atlas = ExtResource("11_1uba5")
+[sub_resource type="AtlasTexture" id="AtlasTexture_mt4vo"]
+atlas = ExtResource("11_7qyur")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_6o5o0"]
-atlas = ExtResource("11_1uba5")
+[sub_resource type="AtlasTexture" id="AtlasTexture_6rb10"]
+atlas = ExtResource("11_7qyur")
 region = Rect2(192, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_7qyur"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_5ek1g"]
+atlas = ExtResource("12_fe8ke")
+region = Rect2(0, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_d3tqp"]
+atlas = ExtResource("12_fe8ke")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_w6nvb"]
+atlas = ExtResource("12_fe8ke")
+region = Rect2(192, 0, 96, 96)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_fj012"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
 "duration": 10.0,
-"texture": SubResource("AtlasTexture_kbgar")
+"texture": SubResource("AtlasTexture_tynsv")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_w7k6m")
+"texture": SubResource("AtlasTexture_mt4vo")
 }, {
 "duration": 8.0,
-"texture": SubResource("AtlasTexture_6o5o0")
+"texture": SubResource("AtlasTexture_6rb10")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_w7k6m")
+"texture": SubResource("AtlasTexture_mt4vo")
 }],
 "loop": true,
 "name": &"idle",
+"speed": 10.0
+}, {
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_5ek1g")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_d3tqp")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_w6nvb")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_5ek1g")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_w6nvb")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_d3tqp")
+}],
+"loop": true,
+"name": &"walk",
 "speed": 10.0
 }]
 
@@ -296,7 +280,7 @@ region = Rect2(96, 0, 96, 96)
 atlas = ExtResource("12_n5uef")
 region = Rect2(192, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_fe8ke"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_3lql5"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -317,37 +301,144 @@ animations = [{
 "speed": 10.0
 }]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_7wp2w"]
-atlas = ExtResource("8_tokus")
+[sub_resource type="AtlasTexture" id="AtlasTexture_beu7u"]
+atlas = ExtResource("7_22pcm")
 region = Rect2(0, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_7qyur"]
-atlas = ExtResource("8_tokus")
+[sub_resource type="AtlasTexture" id="AtlasTexture_m2wva"]
+atlas = ExtResource("7_22pcm")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_fe8ke"]
-atlas = ExtResource("8_tokus")
+[sub_resource type="AtlasTexture" id="AtlasTexture_u5ew7"]
+atlas = ExtResource("7_22pcm")
 region = Rect2(192, 0, 96, 96)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_ahibj"]
-atlas = ExtResource("8_tokus")
+[sub_resource type="AtlasTexture" id="AtlasTexture_1in01"]
+atlas = ExtResource("7_22pcm")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_ahibj"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_ft3li"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
 "duration": 10.0,
-"texture": SubResource("AtlasTexture_7wp2w")
+"texture": SubResource("AtlasTexture_beu7u")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_7qyur")
+"texture": SubResource("AtlasTexture_m2wva")
 }, {
 "duration": 8.0,
-"texture": SubResource("AtlasTexture_fe8ke")
+"texture": SubResource("AtlasTexture_u5ew7")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_ahibj")
+"texture": SubResource("AtlasTexture_1in01")
+}],
+"loop": true,
+"name": &"idle",
+"speed": 10.0
+}]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_kbgar"]
+atlas = ExtResource("11_1uba5")
+region = Rect2(0, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_w7k6m"]
+atlas = ExtResource("11_1uba5")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_6o5o0"]
+atlas = ExtResource("11_1uba5")
+region = Rect2(192, 0, 96, 96)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_txqd1"]
+resource_local_to_scene = true
+animations = [{
+"frames": [{
+"duration": 10.0,
+"texture": SubResource("AtlasTexture_kbgar")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_w7k6m")
+}, {
+"duration": 8.0,
+"texture": SubResource("AtlasTexture_6o5o0")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_w7k6m")
+}],
+"loop": true,
+"name": &"idle",
+"speed": 10.0
+}]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_6mf2i"]
+atlas = ExtResource("8_tokus")
+region = Rect2(0, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_it16u"]
+atlas = ExtResource("8_tokus")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_wjc0t"]
+atlas = ExtResource("8_tokus")
+region = Rect2(192, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_wvpu8"]
+atlas = ExtResource("8_tokus")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_7xna1"]
+resource_local_to_scene = true
+animations = [{
+"frames": [{
+"duration": 10.0,
+"texture": SubResource("AtlasTexture_6mf2i")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_it16u")
+}, {
+"duration": 8.0,
+"texture": SubResource("AtlasTexture_wjc0t")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_wvpu8")
+}],
+"loop": true,
+"name": &"idle",
+"speed": 10.0
+}]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_8swe7"]
+atlas = ExtResource("17_ahibj")
+region = Rect2(0, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_l3irc"]
+atlas = ExtResource("17_ahibj")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_eereg"]
+atlas = ExtResource("17_ahibj")
+region = Rect2(192, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_qc4c2"]
+atlas = ExtResource("17_ahibj")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_y1u7u"]
+resource_local_to_scene = true
+animations = [{
+"frames": [{
+"duration": 10.0,
+"texture": SubResource("AtlasTexture_8swe7")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_l3irc")
+}, {
+"duration": 8.0,
+"texture": SubResource("AtlasTexture_eereg")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_qc4c2")
 }],
 "loop": true,
 "name": &"idle",
@@ -370,7 +461,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("14_7wp2w")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_05rux"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_6bjll"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -407,7 +498,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("15_7qyur")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_ue7og"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_ykhe4"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -422,43 +513,6 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_ig0ma")
-}],
-"loop": true,
-"name": &"idle",
-"speed": 10.0
-}]
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_6mf2i"]
-atlas = ExtResource("8_tokus")
-region = Rect2(0, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_it16u"]
-atlas = ExtResource("8_tokus")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_wjc0t"]
-atlas = ExtResource("8_tokus")
-region = Rect2(192, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_wvpu8"]
-atlas = ExtResource("8_tokus")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_aqb5i"]
-resource_local_to_scene = true
-animations = [{
-"frames": [{
-"duration": 10.0,
-"texture": SubResource("AtlasTexture_6mf2i")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_it16u")
-}, {
-"duration": 8.0,
-"texture": SubResource("AtlasTexture_wjc0t")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_wvpu8")
 }],
 "loop": true,
 "name": &"idle",
@@ -481,7 +535,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("15_7qyur")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_fj012"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_oyy7n"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -496,43 +550,6 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_sh2mb")
-}],
-"loop": true,
-"name": &"idle",
-"speed": 10.0
-}]
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_ue7og"]
-atlas = ExtResource("9_htwo5")
-region = Rect2(0, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_aqb5i"]
-atlas = ExtResource("9_htwo5")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_fj012"]
-atlas = ExtResource("9_htwo5")
-region = Rect2(192, 0, 96, 96)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_3lql5"]
-atlas = ExtResource("9_htwo5")
-region = Rect2(96, 0, 96, 96)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_3lql5"]
-resource_local_to_scene = true
-animations = [{
-"frames": [{
-"duration": 10.0,
-"texture": SubResource("AtlasTexture_ue7og")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_aqb5i")
-}, {
-"duration": 8.0,
-"texture": SubResource("AtlasTexture_fj012")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_3lql5")
 }],
 "loop": true,
 "name": &"idle",
@@ -555,7 +572,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("9_htwo5")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_ft3li"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_mdvm3"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -570,6 +587,43 @@ animations = [{
 }, {
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_mqc7r")
+}],
+"loop": true,
+"name": &"idle",
+"speed": 10.0
+}]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_17egh"]
+atlas = ExtResource("21_05rux")
+region = Rect2(0, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_kuuqr"]
+atlas = ExtResource("21_05rux")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_g7sa3"]
+atlas = ExtResource("21_05rux")
+region = Rect2(192, 0, 96, 96)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_klm8j"]
+atlas = ExtResource("21_05rux")
+region = Rect2(96, 0, 96, 96)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_cecqh"]
+resource_local_to_scene = true
+animations = [{
+"frames": [{
+"duration": 10.0,
+"texture": SubResource("AtlasTexture_17egh")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_kuuqr")
+}, {
+"duration": 8.0,
+"texture": SubResource("AtlasTexture_g7sa3")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_klm8j")
 }],
 "loop": true,
 "name": &"idle",
@@ -592,7 +646,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("17_fe8ke")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_txqd1"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_l0yqg"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -629,7 +683,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("17_fe8ke")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_7xna1"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_dxgbc"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -666,7 +720,7 @@ region = Rect2(192, 0, 96, 96)
 atlas = ExtResource("18_ahibj")
 region = Rect2(96, 0, 96, 96)
 
-[sub_resource type="SpriteFrames" id="SpriteFrames_y1u7u"]
+[sub_resource type="SpriteFrames" id="SpriteFrames_26jv7"]
 resource_local_to_scene = true
 animations = [{
 "frames": [{
@@ -687,6 +741,24 @@ animations = [{
 "speed": 10.0
 }]
 
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_tokus"]
+shader = ExtResource("3_qr3fq")
+shader_parameter/shade_medium_key = Vector3i(0, 255, 0)
+shader_parameter/shade_high_key = Vector3i(160, 255, 160)
+shader_parameter/shade_low_key = Vector3i(0, 160, 0)
+shader_parameter/shade_medium_new = Color(0.596, 0.482, 0.325, 1)
+shader_parameter/shade_high_new = Color(0.6768, 0.5856, 0.45999998, 1)
+shader_parameter/shade_low_new = Color(0.47680002, 0.3856, 0.26, 1)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_htwo5"]
+shader = ExtResource("3_qr3fq")
+shader_parameter/shade_medium_key = Vector3i(0, 255, 0)
+shader_parameter/shade_high_key = Vector3i(160, 255, 160)
+shader_parameter/shade_low_key = Vector3i(0, 160, 0)
+shader_parameter/shade_medium_new = Color(0.847, 0.651, 0.514, 1)
+shader_parameter/shade_high_new = Color(0.8776, 0.72080004, 0.6112, 1)
+shader_parameter/shade_low_new = Color(0.6776, 0.52080005, 0.41120002, 1)
+
 [node name="CharacterRandomizerTest" type="Node2D" unique_id=136000252]
 
 [node name="TileMapLayers" type="Node2D" parent="." unique_id=1483527644]
@@ -705,6 +777,7 @@ y_sort_enabled = true
 [node name="Townie" parent="OnTheGround" unique_id=632242166 instance=ExtResource("2_2g5xe")]
 position = Vector2(225, 152)
 character_seed = 138976455
+shader_material = SubResource("ShaderMaterial_bonk8")
 
 [node name="InteractArea" type="Area2D" parent="OnTheGround/Townie" unique_id=713209077]
 collision_layer = 32
@@ -729,47 +802,43 @@ autostart = true
 
 [node name="Townie2" parent="OnTheGround" unique_id=645401180 instance=ExtResource("2_2g5xe")]
 position = Vector2(415, 233)
+shader_material = SubResource("ShaderMaterial_22pcm")
 
 [node name="AnimatedSprite2DLegs" parent="OnTheGround/Townie2" index="1" unique_id=385222684]
-sprite_frames = SubResource("SpriteFrames_04pia")
+material = SubResource("ShaderMaterial_22pcm")
+sprite_frames = SubResource("SpriteFrames_ue7og")
 
 [node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/AnimatedSprite2DLegs" index="0" unique_id=471097323]
-sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_1uba5"), SubResource("SpriteFrames_n5uef"), SubResource("SpriteFrames_04pia")])
+sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_aqb5i"), SubResource("SpriteFrames_ue7og"), SubResource("SpriteFrames_fj012")])
 
 [node name="AnimatedSprite2DBody" parent="OnTheGround/Townie2/AnimatedSprite2DLegs" index="2" unique_id=2098127821]
-instance_shader_parameters/shade_high_new = Color(0.21403402, 0.75751436, 0.9589514, 1)
-instance_shader_parameters/shade_low_new = Color(0.014034003, 0.55751437, 0.7589514, 1)
-instance_shader_parameters/shade_medium_new = Color(0.017542504, 0.6968929, 0.9486893, 1)
-position = Vector2(0, 0)
-sprite_frames = SubResource("SpriteFrames_7wp2w")
-
-[node name="CelShadingRecolor" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody" index="0" unique_id=1327679537]
-medium_color = Color(0.017542504, 0.6968929, 0.9486893, 1)
-high_color = Color(0.21403402, 0.75751436, 0.9589514, 1)
-low_color = Color(0.014034003, 0.55751437, 0.7589514, 1)
-
-[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody" index="1" unique_id=1733667753]
-sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_7wp2w"), SubResource("SpriteFrames_7qyur"), SubResource("SpriteFrames_fe8ke")])
-
-[node name="AnimatedSprite2DHead" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody" index="3" unique_id=421503015]
-instance_shader_parameters/shade_high_new = Color(0.21403402, 0.75751436, 0.9589514, 1)
-instance_shader_parameters/shade_low_new = Color(0.014034003, 0.55751437, 0.7589514, 1)
-instance_shader_parameters/shade_medium_new = Color(0.017542504, 0.6968929, 0.9486893, 1)
-sprite_frames = SubResource("SpriteFrames_ahibj")
-
-[node name="CelShadingRecolor" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" index="0" unique_id=2000765677]
-medium_color = Color(0.017542504, 0.6968929, 0.9486893, 1)
-high_color = Color(0.21403402, 0.75751436, 0.9589514, 1)
-low_color = Color(0.014034003, 0.55751437, 0.7589514, 1)
-
-[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" index="1" unique_id=592927150]
-sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_ahibj"), SubResource("SpriteFrames_05rux"), SubResource("SpriteFrames_ue7og"), SubResource("SpriteFrames_aqb5i"), SubResource("SpriteFrames_fj012")])
-
-[node name="AnimatedSprite2DHair" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" index="3" unique_id=2123781958]
+material = SubResource("ShaderMaterial_22pcm")
+position = Vector2(0, -6)
 sprite_frames = SubResource("SpriteFrames_3lql5")
 
+[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody" index="0" unique_id=1733667753]
+sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_ft3li"), SubResource("SpriteFrames_txqd1"), SubResource("SpriteFrames_3lql5")])
+
+[node name="AnimatedSprite2DHead" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody" index="2" unique_id=421503015]
+material = SubResource("ShaderMaterial_22pcm")
+position = Vector2(-4, -16)
+sprite_frames = SubResource("SpriteFrames_7xna1")
+
+[node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" index="0" unique_id=592927150]
+sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_y1u7u"), SubResource("SpriteFrames_6bjll"), SubResource("SpriteFrames_ykhe4"), SubResource("SpriteFrames_7xna1"), SubResource("SpriteFrames_oyy7n")])
+
+[node name="AnimatedSprite2DHair" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" index="2" unique_id=2123781958]
+material = SubResource("ShaderMaterial_22pcm")
+sprite_frames = SubResource("SpriteFrames_mdvm3")
+
 [node name="RandomTextureSpriteBehavior" parent="OnTheGround/Townie2/AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead/AnimatedSprite2DHair" index="0" unique_id=358939124]
-sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_ft3li"), SubResource("SpriteFrames_3lql5"), SubResource("SpriteFrames_txqd1"), SubResource("SpriteFrames_7xna1"), SubResource("SpriteFrames_y1u7u")])
+sprite_frames = Array[SpriteFrames]([SubResource("SpriteFrames_mdvm3"), SubResource("SpriteFrames_cecqh"), SubResource("SpriteFrames_l0yqg"), SubResource("SpriteFrames_dxgbc"), SubResource("SpriteFrames_26jv7")])
+
+[node name="CelShadingRecolor" parent="OnTheGround/Townie2" index="2" unique_id=1327679537]
+shader_material = SubResource("ShaderMaterial_22pcm")
+medium_color = Color(0.19466418, 0.61424816, 0.8675251, 1)
+high_color = Color(0.35573137, 0.6913985, 0.8940201, 1)
+low_color = Color(0.15573135, 0.49139854, 0.6940201, 1)
 
 [node name="InteractArea" type="Area2D" parent="OnTheGround/Townie2" unique_id=1760778420]
 collision_layer = 32
@@ -791,6 +860,7 @@ interact_area = NodePath("../InteractArea")
 [node name="Townie3" parent="OnTheGround" unique_id=1154886998 instance=ExtResource("2_2g5xe")]
 position = Vector2(481, 101)
 character_seed = 2207560013
+shader_material = SubResource("ShaderMaterial_tokus")
 
 [node name="FollowWalkBehavior" type="Node2D" parent="OnTheGround/Townie3" unique_id=1949852425 node_paths=PackedStringArray("target", "character")]
 script = ExtResource("19_e0ffc")
@@ -804,6 +874,7 @@ position = Vector2(523, 130)
 scale = Vector2(-1, 1)
 character_seed = 1246173203
 look_at_side = 1
+shader_material = SubResource("ShaderMaterial_htwo5")
 
 [node name="InteractArea" type="Area2D" parent="OnTheGround/Townie4" unique_id=785629688]
 collision_layer = 32

--- a/scenes/game_elements/characters/npcs/components/skin_tones_test.tscn
+++ b/scenes/game_elements/characters/npcs/components/skin_tones_test.tscn
@@ -1,10 +1,19 @@
 [gd_scene format=4 uid="uid://rgy4lqdylwyj"]
 
+[ext_resource type="Shader" uid="uid://bs1yj5q1vidgx" path="res://scenes/game_elements/components/cel_shading_recolor.gdshader" id="2_mtxp3"]
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="3_16rk4"]
-[ext_resource type="Material" uid="uid://b7kf0suo0sc7k" path="res://scenes/game_elements/components/cel_shading_recolor_material.tres" id="5_sygj5"]
 [ext_resource type="Texture2D" uid="uid://8x2wkfw4cgnf" path="res://scenes/game_elements/characters/npcs/components/skin_tones_test.png" id="6_sygj5"]
 [ext_resource type="Script" uid="uid://c0a7xf5qx8p4y" path="res://scenes/game_elements/components/cel_shading_recolor.gd" id="7_jhyvc"]
 [ext_resource type="Script" uid="uid://cms2wqtbxjl1h" path="res://scenes/game_logic/sprite_behaviors/random_frame_sprite_behavior.gd" id="7_sygj5"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_a122a"]
+shader = ExtResource("2_mtxp3")
+shader_parameter/shade_medium_key = Vector3i(0, 255, 0)
+shader_parameter/shade_high_key = Vector3i(160, 255, 160)
+shader_parameter/shade_low_key = Vector3i(0, 160, 0)
+shader_parameter/shade_medium_new = Color(0.9, 0.9, 0, 1)
+shader_parameter/shade_high_new = Color(0.91999996, 0.91999996, 0.2, 1)
+shader_parameter/shade_low_new = Color(0.71999997, 0.71999997, 0, 1)
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_84243"]
 atlas = ExtResource("6_sygj5")
@@ -60,6 +69,42 @@ animations = [{
 "speed": 10.0
 }]
 
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_cp3vn"]
+shader = ExtResource("2_mtxp3")
+shader_parameter/shade_medium_key = Vector3i(0, 255, 0)
+shader_parameter/shade_high_key = Vector3i(160, 255, 160)
+shader_parameter/shade_low_key = Vector3i(0, 160, 0)
+shader_parameter/shade_medium_new = Color(0.882, 0.702, 0.741, 1)
+shader_parameter/shade_high_new = Color(0.9056, 0.7616, 0.7928, 1)
+shader_parameter/shade_low_new = Color(0.7056, 0.5616, 0.5928, 1)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_ljqkd"]
+shader = ExtResource("2_mtxp3")
+shader_parameter/shade_medium_key = Vector3i(0, 255, 0)
+shader_parameter/shade_high_key = Vector3i(160, 255, 160)
+shader_parameter/shade_low_key = Vector3i(0, 160, 0)
+shader_parameter/shade_medium_new = Color(0.686, 0.553, 0.373, 1)
+shader_parameter/shade_high_new = Color(0.7488, 0.64239997, 0.49839997, 1)
+shader_parameter/shade_low_new = Color(0.5488, 0.44239998, 0.2984, 1)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_t3p67"]
+shader = ExtResource("2_mtxp3")
+shader_parameter/shade_medium_key = Vector3i(0, 255, 0)
+shader_parameter/shade_high_key = Vector3i(160, 255, 160)
+shader_parameter/shade_low_key = Vector3i(0, 160, 0)
+shader_parameter/shade_medium_new = Color(0.847, 0.651, 0.514, 1)
+shader_parameter/shade_high_new = Color(0.8776, 0.72080004, 0.6112, 1)
+shader_parameter/shade_low_new = Color(0.6776, 0.52080005, 0.41120002, 1)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_5ajtr"]
+shader = ExtResource("2_mtxp3")
+shader_parameter/shade_medium_key = Vector3i(0, 255, 0)
+shader_parameter/shade_high_key = Vector3i(160, 255, 160)
+shader_parameter/shade_low_key = Vector3i(0, 160, 0)
+shader_parameter/shade_medium_new = Color(0.388, 0.176, 0.282, 1)
+shader_parameter/shade_high_new = Color(0.5104, 0.3408, 0.4256, 1)
+shader_parameter/shade_low_new = Color(0.3104, 0.1408, 0.2256, 1)
+
 [node name="SkinTonesTest" type="Node2D" unique_id=286988060]
 
 [node name="TileMapLayers" type="Node2D" parent="." unique_id=1008882753]
@@ -79,10 +124,7 @@ y_sort_enabled = true
 editor_description = "This node has a material with a shader applied.
 
 The shader allows to remap 3 key colors, which are shades of green, to any color."
-material = ExtResource("5_sygj5")
-instance_shader_parameters/shade_high_new = Color(0.91999996, 0.91999996, 0.2, 1)
-instance_shader_parameters/shade_low_new = Color(0.71999997, 0.71999997, 0, 1)
-instance_shader_parameters/shade_medium_new = Color(0.9, 0.9, 0, 1)
+material = SubResource("ShaderMaterial_a122a")
 position = Vector2(311, 205)
 sprite_frames = SubResource("SpriteFrames_5p6wf")
 animation = &"idle"
@@ -95,6 +137,7 @@ It can derive the high and low colors automatically.
 
 And it knows a list of skin colors. It provides a button to pick a skin color randomly."
 script = ExtResource("7_jhyvc")
+shader_material = SubResource("ShaderMaterial_a122a")
 node_to_recolor = NodePath("..")
 high_color = Color(0.91999996, 0.91999996, 0.2, 1)
 low_color = Color(0.71999997, 0.71999997, 0, 1)
@@ -107,10 +150,7 @@ sprite = NodePath("..")
 metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
 
 [node name="AnimatedSprite2D2" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1813794485]
-material = ExtResource("5_sygj5")
-instance_shader_parameters/shade_high_new = Color(0.9056, 0.7616, 0.7928, 1)
-instance_shader_parameters/shade_low_new = Color(0.7056, 0.5616, 0.5928, 1)
-instance_shader_parameters/shade_medium_new = Color(0.882, 0.702, 0.741, 1)
+material = SubResource("ShaderMaterial_cp3vn")
 position = Vector2(318, 137)
 sprite_frames = SubResource("SpriteFrames_5p6wf")
 animation = &"idle"
@@ -118,6 +158,7 @@ autoplay = "idle"
 
 [node name="CelShadingRecolor" type="Node" parent="OnTheGround/AnimatedSprite2D2" unique_id=46950788 node_paths=PackedStringArray("node_to_recolor")]
 script = ExtResource("7_jhyvc")
+shader_material = SubResource("ShaderMaterial_cp3vn")
 node_to_recolor = NodePath("..")
 medium_color = Color(0.882, 0.702, 0.741, 1)
 high_color = Color(0.9056, 0.7616, 0.7928, 1)
@@ -131,10 +172,7 @@ sprite = NodePath("..")
 metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
 
 [node name="AnimatedSprite2D3" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1927981161]
-material = ExtResource("5_sygj5")
-instance_shader_parameters/shade_high_new = Color(0.7488, 0.64239997, 0.49839997, 1)
-instance_shader_parameters/shade_low_new = Color(0.5488, 0.44239998, 0.2984, 1)
-instance_shader_parameters/shade_medium_new = Color(0.686, 0.553, 0.373, 1)
+material = SubResource("ShaderMaterial_ljqkd")
 position = Vector2(371, 147)
 sprite_frames = SubResource("SpriteFrames_5p6wf")
 animation = &"idle"
@@ -144,6 +182,7 @@ flip_h = true
 
 [node name="CelShadingRecolor" type="Node" parent="OnTheGround/AnimatedSprite2D3" unique_id=964092022 node_paths=PackedStringArray("node_to_recolor")]
 script = ExtResource("7_jhyvc")
+shader_material = SubResource("ShaderMaterial_ljqkd")
 node_to_recolor = NodePath("..")
 medium_color = Color(0.686, 0.553, 0.373, 1)
 high_color = Color(0.7488, 0.64239997, 0.49839997, 1)
@@ -157,10 +196,7 @@ sprite = NodePath("../../AnimatedSprite2D2")
 metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
 
 [node name="AnimatedSprite2D4" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1731923129]
-material = ExtResource("5_sygj5")
-instance_shader_parameters/shade_high_new = Color(0.8776, 0.72080004, 0.6112, 1)
-instance_shader_parameters/shade_low_new = Color(0.6776, 0.52080005, 0.41120002, 1)
-instance_shader_parameters/shade_medium_new = Color(0.847, 0.651, 0.514, 1)
+material = SubResource("ShaderMaterial_t3p67")
 position = Vector2(390, 176)
 sprite_frames = SubResource("SpriteFrames_5p6wf")
 animation = &"idle"
@@ -170,6 +206,7 @@ flip_h = true
 
 [node name="CelShadingRecolor" type="Node" parent="OnTheGround/AnimatedSprite2D4" unique_id=1030463016 node_paths=PackedStringArray("node_to_recolor")]
 script = ExtResource("7_jhyvc")
+shader_material = SubResource("ShaderMaterial_t3p67")
 node_to_recolor = NodePath("..")
 medium_color = Color(0.847, 0.651, 0.514, 1)
 high_color = Color(0.8776, 0.72080004, 0.6112, 1)
@@ -182,29 +219,27 @@ script = ExtResource("7_sygj5")
 sprite = NodePath("../../AnimatedSprite2D2")
 metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
 
-[node name="AnimatedSprite2D5" type="AnimatedSprite2D" parent="." unique_id=447592433]
-material = ExtResource("5_sygj5")
-instance_shader_parameters/shade_high_new = Color(0.5104, 0.3408, 0.4256, 1)
-instance_shader_parameters/shade_low_new = Color(0.3104, 0.1408, 0.2256, 1)
-instance_shader_parameters/shade_medium_new = Color(0.388, 0.176, 0.282, 1)
+[node name="AnimatedSprite2D5" type="AnimatedSprite2D" parent="OnTheGround" unique_id=447592433]
+material = SubResource("ShaderMaterial_5ajtr")
 position = Vector2(268, 149)
 sprite_frames = SubResource("SpriteFrames_5p6wf")
 animation = &"idle"
 autoplay = "idle"
 frame = 4
 
-[node name="CelShadingRecolor" type="Node" parent="AnimatedSprite2D5" unique_id=399976614 node_paths=PackedStringArray("node_to_recolor")]
+[node name="CelShadingRecolor" type="Node" parent="OnTheGround/AnimatedSprite2D5" unique_id=399976614 node_paths=PackedStringArray("node_to_recolor")]
 script = ExtResource("7_jhyvc")
+shader_material = SubResource("ShaderMaterial_5ajtr")
 node_to_recolor = NodePath("..")
 medium_color = Color(0.388, 0.176, 0.282, 1)
 high_color = Color(0.5104, 0.3408, 0.4256, 1)
 low_color = Color(0.3104, 0.1408, 0.2256, 1)
 metadata/_custom_type_script = "uid://c0a7xf5qx8p4y"
 
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="AnimatedSprite2D5" unique_id=174050375 node_paths=PackedStringArray("sprite")]
+[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/AnimatedSprite2D5" unique_id=174050375 node_paths=PackedStringArray("sprite")]
 position = Vector2(-318, -137)
 script = ExtResource("7_sygj5")
-sprite = NodePath("../../OnTheGround/AnimatedSprite2D2")
+sprite = NodePath("../../AnimatedSprite2D2")
 metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="." unique_id=1967059135]

--- a/scenes/game_elements/characters/npcs/townie.tscn
+++ b/scenes/game_elements/characters/npcs/townie.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Script" uid="uid://c0a7xf5qx8p4y" path="res://scenes/game_elements/components/cel_shading_recolor.gd" id="2_nj51j"]
 [ext_resource type="Script" uid="uid://dl6rgfwdn3qp4" path="res://scenes/game_elements/characters/components/character_randomizer.gd" id="2_xf1o5"]
 [ext_resource type="SpriteFrames" uid="uid://do4waj3mgr6vw" path="res://scenes/game_elements/characters/components/sprite_frames/townie-legs_003.dy_-12.tres" id="3_4rgc5"]
+[ext_resource type="Shader" uid="uid://bs1yj5q1vidgx" path="res://scenes/game_elements/components/cel_shading_recolor.gdshader" id="3_byt3c"]
 [ext_resource type="Script" uid="uid://boyesrjdix688" path="res://scenes/game_logic/sprite_behaviors/random_texture_sprite_behavior.gd" id="5_8nfuc"]
 [ext_resource type="SpriteFrames" uid="uid://bygxgwwtt1j6h" path="res://scenes/game_elements/characters/components/sprite_frames/townie-legs_001.tres" id="5_r7ycj"]
 [ext_resource type="SpriteFrames" uid="uid://ubitgryup0jx" path="res://scenes/game_elements/characters/components/sprite_frames/townie-legs_002.dy_-6.tres" id="6_hbfaq"]
@@ -22,22 +23,32 @@
 [ext_resource type="SpriteFrames" uid="uid://dnfyg3i87cp17" path="res://scenes/game_elements/characters/components/sprite_frames/townie-hair_005.tres" id="24_hskxo"]
 [ext_resource type="SpriteFrames" uid="uid://c43yaqne7a2kh" path="res://scenes/game_elements/characters/components/sprite_frames/townie-hair_002.tres" id="33_m1eb2"]
 
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_byt3c"]
+resource_local_to_scene = true
+shader = ExtResource("3_byt3c")
+shader_parameter/shade_medium_key = Vector3i(0, 255, 0)
+shader_parameter/shade_high_key = Vector3i(160, 255, 160)
+shader_parameter/shade_low_key = Vector3i(0, 160, 0)
+shader_parameter/shade_medium_new = Color(0.89, 0.89, 0, 1)
+shader_parameter/shade_high_new = Color(0.91, 0.91, 0.2, 1)
+shader_parameter/shade_low_new = Color(0.71, 0.71, 0, 1)
+
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_qs15o"]
 
-[node name="Townie" type="CharacterBody2D" unique_id=1098678013]
+[node name="Townie" type="CharacterBody2D" unique_id=1098678013 node_paths=PackedStringArray("cel_shading_recolor")]
 material = ExtResource("1_nj51j")
-instance_shader_parameters/shade_high_new = Color(0.9056, 0.7616, 0.7928, 1)
-instance_shader_parameters/shade_low_new = Color(0.7056, 0.5616, 0.5928, 1)
-instance_shader_parameters/shade_medium_new = Color(0.882, 0.702, 0.741, 1)
 collision_layer = 2
 collision_mask = 0
 script = ExtResource("2_xf1o5")
+cel_shading_recolor = NodePath("CelShadingRecolor")
+shader_material = SubResource("ShaderMaterial_byt3c")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=128596675]
 rotation = -1.5707964
 shape = SubResource("CapsuleShape2D_qs15o")
 
 [node name="AnimatedSprite2DLegs" type="AnimatedSprite2D" parent="." unique_id=385222684]
+material = SubResource("ShaderMaterial_byt3c")
 position = Vector2(-3, -31)
 sprite_frames = ExtResource("3_4rgc5")
 animation = &"idle"
@@ -56,21 +67,11 @@ sprite = NodePath("..")
 metadata/_custom_type_script = "uid://dy68p7gf07pi3"
 
 [node name="AnimatedSprite2DBody" type="AnimatedSprite2D" parent="AnimatedSprite2DLegs" unique_id=2098127821]
-material = ExtResource("1_nj51j")
-instance_shader_parameters/shade_high_new = Color(0.91999996, 0.91999996, 0.2, 1)
-instance_shader_parameters/shade_low_new = Color(0.71999997, 0.71999997, 0, 1)
-instance_shader_parameters/shade_medium_new = Color(0.9, 0.9, 0, 1)
+material = SubResource("ShaderMaterial_byt3c")
 position = Vector2(0, -12)
 sprite_frames = ExtResource("16_5y6le")
 animation = &"idle"
 autoplay = "idle"
-
-[node name="CelShadingRecolor" type="Node" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody" unique_id=1327679537 node_paths=PackedStringArray("node_to_recolor")]
-script = ExtResource("2_nj51j")
-node_to_recolor = NodePath("..")
-high_color = Color(0.91999996, 0.91999996, 0.2, 1)
-low_color = Color(0.71999997, 0.71999997, 0, 1)
-metadata/_custom_type_script = "uid://c0a7xf5qx8p4y"
 
 [node name="RandomTextureSpriteBehavior" type="Node2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody" unique_id=1733667753 node_paths=PackedStringArray("sprite")]
 script = ExtResource("5_8nfuc")
@@ -84,20 +85,10 @@ sprite = NodePath("..")
 metadata/_custom_type_script = "uid://dy68p7gf07pi3"
 
 [node name="AnimatedSprite2DHead" type="AnimatedSprite2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody" unique_id=421503015]
-material = ExtResource("1_nj51j")
-instance_shader_parameters/shade_high_new = Color(0.91999996, 0.91999996, 0.2, 1)
-instance_shader_parameters/shade_low_new = Color(0.71999997, 0.71999997, 0, 1)
-instance_shader_parameters/shade_medium_new = Color(0.9, 0.9, 0, 1)
+material = SubResource("ShaderMaterial_byt3c")
 sprite_frames = ExtResource("22_8wbfo")
 animation = &"idle"
 autoplay = "idle"
-
-[node name="CelShadingRecolor" type="Node" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" unique_id=2000765677 node_paths=PackedStringArray("node_to_recolor")]
-script = ExtResource("2_nj51j")
-node_to_recolor = NodePath("..")
-high_color = Color(0.91999996, 0.91999996, 0.2, 1)
-low_color = Color(0.71999997, 0.71999997, 0, 1)
-metadata/_custom_type_script = "uid://c0a7xf5qx8p4y"
 
 [node name="RandomTextureSpriteBehavior" type="Node2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" unique_id=592927150 node_paths=PackedStringArray("sprite")]
 script = ExtResource("5_8nfuc")
@@ -112,6 +103,7 @@ sprite = NodePath("..")
 metadata/_custom_type_script = "uid://dy68p7gf07pi3"
 
 [node name="AnimatedSprite2DHair" type="AnimatedSprite2D" parent="AnimatedSprite2DLegs/AnimatedSprite2DBody/AnimatedSprite2DHead" unique_id=2123781958]
+material = SubResource("ShaderMaterial_byt3c")
 sprite_frames = ExtResource("33_m1eb2")
 animation = &"idle"
 autoplay = "idle"
@@ -128,3 +120,10 @@ script = ExtResource("10_syy7w")
 character = NodePath("../../../../..")
 sprite = NodePath("..")
 metadata/_custom_type_script = "uid://dy68p7gf07pi3"
+
+[node name="CelShadingRecolor" type="Node" parent="." unique_id=1327679537]
+script = ExtResource("2_nj51j")
+shader_material = SubResource("ShaderMaterial_byt3c")
+high_color = Color(0.91999996, 0.91999996, 0.2, 1)
+low_color = Color(0.71999997, 0.71999997, 0, 1)
+metadata/_custom_type_script = "uid://c0a7xf5qx8p4y"

--- a/scenes/game_elements/components/cel_shading_recolor.gd
+++ b/scenes/game_elements/components/cel_shading_recolor.gd
@@ -11,10 +11,16 @@ extends Node
 ## But instead of dealing with a full palette, this will recolor 3 shades.
 ## Which is the style expected in Threadbare.
 ## [br][br]
-## [b]Note:[/b] This behavior will only work if the [member node_to_recolor] has the
-## material "cel_shading_recolor_material.tres" applied to it.
+## [b]Note:[/b] This behavior will only work if the [member shader_material] is a
+## duplicate of "cel_shading_recolor_material.tres".
+## [br][br]
+## [b]Note:[/b] A node can be set in [member node_to_recolor] as a shortcut to
+## use its material directly.
 ## [br][br]
 ## One possible use of this is to apply different skin tones to characters.
+## [br][br]
+## Share the [member shader_material] to apply the same recoloring to multiple
+## sprites (multiple parts of the same character, for instance).
 
 ## Named skin colors
 ## [br][br]
@@ -71,6 +77,12 @@ const SKIN_COLORS: Dictionary[String, Color] = {
 	"pearl": Color(0.949, 0.867, 0.894, 1.0),
 }
 
+## The shader material to modify.
+## If [member node_to_recolor] has a material of type [ShaderMaterial], that one will be used.
+## [b]Note:[/b] This behavior will only work if this
+## material is a duplicate of "cel_shading_recolor_material.tres".
+@export var shader_material: ShaderMaterial
+
 ## The node that will be recolored
 ## [br][br]
 ## [b]Note:[/b] This behavior will only work if it has the
@@ -101,16 +113,16 @@ const SKIN_COLORS: Dictionary[String, Color] = {
 var random_skin_color_button: Callable = set_random_skin_color
 
 
-func _enter_tree() -> void:
-	if not node_to_recolor and get_parent() is CanvasItem:
-		node_to_recolor = get_parent()
-		medium_color = medium_color
+func _ready() -> void:
+	colorize()
 
 
 func _set_node_to_recolor(new_node_to_recolor: CanvasItem) -> void:
 	node_to_recolor = new_node_to_recolor
-	update_configuration_warnings()
-	colorize()
+	if not shader_material and node_to_recolor:
+		shader_material = node_to_recolor.material as ShaderMaterial
+		update_configuration_warnings()
+		colorize()
 
 
 func _set_medium_color(new_medium_color: Color) -> void:
@@ -151,11 +163,12 @@ func _validate_property(property: Dictionary) -> void:
 
 ## Apply the colors by setting the shader parameters
 func colorize() -> void:
-	if not node_to_recolor:
+	if not shader_material:
 		return
-	node_to_recolor.set_instance_shader_parameter("shade_medium_new", medium_color)
-	node_to_recolor.set_instance_shader_parameter("shade_high_new", high_color)
-	node_to_recolor.set_instance_shader_parameter("shade_low_new", low_color)
+
+	shader_material.set_shader_parameter("shade_medium_new", medium_color)
+	shader_material.set_shader_parameter("shade_high_new", high_color)
+	shader_material.set_shader_parameter("shade_low_new", low_color)
 
 
 ## Pick a random color from [constant SKIN_COLORS] and automatically set all shades from it.
@@ -168,10 +181,6 @@ func set_random_skin_color(rng: RandomNumberGenerator = null) -> void:
 
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: PackedStringArray
-	if not node_to_recolor:
-		warnings.append("The Skin Node must be set.")
-		return warnings
-	var shader_material: ShaderMaterial = node_to_recolor.material as ShaderMaterial
 	if not shader_material:
 		warnings.append("The Skin Node material must be a ShaderMaterial.")
 		return warnings
@@ -179,6 +188,6 @@ func _get_configuration_warnings() -> PackedStringArray:
 		warnings.append("The Skin Node material must have a shader.")
 		return warnings
 	for uniform_name: String in ["shade_medium_new", "shade_high_new", "shade_low_new"]:
-		if node_to_recolor.get_instance_shader_parameter(uniform_name) == null:
-			warnings.append("The Node To Recolor must have an instance uniform %s." % uniform_name)
+		if shader_material.get_shader_parameter(uniform_name) == null:
+			warnings.append("The Node To Recolor material must have an uniform %s." % uniform_name)
 	return warnings

--- a/scenes/game_elements/components/cel_shading_recolor.gdshader
+++ b/scenes/game_elements/components/cel_shading_recolor.gdshader
@@ -38,17 +38,17 @@ group_uniforms NewColors;
  * [br][br]
  * Defaults to yellow emoji-like color.
  */
-instance uniform vec4 shade_medium_new : source_color = vec4(0.89, 0.89, 0, 1);
+uniform vec4 shade_medium_new : source_color = vec4(0.89, 0.89, 0, 1);
 
 /**
  * The new high or lightened color.
  */
-instance uniform vec4 shade_high_new : source_color = vec4(0.91, 0.91, 0.2, 1);
+uniform vec4 shade_high_new : source_color = vec4(0.91, 0.91, 0.2, 1);
 
 /**
  * The new low or darkened color.
  */
-instance uniform vec4 shade_low_new : source_color = vec4(0.71, 0.71, 0, 1);
+uniform vec4 shade_low_new : source_color = vec4(0.71, 0.71, 0, 1);
 
 void fragment() {
 	ivec3 colori = ivec3(round(COLOR.rgb * 255.0));


### PR DESCRIPTION
Do not rely on instance shader parameters for recoloring. Instead, make the material unique when a different recolor is needed. For instance, by duplicating the cel_shading_recolor_material.tres.