### PR TITLE
Void particles outline

### DIFF
--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/dust-cloud.png
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/dust-cloud.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b8a01835dedcdc441a3ade4663745e3547744af0526aa0c98a7fd855d317c8b
-size 603
+oid sha256:2c1e1bb5298eaca60a0aaae074c09e23ea31e873e80e7299263d93833c3c6e96
+size 949

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/particles_canvasgroup_outline.gdshader
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/particles_canvasgroup_outline.gdshader
@@ -1,0 +1,32 @@
+/**
+ * Particles CanvasGroup outline effect.
+ *
+ * SPDX-FileCopyrightText: The Threadbare Authors
+ * SPDX-License-Identifier: MPL-2.0
+ */
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
+
+uniform vec4 outline_color : source_color = vec4(1.0);
+uniform float thickness : hint_range(0.0, 10.0) = 2.0;
+
+
+void fragment() {
+	vec4 color = textureLod(screen_texture, SCREEN_UV, 0.0);
+
+	vec4 outline = texture(screen_texture, SCREEN_UV - vec2(thickness, 0.0) * SCREEN_PIXEL_SIZE);
+	outline += texture(screen_texture, SCREEN_UV + vec2(thickness, 0.0) * SCREEN_PIXEL_SIZE);
+	outline += texture(screen_texture, SCREEN_UV - vec2(0.0, thickness) * SCREEN_PIXEL_SIZE);
+	outline += texture(screen_texture, SCREEN_UV + vec2(0.0, thickness) * SCREEN_PIXEL_SIZE);
+
+	outline.rgb = outline_color.rgb;
+	outline.a *= outline_color.a;
+
+	if (color.a > 0.0001) {
+		color.rgb /= color.a;
+	}
+
+	COLOR *= mix(outline, color, color.a);
+}

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/particles_canvasgroup_outline.gdshader.uid
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/particles_canvasgroup_outline.gdshader.uid
@@ -1,0 +1,1 @@
+uid://dvyec12fgsuta

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_particles.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_particles.tscn
@@ -4,7 +4,7 @@
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_31awk"]
 particles_animation = true
-particles_anim_h_frames = 5
+particles_anim_h_frames = 3
 particles_anim_v_frames = 1
 particles_anim_loop = false
 

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_particles.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_particles.tscn
@@ -8,23 +8,17 @@ particles_anim_h_frames = 3
 particles_anim_v_frames = 1
 particles_anim_loop = false
 
-[sub_resource type="Curve" id="Curve_8l6e1"]
-_data = [Vector2(0, 0.733414), 0.0, 0.0, 0, 0, Vector2(0.315152, 0.717732), 0.0, 0.0, 0, 0, Vector2(0.9, 0), 0.0, 0.0, 0, 0, Vector2(0.99697, 0), 0.0, 0.0, 0, 0]
-point_count = 4
-
-[sub_resource type="CurveTexture" id="CurveTexture_rrhr1"]
-curve = SubResource("Curve_8l6e1")
-
 [sub_resource type="Curve" id="Curve_304le"]
-_data = [Vector2(0, 1), 0.0, 1.4, 0, 0, Vector2(1, 0.407895), 0.0, 0.0, 0, 0]
+_data = [Vector2(0, 0.033189893), 0.0, 6.926748, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
 point_count = 2
+metadata/_snap_count = 2
 
 [sub_resource type="CurveTexture" id="CurveTexture_45we0"]
 curve = SubResource("Curve_304le")
 
 [sub_resource type="ParticleProcessMaterial" id="ParticleProcessMaterial_rrhr1"]
 particle_flag_disable_z = true
-emission_shape = 1
+emission_shape = 2
 emission_sphere_radius = 120.0
 angular_velocity_min = -10.0
 angular_velocity_max = 9.99998
@@ -34,7 +28,6 @@ gravity = Vector3(0, 0, 0)
 scale_min = 1.8
 scale_max = 2.0
 scale_curve = SubResource("CurveTexture_45we0")
-alpha_curve = SubResource("CurveTexture_rrhr1")
 anim_offset_max = 1.0
 
 [node name="GPUParticles2D" type="GPUParticles2D" unique_id=1339463382]

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.gd
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.gd
@@ -47,6 +47,7 @@ var _live_particles: int = 0
 @onready var path_walk_behavior: PathWalkBehavior = %PathWalkBehavior
 @onready var follow_walk_behavior: NavigationFollowWalkBehavior = %NavigationFollowWalkBehavior
 @onready var alert_animation: AnimationPlayer = %AlertAnimation
+@onready var particles_canvas_group: CanvasGroup = %ParticlesCanvasGroup
 
 
 func _set_idle_patrol_path(new_path: Path2D) -> void:
@@ -123,7 +124,7 @@ func _emit_particles() -> void:
 
 	var particles: GPUParticles2D = VOID_PARTICLES.instantiate()
 	particles.emitting = true
-	add_child(particles)
+	particles_canvas_group.add_child(particles)
 	_live_particles += 1
 
 	await particles.finished

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="Script" uid="uid://csev4hv57utxv" path="res://scenes/game_logic/walk_behaviors/character_speeds.gd" id="3_45we0"]
 [ext_resource type="AudioStream" uid="uid://dgpeb1dtmfqud" path="res://assets/third_party/sounds/characters/enemies/guard/AlertSound.ogg" id="5_2dnul"]
 [ext_resource type="Texture2D" uid="uid://c75ofhy3swhj3" path="res://scenes/game_elements/characters/enemies/guard/components/exclamation_mark.png" id="6_pumxu"]
+[ext_resource type="Shader" uid="uid://dvyec12fgsuta" path="res://scenes/quests/lore_quests/quest_002/1_void_runner/components/particles_canvasgroup_outline.gdshader" id="7_o4sxw"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_8g3pn"]
 size = Vector2(68, 20)
@@ -99,6 +100,11 @@ _data = {
 &"alert": SubResource("Animation_pumxu")
 }
 
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_gwqur"]
+shader = ExtResource("7_o4sxw")
+shader_parameter/outline_color = Color(1, 1, 1, 1)
+shader_parameter/thickness = 2.0
+
 [node name="VoidSpreadingEnemy" type="CharacterBody2D" unique_id=1007896559]
 collision_layer = 0
 collision_mask = 0
@@ -158,5 +164,9 @@ texture = ExtResource("6_pumxu")
 [node name="AlertAnimation" type="AnimationPlayer" parent="." unique_id=76419508]
 unique_name_in_owner = true
 libraries/ = SubResource("AnimationLibrary_gwqur")
+
+[node name="ParticlesCanvasGroup" type="CanvasGroup" parent="." unique_id=574273484]
+unique_name_in_owner = true
+material = SubResource("ShaderMaterial_gwqur")
 
 [connection signal="body_entered" from="PlayerCaptureArea" to="." method="_on_player_capture_area_body_entered"]


### PR DESCRIPTION
As delivered by PixelFrog, and composed the 3 of them in a row with GIMP. And change the amount of rows to 3, the new amount of particle variations.

## Void enemy: Add outline to all particles

To do it, because the GPUParticle2D needs a CanvasItemMaterial for the 3
variations, add a CanvasGroup and apply the outline shader to it.

Also, change the particles to:
- Animate the scale animation now starting at zero and ending at zero too.
- Do not animate the alpha of particles anymore.
- Emit from the sphere surface (not from sphere).

Resolve https://github.com/endlessm/threadbare/issues/1857