### PR TITLE
HUD hint buttons: Project shadow for better contrast

### DIFF
--- a/assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard-&-mouse_sheet_default.png
+++ b/assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard-&-mouse_sheet_default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1846ff7e8ee22c3a4fb88efc8e569e98edef5b127bd4a6fbae11e16888578c92
-size 29862
+oid sha256:e7d1d25ca8515c413d2cbb675e11a2c792f2f97f13267433df247e1398dc4d6d
+size 24004

--- a/scenes/ui_elements/input_hints/aim_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/aim_input_hint.tscn
@@ -1,5 +1,6 @@
 [gd_scene format=3 uid="uid://cqkly1vjd6xhy"]
 
+[ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="1_65rvq"]
 [ext_resource type="Texture2D" uid="uid://bc8ffgelnq2nn" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_arrows_none.tres" id="1_yljil"]
 [ext_resource type="Script" uid="uid://bcx7jadxu27en" path="res://scenes/game_elements/props/hint/input_key/directional_input_hint.gd" id="2_k7hqe"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="3_k7hqe"]
@@ -9,6 +10,7 @@ offset_right = 40.0
 offset_bottom = 40.0
 
 [node name="AimHint" type="TextureRect" parent="." unique_id=2095395309]
+material = ExtResource("1_65rvq")
 layout_mode = 2
 texture = ExtResource("1_yljil")
 script = ExtResource("2_k7hqe")

--- a/scenes/ui_elements/input_hints/components/drop_shadow.gdshader
+++ b/scenes/ui_elements/input_hints/components/drop_shadow.gdshader
@@ -1,0 +1,21 @@
+/**
+ * Drop shadow shader
+ *
+ * This shader drops a shadow. Intended for button textures
+ * in the input HUD.
+ *
+ * SPDX-FileCopyrightText: The Threadbare Authors
+ * SPDX-License-Identifier: MPL-2.0
+ */
+shader_type canvas_item;
+
+uniform vec2 offset = vec2(2.0, 2.0);
+uniform vec4 shadow_color: source_color = vec4(0.0, 0.0, 0.0, 1.0);
+
+void fragment() {
+	vec4 color = texture(TEXTURE, UV);
+	vec4 shadow = texture(TEXTURE, UV - offset * TEXTURE_PIXEL_SIZE);
+	shadow.rgb = shadow_color.rgb;
+	shadow.a *= shadow_color.a;
+	COLOR = mix(shadow, color, color.a);
+}

--- a/scenes/ui_elements/input_hints/components/drop_shadow.gdshader.uid
+++ b/scenes/ui_elements/input_hints/components/drop_shadow.gdshader.uid
@@ -1,0 +1,1 @@
+uid://ddrxo4iq6cxk7

--- a/scenes/ui_elements/input_hints/components/drop_shadow_material.tres
+++ b/scenes/ui_elements/input_hints/components/drop_shadow_material.tres
@@ -1,0 +1,8 @@
+[gd_resource type="ShaderMaterial" format=3 uid="uid://cruf3tlajs4jo"]
+
+[ext_resource type="Shader" uid="uid://ddrxo4iq6cxk7" path="res://scenes/ui_elements/input_hints/components/drop_shadow.gdshader" id="1_k7b6b"]
+
+[resource]
+shader = ExtResource("1_k7b6b")
+shader_parameter/offset = Vector2(2, 2)
+shader_parameter/shadow_color = Color(0, 0, 0, 1)

--- a/scenes/ui_elements/input_hints/interact_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/interact_input_hint.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_txh2t"]
 [ext_resource type="Script" uid="uid://ntkyy7hnkwh7" path="res://scenes/ui_elements/input_hints/components/labeled_input_hint.gd" id="2_y4ddx"]
+[ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="3_pwflt"]
 [ext_resource type="Texture2D" uid="uid://d2s8w7any6x45" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_space.tres" id="3_vvpol"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="3_y4ddx"]
 [ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="5_gekfg"]
@@ -11,6 +12,7 @@ theme = ExtResource("1_txh2t")
 script = ExtResource("2_y4ddx")
 
 [node name="RepelHint" type="TextureRect" parent="." unique_id=492172300]
+material = ExtResource("3_pwflt")
 layout_mode = 2
 size_flags_vertical = 8
 texture = ExtResource("3_vvpol")

--- a/scenes/ui_elements/input_hints/movement_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/movement_input_hint.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://dt1y8odxq0xys"]
 
 [ext_resource type="Texture2D" uid="uid://bc8ffgelnq2nn" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_arrows_none.tres" id="1_wvg1n"]
+[ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="1_yv88g"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="3_ie8jv"]
 [ext_resource type="Script" uid="uid://bcx7jadxu27en" path="res://scenes/game_elements/props/hint/input_key/directional_input_hint.gd" id="27_vxq6f"]
 
@@ -12,6 +13,7 @@ offset_bottom = 64.0
 size_flags_horizontal = 0
 
 [node name="DirectionalInputHint" type="TextureRect" parent="." unique_id=883529731]
+material = ExtResource("1_yv88g")
 layout_mode = 2
 texture = ExtResource("1_wvg1n")
 script = ExtResource("27_vxq6f")

--- a/scenes/ui_elements/input_hints/repel_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/repel_input_hint.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://dkx3dgc1br3b4"]
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_ts6v2"]
+[ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="2_4govd"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="3_af5s8"]
 [ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="4_07f5k"]
 [ext_resource type="Texture2D" uid="uid://dsre3bn521s4n" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/mouse_right_outline.tres" id="4_af5s8"]
@@ -10,6 +11,7 @@
 theme = ExtResource("1_ts6v2")
 
 [node name="RepelHint" type="TextureRect" parent="." unique_id=142530974]
+material = ExtResource("2_4govd")
 layout_mode = 2
 size_flags_vertical = 8
 texture = ExtResource("4_af5s8")
@@ -18,6 +20,7 @@ action_name = &"repel"
 devices = ExtResource("4_07f5k")
 
 [node name="TextureRectAlt" type="TextureRect" parent="." unique_id=53201882]
+material = ExtResource("2_4govd")
 layout_mode = 2
 size_flags_vertical = 8
 texture = ExtResource("8_j3y3l")

--- a/scenes/ui_elements/input_hints/reset_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/reset_input_hint.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://cjg3rptgsh0lf"]
 
 [ext_resource type="Texture2D" uid="uid://do0gp3uj3iiw3" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_r.tres" id="1_qfkb4"]
+[ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="1_ykdc3"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="2_jc2yi"]
 [ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="3_qoa1j"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="7_ut24o"]
@@ -11,6 +12,7 @@ custom_minimum_size = Vector2(64, 64)
 size_flags_horizontal = 0
 
 [node name="ResetHint" type="TextureRect" parent="." unique_id=1319844575]
+material = ExtResource("1_ykdc3")
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 8

--- a/scenes/ui_elements/input_hints/run_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/run_input_hint.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://badjtfhkj7gbt"]
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_fw67w"]
+[ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/hint_button_material.tres" id="2_4tvpx"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="2_fw67w"]
 [ext_resource type="Texture2D" uid="uid://dnttje26if8fw" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_shift_icon.tres" id="2_l8qil"]
 [ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="4_1lsuh"]
@@ -10,6 +11,7 @@ custom_minimum_size = Vector2(64, 64)
 theme = ExtResource("1_fw67w")
 
 [node name="RunHint" type="TextureRect" parent="." unique_id=809781428]
+material = ExtResource("2_4tvpx")
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 2
 texture = ExtResource("2_l8qil")

--- a/scenes/ui_elements/input_hints/skip_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/skip_input_hint.tscn
@@ -1,5 +1,6 @@
 [gd_scene format=3 uid="uid://b50dfpi7c1sdw"]
 
+[ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="1_grytx"]
 [ext_resource type="Texture2D" uid="uid://be8kao32d16ao" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_x.tres" id="1_sb40v"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="2_6gqhh"]
 [ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="3_86k3p"]
@@ -11,6 +12,7 @@ custom_minimum_size = Vector2(64, 64)
 size_flags_horizontal = 0
 
 [node name="InteractInput" type="TextureRect" parent="." unique_id=2083489092]
+material = ExtResource("1_grytx")
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 8

--- a/scenes/ui_elements/input_hints/throw_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/throw_input_hint.tscn
@@ -4,12 +4,14 @@
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="3_g0g4i"]
 [ext_resource type="Texture2D" uid="uid://dug86v7cum1kf" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/mouse_left_outline.tres" id="4_81p17"]
 [ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="4_aei35"]
+[ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="5_dwmin"]
 [ext_resource type="Texture2D" uid="uid://be8kao32d16ao" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_x.tres" id="8_5pjl8"]
 
 [node name="ThrowInputHint" type="HBoxContainer" unique_id=1113313011]
 theme = ExtResource("1_hvmxk")
 
 [node name="ThrowHint" type="TextureRect" parent="." unique_id=2113188219]
+material = ExtResource("5_dwmin")
 layout_mode = 2
 size_flags_vertical = 8
 texture = ExtResource("4_81p17")
@@ -18,6 +20,7 @@ action_name = &"throw"
 devices = ExtResource("4_aei35")
 
 [node name="TextureRect2" type="TextureRect" parent="." unique_id=2115622263]
+material = ExtResource("5_dwmin")
 layout_mode = 2
 size_flags_vertical = 8
 texture = ExtResource("8_5pjl8")

--- a/scenes/ui_elements/input_hints/undo_input_hint.tscn
+++ b/scenes/ui_elements/input_hints/undo_input_hint.tscn
@@ -1,5 +1,6 @@
 [gd_scene format=3 uid="uid://bl3pt0n5r8tm5"]
 
+[ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="1_22y0p"]
 [ext_resource type="Texture2D" uid="uid://bry0q0k1nmmyh" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_z.tres" id="1_jkby0"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="2_ewe37"]
 [ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="3_xqpg3"]
@@ -11,6 +12,7 @@ custom_minimum_size = Vector2(64, 64)
 size_flags_horizontal = 0
 
 [node name="UndoInput" type="TextureRect" parent="." unique_id=2101272366]
+material = ExtResource("1_22y0p")
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 8


### PR DESCRIPTION
Use the same offset and color than the text label shadow.

## Mouse and keyboard atlas: Remove rectangle of solid pixels

Which actually don't contain any icons. Because when cropping slices of this
atlas right below this area, the drop shadow shader does drop a shadow for the
pixels above.
