### PR TITLE
player: Hide PointLight2D node

### DIFF
--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -390,6 +390,7 @@ rotation = -1.5708
 shape = SubResource("CapsuleShape2D_3vyb7")
 
 [node name="PointLight2D" type="PointLight2D" parent="." unique_id=460659966 groups=["night-lights"]]
+visible = false
 visibility_layer = 2
 scale = Vector2(4, 3)
 enabled = false


### PR DESCRIPTION
player: Hide PointLight2D node

This node is 1024×768px. And although it is not visible in the editor in
scenes which instance the player scene, it is clickable, so trying to
click on other nodes that happen to be within the invisible 1024×768 box
around the player causes the player to be selected instead (if the
player is further down the scene tree). Very confusing until I figured
out why.

The ArtificialLightBehavior._ready() function updates the visibility of
the PointLight2D so hiding it in the player scene doesn't have any
impact on gameplay.
