### PR TITLE
Input HUD: Use consistent input button icons

### DIFF
--- a/scenes/game_elements/props/hint/input_key/interact_input.gd
+++ b/scenes/game_elements/props/hint/input_key/interact_input.gd
@@ -3,14 +3,11 @@
 extends TextureRect
 
 @export var action_name: StringName
-@export var keyboard_texture: Texture2D
-@export var xbox_controller_texture: Texture2D
-@export var playstation_controller_texture: Texture2D
-@export var nintendo_controller_texture: Texture2D
-@export var steam_controller_texture: Texture2D
+@export var alternative: bool = false
+@export var devices: InputHintManager
 
 
-func _physics_process(_delta: float) -> void:
+func _process(_delta: float) -> void:
 	if Input.is_action_pressed(action_name):
 		modulate = Color.GRAY
 	else:
@@ -18,29 +15,18 @@ func _physics_process(_delta: float) -> void:
 
 
 func _ready() -> void:
-	InputHelper.device_changed.connect(_on_input_device_changed)
-	_on_input_device_changed(InputHelper.device, InputHelper.device_index)
+	if devices:
+		InputHelper.device_changed.connect(_on_input_device_changed)
+		_on_input_device_changed(InputHelper.device, InputHelper.device_index)
+	else:
+		push_warning("%s: Per-device textures not configured" % get_path())
 
 
 func _on_input_device_changed(device: String, _device_index: int) -> void:
-	visible = true  # Always visible (hybrid)
-
-	match device:
-		InputHelper.DEVICE_KEYBOARD:
-			if keyboard_texture:
-				texture = keyboard_texture
-
-		InputHelper.DEVICE_XBOX_CONTROLLER:
-			texture = xbox_controller_texture
-
-		InputHelper.DEVICE_PLAYSTATION_CONTROLLER:
-			texture = playstation_controller_texture
-
-		InputHelper.DEVICE_SWITCH_CONTROLLER:
-			texture = nintendo_controller_texture
-
-		InputHelper.DEVICE_STEAMDECK_CONTROLLER:
-			texture = steam_controller_texture
-
-		_:
-			texture = xbox_controller_texture
+	var textures := devices.device_map[InputHelper.device]
+	if alternative:
+		texture = textures.get(action_name + "_alt")
+		visible = texture != null
+	else:
+		texture = textures.get(action_name)
+		visible = true

--- a/scenes/game_elements/props/hint/resources/joypadButtonTextures.gd
+++ b/scenes/game_elements/props/hint/resources/joypadButtonTextures.gd
@@ -10,6 +10,35 @@ extends Resource
 ## Textures for the [code]aim_*[/code] actions
 @export var aim: DirectionalInputTextures
 
+## Texture for the [code]running[/code] action
+@export var running: Texture2D
+
+## Texture for the [code]interact[/code] action
+@export var interact: Texture2D
+
+## Texture for the [code]repel[/code] action
+@export var repel: Texture2D
+
+## Alternative texture for the [code]repel[/code] action (i.e. the keyboard key
+## as opposed to mouse button)
+@export var repel_alt: Texture2D
+
+## Texture for the [code]throw[/code] action
+@export var throw: Texture2D
+
+## Alternative texture for the [code]throw[/code] action (i.e. the keyboard key
+## as opposed to mouse button)
+@export var throw_alt: Texture2D
+
+## Texture for the [code]sokoban_undo[/code] action
+@export var sokoban_undo: Texture2D
+
+## Texture for the [code]sokoban_reset[/code] action
+@export var sokoban_reset: Texture2D
+
+## Texture for the [code]sokoban_skip[/code] action
+@export var sokoban_skip: Texture2D
+
 
 ## Returns the texture for a directional action. For instance, to get the
 ## correct texture for the [code]aim_left[/code] action, use:

--- a/scenes/game_elements/props/hint/resources/keyboard.tres
+++ b/scenes/game_elements/props/hint/resources/keyboard.tres
@@ -7,6 +7,13 @@
 [ext_resource type="Texture2D" uid="uid://bc8ffgelnq2nn" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_arrows_none.tres" id="4_8ua6o"]
 [ext_resource type="Script" uid="uid://dhgm1dl0ohox5" path="res://scenes/game_elements/props/hint/resources/directional_input_textures.gd" id="4_ixpgq"]
 [ext_resource type="Texture2D" uid="uid://bgcopu7b0q6iy" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_arrows_up_outline.tres" id="5_4b2ex"]
+[ext_resource type="Texture2D" uid="uid://c6fggds355rko" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_space_outline.tres" id="7_xgsrv"]
+[ext_resource type="Texture2D" uid="uid://dsre3bn521s4n" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/mouse_right_outline.tres" id="8_7o4sm"]
+[ext_resource type="Texture2D" uid="uid://bko5l0he6rf5o" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_z_outline.tres" id="9_nexuq"]
+[ext_resource type="Texture2D" uid="uid://00rpvlvvuems" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_shift_icon_outline.tres" id="10_jffwy"]
+[ext_resource type="Texture2D" uid="uid://c88qkrdjmolti" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_r_outline.tres" id="12_ac6oh"]
+[ext_resource type="Texture2D" uid="uid://cl3gxcavxrefq" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_x_outline.tres" id="13_12qfk"]
+[ext_resource type="Texture2D" uid="uid://dug86v7cum1kf" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/mouse_left_outline.tres" id="14_gs4lw"]
 
 [sub_resource type="Resource" id="Resource_j5qbp"]
 script = ExtResource("4_ixpgq")
@@ -20,4 +27,13 @@ right = ExtResource("3_j5qbp")
 script = ExtResource("1_cfqun")
 move = SubResource("Resource_j5qbp")
 aim = SubResource("Resource_j5qbp")
+running = ExtResource("10_jffwy")
+interact = ExtResource("7_xgsrv")
+repel = ExtResource("8_7o4sm")
+repel_alt = ExtResource("9_nexuq")
+throw = ExtResource("14_gs4lw")
+throw_alt = ExtResource("13_12qfk")
+sokoban_undo = ExtResource("9_nexuq")
+sokoban_reset = ExtResource("12_ac6oh")
+sokoban_skip = ExtResource("13_12qfk")
 metadata/_custom_type_script = "uid://c0haweg5svww1"

--- a/scenes/game_elements/props/hint/resources/playstation.tres
+++ b/scenes/game_elements/props/hint/resources/playstation.tres
@@ -12,6 +12,13 @@
 [ext_resource type="Texture2D" uid="uid://dspkrq3jsh26x" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_r.tres" id="5_jo447"]
 [ext_resource type="Texture2D" uid="uid://b5k4atvuhf6xp" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_dpad_up_outline.tres" id="5_oi6ek"]
 [ext_resource type="Texture2D" uid="uid://d2fkhf81x8u6d" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_r_up.tres" id="6_q44m7"]
+[ext_resource type="Texture2D" uid="uid://cjhshus64ytpq" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_cross_outline.tres" id="7_kkpem"]
+[ext_resource type="Texture2D" uid="uid://c8cfu7jw7nnbs" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_trigger_r1_outline.tres" id="13_rd2vx"]
+[ext_resource type="Texture2D" uid="uid://co0m0w1t84na8" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_trigger_l1_outline.tres" id="14_wqnvl"]
+[ext_resource type="Texture2D" uid="uid://dltoru1w8ue7w" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_square_outline.tres" id="16_y4fr0"]
+[ext_resource type="Texture2D" uid="uid://d3rhotqp5gg7h" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_triangle_outline.tres" id="17_8wf4n"]
+[ext_resource type="Texture2D" uid="uid://7qdppn7p05b1" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_circle_outline.tres" id="18_0nat0"]
+[ext_resource type="Texture2D" uid="uid://df8vlifau6x6w" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_trigger_r2_outline.tres" id="19_khsdn"]
 
 [sub_resource type="Resource" id="Resource_emb5i"]
 script = ExtResource("4_cghs7")
@@ -35,4 +42,11 @@ metadata/_custom_type_script = "uid://dhgm1dl0ohox5"
 script = ExtResource("1_omqst")
 move = SubResource("Resource_kkpem")
 aim = SubResource("Resource_emb5i")
+running = ExtResource("14_wqnvl")
+interact = ExtResource("7_kkpem")
+repel = ExtResource("13_rd2vx")
+throw = ExtResource("19_khsdn")
+sokoban_undo = ExtResource("18_0nat0")
+sokoban_reset = ExtResource("16_y4fr0")
+sokoban_skip = ExtResource("17_8wf4n")
 metadata/_custom_type_script = "uid://c0haweg5svww1"

--- a/scenes/game_elements/props/hint/resources/steamdeck.tres
+++ b/scenes/game_elements/props/hint/resources/steamdeck.tres
@@ -12,6 +12,13 @@
 [ext_resource type="Texture2D" uid="uid://bsxgtg4k28e61" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_dpad_up_outline.tres" id="5_1ctii"]
 [ext_resource type="Texture2D" uid="uid://b01qu3gqd3ctu" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_r.tres" id="5_3pkdl"]
 [ext_resource type="Texture2D" uid="uid://7ob6261vwokk" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_r_up.tres" id="6_poinc"]
+[ext_resource type="Texture2D" uid="uid://d223ajwmavjy8" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_a_outline.tres" id="7_wb6ss"]
+[ext_resource type="Texture2D" uid="uid://b7rygdiqbuuik" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_r1_outline.tres" id="13_enqan"]
+[ext_resource type="Texture2D" uid="uid://c2dy27tlmsigy" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_l1_outline.tres" id="14_hxnoe"]
+[ext_resource type="Texture2D" uid="uid://rrbih026ixaf" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_x_outline.tres" id="16_va1ks"]
+[ext_resource type="Texture2D" uid="uid://dn8vx333yunpe" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_y_outline.tres" id="17_vbsy4"]
+[ext_resource type="Texture2D" uid="uid://b2f4prnfhd1k1" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_b_outline.tres" id="18_otkfu"]
+[ext_resource type="Texture2D" uid="uid://jp3e3lyaan40" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_r2_outline.tres" id="19_c7evk"]
 
 [sub_resource type="Resource" id="Resource_domy7"]
 script = ExtResource("4_3qkoy")
@@ -35,4 +42,11 @@ metadata/_custom_type_script = "uid://dhgm1dl0ohox5"
 script = ExtResource("1_aumst")
 move = SubResource("Resource_wb6ss")
 aim = SubResource("Resource_domy7")
+running = ExtResource("14_hxnoe")
+interact = ExtResource("7_wb6ss")
+repel = ExtResource("13_enqan")
+throw = ExtResource("19_c7evk")
+sokoban_undo = ExtResource("18_otkfu")
+sokoban_reset = ExtResource("16_va1ks")
+sokoban_skip = ExtResource("17_vbsy4")
 metadata/_custom_type_script = "uid://c0haweg5svww1"

--- a/scenes/game_elements/props/hint/resources/switch.tres
+++ b/scenes/game_elements/props/hint/resources/switch.tres
@@ -12,6 +12,13 @@
 [ext_resource type="Texture2D" uid="uid://bk5kfa10mmwlb" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_r.tres" id="5_3yvyh"]
 [ext_resource type="Texture2D" uid="uid://cbfuj8bkq6seu" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_dpad_up_outline.tres" id="5_mujfa"]
 [ext_resource type="Texture2D" uid="uid://cnnufqepabnm2" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_r_up.tres" id="6_0s2bm"]
+[ext_resource type="Texture2D" uid="uid://cw4b0a55wdndp" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_b_outline.tres" id="7_nqwbi"]
+[ext_resource type="Texture2D" uid="uid://cren16wfvch5p" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_r_outline.tres" id="13_x12kq"]
+[ext_resource type="Texture2D" uid="uid://bfestobnif7sl" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_l_outline.tres" id="14_lbflk"]
+[ext_resource type="Texture2D" uid="uid://bkeqno6623dcj" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_y_outline.tres" id="16_yfmui"]
+[ext_resource type="Texture2D" uid="uid://cdgyk384ou7gp" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_x_outline.tres" id="17_buody"]
+[ext_resource type="Texture2D" uid="uid://bxvdat8x7qdm0" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_a_outline.tres" id="18_poutv"]
+[ext_resource type="Texture2D" uid="uid://dawyfturb2nwq" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_zr_outline.tres" id="19_h0ie6"]
 
 [sub_resource type="Resource" id="Resource_mv42c"]
 script = ExtResource("4_56m3b")
@@ -34,4 +41,11 @@ right = ExtResource("3_c5mv4")
 script = ExtResource("1_feeyu")
 move = SubResource("Resource_c5mv4")
 aim = SubResource("Resource_mv42c")
+running = ExtResource("14_lbflk")
+interact = ExtResource("7_nqwbi")
+repel = ExtResource("13_x12kq")
+throw = ExtResource("19_h0ie6")
+sokoban_undo = ExtResource("18_poutv")
+sokoban_reset = ExtResource("16_yfmui")
+sokoban_skip = ExtResource("17_buody")
 metadata/_custom_type_script = "uid://c0haweg5svww1"

--- a/scenes/game_elements/props/hint/resources/xbox.tres
+++ b/scenes/game_elements/props/hint/resources/xbox.tres
@@ -12,6 +12,13 @@
 [ext_resource type="Texture2D" uid="uid://ci1j0k8leqa3o" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_r.tres" id="5_g15f5"]
 [ext_resource type="Texture2D" uid="uid://bcwquyrkyor4j" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_dpad_up_outline.tres" id="5_kariy"]
 [ext_resource type="Texture2D" uid="uid://b45ky4pi3jety" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_r_up.tres" id="6_tv03i"]
+[ext_resource type="Texture2D" uid="uid://csbx81u4w37rp" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_a_outline.tres" id="7_tskv1"]
+[ext_resource type="Texture2D" uid="uid://m1fgpc7ru2b5" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_rb_outline.tres" id="13_fvgft"]
+[ext_resource type="Texture2D" uid="uid://dvkwc3688asij" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_lb_outline.tres" id="14_pukp1"]
+[ext_resource type="Texture2D" uid="uid://b8oqqn2re8bb4" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_x_outline.tres" id="16_5vyqi"]
+[ext_resource type="Texture2D" uid="uid://dk1g11haycllj" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_y_outline.tres" id="17_snkap"]
+[ext_resource type="Texture2D" uid="uid://cpafwyrjkngt3" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_b_outline.tres" id="18_0iss4"]
+[ext_resource type="Texture2D" uid="uid://bowdggq0c1ir4" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_rt_outline.tres" id="19_21ad5"]
 
 [sub_resource type="Resource" id="Resource_cci5c"]
 script = ExtResource("1_qwpf8")
@@ -34,4 +41,11 @@ right = ExtResource("3_nh82o")
 script = ExtResource("1_bisyu")
 move = SubResource("Resource_qwpf8")
 aim = SubResource("Resource_cci5c")
+running = ExtResource("14_pukp1")
+interact = ExtResource("7_tskv1")
+repel = ExtResource("13_fvgft")
+throw = ExtResource("19_21ad5")
+sokoban_undo = ExtResource("18_0iss4")
+sokoban_reset = ExtResource("16_5vyqi")
+sokoban_skip = ExtResource("17_snkap")
 metadata/_custom_type_script = "uid://c0haweg5svww1"

--- a/scenes/quests/story_quests/champ/3_stealth/champ_stealth.tscn
+++ b/scenes/quests/story_quests/champ/3_stealth/champ_stealth.tscn
@@ -54,9 +54,9 @@
 [ext_resource type="Resource" uid="uid://dl6n1ifa5ktnp" path="res://scenes/quests/story_quests/champ/3_stealth/stealth_components/champ_incomplete_stealth_movement_hint.dialogue" id="28_fqjr6"]
 [ext_resource type="PackedScene" uid="uid://drew54gcfpekn" path="res://scenes/quests/story_quests/champ/3_stealth/stealth_components/champ_water_rock/champ_water_rock.tscn" id="29_rik0t"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="30_nyycj"]
+[ext_resource type="Texture2D" uid="uid://c63g4rx3fvw4o" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_c_outline.tres" id="31_8k5n0"]
+[ext_resource type="Texture2D" uid="uid://djen1whwwin1w" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_f_outline.tres" id="33_1n21b"]
 [ext_resource type="Resource" uid="uid://bmharix12w26t" path="res://scenes/quests/story_quests/champ/3_stealth/stealth_components/champ_blink.dialogue" id="34_g76pt"]
-[ext_resource type="Texture2D" uid="uid://djen1whwwin1w" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_f_outline.tres" id="37_yfmpo"]
-[ext_resource type="Texture2D" uid="uid://c63g4rx3fvw4o" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_c_outline.tres" id="38_wbd51"]
 [ext_resource type="Texture2D" uid="uid://h606ovawbm0x" path="res://scenes/quests/story_quests/champ/3_stealth/stealth_components/BlinkMarker.png" id="44_onp74"]
 [ext_resource type="Script" uid="uid://hqdquinbimce" path="res://scenes/game_elements/props/teleporter/teleporter.gd" id="46_8k5n0"]
 [ext_resource type="Resource" uid="uid://cxjgjjb44ssnm" path="res://scenes/quests/story_quests/champ/3_stealth/stealth_components/champ_walking_on_water.dialogue" id="55_rosy4"]
@@ -1752,7 +1752,7 @@ layout_mode = 2
 
 [node name="Interaction_hint" type="TextureRect" parent="ScreenOverlay/Hint/Blink_Hint" unique_id=207495647]
 layout_mode = 2
-texture = ExtResource("38_wbd51")
+texture = ExtResource("31_8k5n0")
 script = ExtResource("30_nyycj")
 action_name = &"champ_blink"
 
@@ -1765,7 +1765,7 @@ layout_mode = 2
 
 [node name="Water_hint" type="TextureRect" parent="ScreenOverlay/Hint/walking_on_water" unique_id=506122502]
 layout_mode = 2
-texture = ExtResource("37_yfmpo")
+texture = ExtResource("33_1n21b")
 script = ExtResource("30_nyycj")
 action_name = &"champ_walk_on_water"
 

--- a/scenes/quests/story_quests/shjourney/0_IntroVideo/saltar_video.gd
+++ b/scenes/quests/story_quests/shjourney/0_IntroVideo/saltar_video.gd
@@ -3,5 +3,7 @@
 extends VideoStreamPlayer
 
 func _input(event):
-	if event.is_action_pressed("ui_select"):
-		get_tree().change_scene_to_file("res://scenes/quests/story_quests/shjourney/1_IntroAnimacion/SleepingBros.tscn")
+	if event.is_action_pressed(&"interact"):
+		SceneSwitcher.change_to_file(
+			"res://scenes/quests/story_quests/shjourney/1_IntroAnimacion/SleepingBros.tscn"
+		)

--- a/scenes/quests/story_quests/shjourney/1_IntroAnimacion/saltar_escena.gd
+++ b/scenes/quests/story_quests/shjourney/1_IntroAnimacion/saltar_escena.gd
@@ -3,5 +3,5 @@
 extends AnimatedSprite2D
 
 func _input(event):
-	if event.is_action_pressed("ui_select"):
-		get_tree().change_scene_to_file("res://scenes/quests/story_quests/shjourney/2_shjourney_intro/template_intro.tscn")
+	if event.is_action_pressed("interact"):
+		SceneSwitcher.change_to_file("res://scenes/quests/story_quests/shjourney/2_shjourney_intro/template_intro.tscn")

--- a/scenes/quests/story_quests/shjourney/saltar_cinematica_hint.tscn
+++ b/scenes/quests/story_quests/shjourney/saltar_cinematica_hint.tscn
@@ -1,11 +1,8 @@
 [gd_scene format=3 uid="uid://bdlaxkehg7vd6"]
 
-[ext_resource type="Texture2D" uid="uid://c6fggds355rko" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_space_outline.tres" id="1_0n78t"]
+[ext_resource type="Texture2D" uid="uid://d2s8w7any6x45" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_space.tres" id="1_x4qh5"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="2_lbtwt"]
-[ext_resource type="Texture2D" uid="uid://cxnx628qkf1br" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_color_a.tres" id="3_lbtwt"]
-[ext_resource type="Texture2D" uid="uid://da6qvcr5sq71n" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_color_cross_outline.tres" id="4_2ul1c"]
-[ext_resource type="Texture2D" uid="uid://upt0tmtsk3y2" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_a.tres" id="5_2k2oy"]
-[ext_resource type="Texture2D" uid="uid://d223ajwmavjy8" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_a_outline.tres" id="6_gaoc7"]
+[ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="3_7cupx"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="7_07epa"]
 
 [node name="SaltarCinematicaHint" type="HBoxContainer" unique_id=1402783077]
@@ -15,14 +12,10 @@ offset_bottom = 100.0
 [node name="TextureRect" type="TextureRect" parent="." unique_id=281216563]
 layout_mode = 2
 size_flags_vertical = 8
-texture = ExtResource("1_0n78t")
+texture = ExtResource("1_x4qh5")
 script = ExtResource("2_lbtwt")
 action_name = &"interact"
-keyboard_texture = ExtResource("1_0n78t")
-xbox_controller_texture = ExtResource("3_lbtwt")
-playstation_controller_texture = ExtResource("4_2ul1c")
-nintendo_controller_texture = ExtResource("5_2k2oy")
-steam_controller_texture = ExtResource("6_gaoc7")
+devices = ExtResource("3_7cupx")
 
 [node name="Label" type="Label" parent="." unique_id=107845220]
 layout_mode = 2

--- a/scenes/ui_elements/input_hints/input_hud.tscn
+++ b/scenes/ui_elements/input_hints/input_hud.tscn
@@ -30,12 +30,11 @@ theme_override_constants/margin_right = 8
 [node name="TabContainer" type="TabContainer" parent="MarginContainer" unique_id=2133091109]
 self_modulate = Color(1, 1, 1, 0)
 layout_mode = 2
-current_tab = 1
+current_tab = 0
 tabs_visible = false
 
 [node name="NormalControls" type="HBoxContainer" parent="MarginContainer/TabContainer" unique_id=2094239495]
 unique_name_in_owner = true
-visible = false
 z_index = 38
 layout_mode = 2
 metadata/_tab_index = 0
@@ -48,7 +47,6 @@ layout_mode = 2
 
 [node name="InteractInputHint" parent="MarginContainer/TabContainer/NormalControls" unique_id=1438993105 instance=ExtResource("4_ae80x")]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
 
 [node name="Spacer" type="Control" parent="MarginContainer/TabContainer/NormalControls" unique_id=1059909765]
@@ -58,21 +56,19 @@ size_flags_horizontal = 3
 
 [node name="AimInputHint" parent="MarginContainer/TabContainer/NormalControls" unique_id=2095395309 instance=ExtResource("1_u1put")]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
 
 [node name="ThrowInputHint" parent="MarginContainer/TabContainer/NormalControls" unique_id=1113313011 instance=ExtResource("5_ke286")]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
 
 [node name="RepelInputHint" parent="MarginContainer/TabContainer/NormalControls" unique_id=1938432601 instance=ExtResource("3_xu7en")]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
 
 [node name="SokobanControls" type="HBoxContainer" parent="MarginContainer/TabContainer" unique_id=1543053795]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 metadata/_tab_index = 1
 

--- a/scenes/ui_elements/input_hints/interact_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/interact_input_hint.tscn
@@ -1,13 +1,10 @@
 [gd_scene format=3 uid="uid://b2r2pvcppbl4v"]
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_txh2t"]
-[ext_resource type="Texture2D" uid="uid://c6fggds355rko" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_space_outline.tres" id="2_vvpol"]
 [ext_resource type="Script" uid="uid://ntkyy7hnkwh7" path="res://scenes/ui_elements/input_hints/components/labeled_input_hint.gd" id="2_y4ddx"]
+[ext_resource type="Texture2D" uid="uid://d2s8w7any6x45" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_space.tres" id="3_vvpol"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="3_y4ddx"]
-[ext_resource type="Texture2D" uid="uid://cxnx628qkf1br" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_color_a.tres" id="4_6mrrw"]
-[ext_resource type="Texture2D" uid="uid://da6qvcr5sq71n" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_color_cross_outline.tres" id="5_8u7s0"]
-[ext_resource type="Texture2D" uid="uid://upt0tmtsk3y2" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_a.tres" id="6_6csox"]
-[ext_resource type="Texture2D" uid="uid://d223ajwmavjy8" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_a_outline.tres" id="7_73850"]
+[ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="5_gekfg"]
 
 [node name="InteractInputHint" type="HBoxContainer" unique_id=1438993105]
 theme = ExtResource("1_txh2t")
@@ -16,14 +13,10 @@ script = ExtResource("2_y4ddx")
 [node name="RepelHint" type="TextureRect" parent="." unique_id=492172300]
 layout_mode = 2
 size_flags_vertical = 8
-texture = ExtResource("2_vvpol")
+texture = ExtResource("3_vvpol")
 script = ExtResource("3_y4ddx")
 action_name = &"interact"
-keyboard_texture = ExtResource("2_vvpol")
-xbox_controller_texture = ExtResource("4_6mrrw")
-playstation_controller_texture = ExtResource("5_8u7s0")
-nintendo_controller_texture = ExtResource("6_6csox")
-steam_controller_texture = ExtResource("7_73850")
+devices = ExtResource("5_gekfg")
 
 [node name="Label" type="Label" parent="." unique_id=2095697003]
 unique_name_in_owner = true

--- a/scenes/ui_elements/input_hints/repel_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/repel_input_hint.tscn
@@ -2,12 +2,9 @@
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_ts6v2"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="3_af5s8"]
+[ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="4_07f5k"]
 [ext_resource type="Texture2D" uid="uid://dsre3bn521s4n" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/mouse_right_outline.tres" id="4_af5s8"]
-[ext_resource type="Texture2D" uid="uid://b8vx7d65vtyoe" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_rb.tres" id="5_dmgl2"]
-[ext_resource type="Texture2D" uid="uid://d4js371huf717" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_trigger_r1.tres" id="6_af5s8"]
-[ext_resource type="Texture2D" uid="uid://bwgbwlyaom3ax" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_r.tres" id="7_af5s8"]
-[ext_resource type="Texture2D" uid="uid://dqlcod0kb4mfi" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_r1.tres" id="8_af5s8"]
-[ext_resource type="Texture2D" uid="uid://bko5l0he6rf5o" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_z_outline.tres" id="9_af5s8"]
+[ext_resource type="Texture2D" uid="uid://bry0q0k1nmmyh" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_z.tres" id="8_j3y3l"]
 
 [node name="RepelInputHint" type="HBoxContainer" unique_id=736303687]
 theme = ExtResource("1_ts6v2")
@@ -18,19 +15,16 @@ size_flags_vertical = 8
 texture = ExtResource("4_af5s8")
 script = ExtResource("3_af5s8")
 action_name = &"repel"
-keyboard_texture = ExtResource("4_af5s8")
-xbox_controller_texture = ExtResource("5_dmgl2")
-playstation_controller_texture = ExtResource("6_af5s8")
-nintendo_controller_texture = ExtResource("7_af5s8")
-steam_controller_texture = ExtResource("8_af5s8")
+devices = ExtResource("4_07f5k")
 
 [node name="TextureRectAlt" type="TextureRect" parent="." unique_id=53201882]
 layout_mode = 2
 size_flags_vertical = 8
-texture = ExtResource("9_af5s8")
+texture = ExtResource("8_j3y3l")
 script = ExtResource("3_af5s8")
 action_name = &"repel"
-keyboard_texture = ExtResource("9_af5s8")
+alternative = true
+devices = ExtResource("4_07f5k")
 
 [node name="Label" type="Label" parent="." unique_id=1879289720]
 layout_mode = 2

--- a/scenes/ui_elements/input_hints/reset_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/reset_input_hint.tscn
@@ -1,11 +1,8 @@
 [gd_scene format=3 uid="uid://cjg3rptgsh0lf"]
 
-[ext_resource type="Texture2D" uid="uid://c88qkrdjmolti" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_r_outline.tres" id="1_lpid6"]
+[ext_resource type="Texture2D" uid="uid://do0gp3uj3iiw3" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_r.tres" id="1_qfkb4"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="2_jc2yi"]
-[ext_resource type="Texture2D" uid="uid://1sh6nf18rlha" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_color_x_outline.tres" id="3_i3vud"]
-[ext_resource type="Texture2D" uid="uid://dltoru1w8ue7w" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_square_outline.tres" id="4_no2ym"]
-[ext_resource type="Texture2D" uid="uid://bkeqno6623dcj" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_y_outline.tres" id="5_acjax"]
-[ext_resource type="Texture2D" uid="uid://rrbih026ixaf" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_x_outline.tres" id="6_7xjue"]
+[ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="3_qoa1j"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="7_ut24o"]
 
 [node name="ResettInputHint" type="HBoxContainer" unique_id=1042096726]
@@ -17,14 +14,10 @@ size_flags_horizontal = 0
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 8
-texture = ExtResource("1_lpid6")
+texture = ExtResource("1_qfkb4")
 script = ExtResource("2_jc2yi")
 action_name = &"sokoban_reset"
-keyboard_texture = ExtResource("1_lpid6")
-xbox_controller_texture = ExtResource("3_i3vud")
-playstation_controller_texture = ExtResource("4_no2ym")
-nintendo_controller_texture = ExtResource("5_acjax")
-steam_controller_texture = ExtResource("6_7xjue")
+devices = ExtResource("3_qoa1j")
 
 [node name="Label" type="Label" parent="." unique_id=2059219668]
 layout_mode = 2

--- a/scenes/ui_elements/input_hints/run_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/run_input_hint.tscn
@@ -2,11 +2,8 @@
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_fw67w"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="2_fw67w"]
-[ext_resource type="Texture2D" uid="uid://crjsc68he8u5s" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_shift_outline.tres" id="2_lfnk4"]
-[ext_resource type="Texture2D" uid="uid://i8ml62flydha" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_color_lb_outline.tres" id="4_3yb1f"]
-[ext_resource type="Texture2D" uid="uid://dfbsi8lsnorsm" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_trigger_l1_alternative_outline.tres" id="5_dr0c4"]
-[ext_resource type="Texture2D" uid="uid://d3xcwvn1am5pi" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_l.tres" id="6_5kmqj"]
-[ext_resource type="Texture2D" uid="uid://c2dy27tlmsigy" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_l1_outline.tres" id="7_ak3lp"]
+[ext_resource type="Texture2D" uid="uid://dnttje26if8fw" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_shift_icon.tres" id="2_l8qil"]
+[ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="4_1lsuh"]
 
 [node name="RunInputHint" type="HBoxContainer" unique_id=204428787]
 custom_minimum_size = Vector2(64, 64)
@@ -15,14 +12,11 @@ theme = ExtResource("1_fw67w")
 [node name="RunHint" type="TextureRect" parent="." unique_id=809781428]
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 2
-texture = ExtResource("2_lfnk4")
+texture = ExtResource("2_l8qil")
 script = ExtResource("2_fw67w")
 action_name = &"running"
-keyboard_texture = ExtResource("2_lfnk4")
-xbox_controller_texture = ExtResource("4_3yb1f")
-playstation_controller_texture = ExtResource("5_dr0c4")
-nintendo_controller_texture = ExtResource("6_5kmqj")
-steam_controller_texture = ExtResource("7_ak3lp")
+alternative = null
+devices = ExtResource("4_1lsuh")
 
 [node name="Label" type="Label" parent="." unique_id=779915588]
 layout_mode = 2

--- a/scenes/ui_elements/input_hints/skip_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/skip_input_hint.tscn
@@ -1,11 +1,8 @@
 [gd_scene format=3 uid="uid://b50dfpi7c1sdw"]
 
-[ext_resource type="Texture2D" uid="uid://cl3gxcavxrefq" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_x_outline.tres" id="1_h2bti"]
+[ext_resource type="Texture2D" uid="uid://be8kao32d16ao" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_x.tres" id="1_sb40v"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="2_6gqhh"]
-[ext_resource type="Texture2D" uid="uid://ds1gncqxuv7p7" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_color_y_outline.tres" id="3_iqeim"]
-[ext_resource type="Texture2D" uid="uid://d3rhotqp5gg7h" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_triangle_outline.tres" id="4_jpogt"]
-[ext_resource type="Texture2D" uid="uid://cdgyk384ou7gp" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_x_outline.tres" id="5_5433x"]
-[ext_resource type="Texture2D" uid="uid://dn8vx333yunpe" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_y_outline.tres" id="6_bj40i"]
+[ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="3_86k3p"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="7_3w1ni"]
 
 [node name="SkipInputHint" type="HBoxContainer" unique_id=2102034377]
@@ -17,14 +14,10 @@ size_flags_horizontal = 0
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 8
-texture = ExtResource("1_h2bti")
+texture = ExtResource("1_sb40v")
 script = ExtResource("2_6gqhh")
 action_name = &"sokoban_skip"
-keyboard_texture = ExtResource("1_h2bti")
-xbox_controller_texture = ExtResource("3_iqeim")
-playstation_controller_texture = ExtResource("4_jpogt")
-nintendo_controller_texture = ExtResource("5_5433x")
-steam_controller_texture = ExtResource("6_bj40i")
+devices = ExtResource("3_86k3p")
 
 [node name="Label" type="Label" parent="." unique_id=574082432]
 layout_mode = 2

--- a/scenes/ui_elements/input_hints/throw_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/throw_input_hint.tscn
@@ -3,11 +3,8 @@
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_hvmxk"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="3_g0g4i"]
 [ext_resource type="Texture2D" uid="uid://dug86v7cum1kf" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/mouse_left_outline.tres" id="4_81p17"]
-[ext_resource type="Texture2D" uid="uid://bowdggq0c1ir4" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_rt_outline.tres" id="4_cgyew"]
-[ext_resource type="Texture2D" uid="uid://bpbe2jg7uiaf6" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_trigger_r2_alternative_outline.tres" id="5_g0g4i"]
-[ext_resource type="Texture2D" uid="uid://dawyfturb2nwq" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_zr_outline.tres" id="6_81p17"]
-[ext_resource type="Texture2D" uid="uid://jp3e3lyaan40" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_r2_outline.tres" id="7_vu6nt"]
-[ext_resource type="Texture2D" uid="uid://cl3gxcavxrefq" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_x_outline.tres" id="9_g0g4i"]
+[ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="4_aei35"]
+[ext_resource type="Texture2D" uid="uid://be8kao32d16ao" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_x.tres" id="8_5pjl8"]
 
 [node name="ThrowInputHint" type="HBoxContainer" unique_id=1113313011]
 theme = ExtResource("1_hvmxk")
@@ -18,19 +15,16 @@ size_flags_vertical = 8
 texture = ExtResource("4_81p17")
 script = ExtResource("3_g0g4i")
 action_name = &"throw"
-keyboard_texture = ExtResource("4_81p17")
-xbox_controller_texture = ExtResource("4_cgyew")
-playstation_controller_texture = ExtResource("5_g0g4i")
-nintendo_controller_texture = ExtResource("6_81p17")
-steam_controller_texture = ExtResource("7_vu6nt")
+devices = ExtResource("4_aei35")
 
 [node name="TextureRect2" type="TextureRect" parent="." unique_id=2115622263]
 layout_mode = 2
 size_flags_vertical = 8
-texture = ExtResource("9_g0g4i")
+texture = ExtResource("8_5pjl8")
 script = ExtResource("3_g0g4i")
 action_name = &"throw"
-keyboard_texture = ExtResource("9_g0g4i")
+alternative = true
+devices = ExtResource("4_aei35")
 
 [node name="Label" type="Label" parent="." unique_id=114048661]
 layout_mode = 2

--- a/scenes/ui_elements/input_hints/undo_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/undo_input_hint.tscn
@@ -1,11 +1,8 @@
 [gd_scene format=3 uid="uid://bl3pt0n5r8tm5"]
 
-[ext_resource type="Texture2D" uid="uid://bko5l0he6rf5o" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_z_outline.tres" id="1_jkby0"]
+[ext_resource type="Texture2D" uid="uid://bry0q0k1nmmyh" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_z.tres" id="1_jkby0"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="2_ewe37"]
-[ext_resource type="Texture2D" uid="uid://cpafwyrjkngt3" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_b_outline.tres" id="3_hi2j7"]
-[ext_resource type="Texture2D" uid="uid://7qdppn7p05b1" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_circle_outline.tres" id="4_2va3a"]
-[ext_resource type="Texture2D" uid="uid://upt0tmtsk3y2" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_a.tres" id="5_3iho2"]
-[ext_resource type="Texture2D" uid="uid://ddukicr2ko75b" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_b.tres" id="6_27mw4"]
+[ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="3_xqpg3"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="7_mx5dm"]
 
 [node name="UndoInputHint" type="HBoxContainer" unique_id=1063563018]
@@ -20,11 +17,7 @@ size_flags_vertical = 8
 texture = ExtResource("1_jkby0")
 script = ExtResource("2_ewe37")
 action_name = &"sokoban_undo"
-keyboard_texture = ExtResource("1_jkby0")
-xbox_controller_texture = ExtResource("3_hi2j7")
-playstation_controller_texture = ExtResource("4_2va3a")
-nintendo_controller_texture = ExtResource("5_3iho2")
-steam_controller_texture = ExtResource("6_27mw4")
+devices = ExtResource("3_xqpg3")
 
 [node name="Label" type="Label" parent="." unique_id=1638305220]
 layout_mode = 2


### PR DESCRIPTION
Previously we had a mixture of outline and filled icons; and of colour
and monochrome icons for Xbox and PlayStation.

Refactor the way that these icons are assigned so that they are stored
in the same JoypadButtonTextures resource as directional inputs. This
means that the textures for a device type can be configured all in one
place.

Consistently use outline icons, which are more legible and obscure less of the world.

Consistently use monochrome icons for Xbox. It is true
that official Xbox controllers do have colours on the A/B/X/Y buttons
but looking at some photos in an image search, the colours are either
used for the text (not the surrounding button), or are printed as a
little directional key in between the four buttons. I own two Xbox-style
controllers made by 8BitDo; they use the XBox RB/RT labels for shoulder
buttons rather than R1/R2 so the use of xbox textures for generic
controllers seems appropriate, but they do not use colours.

Similarly, use monochrome icons for PlayStation. Some PlayStation
controllers have coloured buttons, but many more do not, and I don't
think the colours are the strongest association.

Some of the Switch button textures were inconsistent with the input map;
fix these in the process. Unfortunately I was unable to pair my Switch 2
JoyCons with my laptop so I can't actually test these. (If we wanted to
support Switch controllers "properly", IMO we should swap the mappings
so that the Switch "A" button is interact, but that's one for another
lifetime.)

For champ_stealth, rather than adding these champ_specific actions to
the global input map, make interact_input.gd skip the per-device mapping
if it is not provided, which improves on the previous behaviour of
showing blank icons when using a controller.

For Sueños Nocturnos, which has a custom "Saltar cinemática." hint, use
the "interact" button (matching the previous hardcoded button textures),
and adjust the action it looks for to match so that joypad buttons
actually work.

