### PR TITLE
Replace "Abandon Quest" with "Skip Tutorial" for tutorial quest

### DIFF
--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -9,6 +9,7 @@ extends CanvasLayer
 @onready var resume_button: Button = %ResumeButton
 @onready var options: Control = %Options
 @onready var abandon_quest_button: Button = %AbandonQuestButton
+@onready var skip_tutorial_button: Button = %SkipTutorialButton
 
 
 func _ready() -> void:
@@ -29,7 +30,15 @@ func toggle_pause() -> void:
 	Input.set_default_cursor_shape(Input.CURSOR_ARROW if new_state else Input.CURSOR_CROSS)
 
 	if new_state:
-		abandon_quest_button.visible = GameState.is_on_quest()
+		if not GameState.current_quest:
+			skip_tutorial_button.hide()
+			abandon_quest_button.hide()
+		elif GameState.current_quest.skippable:
+			skip_tutorial_button.show()
+			abandon_quest_button.hide()
+		else:
+			skip_tutorial_button.hide()
+			abandon_quest_button.show()
 		pause_menu.show()
 		resume_button.grab_focus()
 
@@ -37,6 +46,16 @@ func toggle_pause() -> void:
 func _on_abandon_quest_pressed() -> void:
 	toggle_pause()
 	GameState.abandon_quest()
+	SceneSwitcher.change_to_file_with_transition(
+		frays_end, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+	)
+
+
+func _on_skip_tutorial_pressed() -> void:
+	toggle_pause()
+	for ability: Enums.PlayerAbilities in GameState.current_quest.skip_abilities:
+		GameState.set_ability(ability, true)
+	GameState.mark_quest_completed()
 	SceneSwitcher.change_to_file_with_transition(
 		frays_end, ^"", Transition.Effect.FADE, Transition.Effect.FADE
 	)

--- a/scenes/globals/pause/pause_overlay.tscn
+++ b/scenes/globals/pause/pause_overlay.tscn
@@ -93,6 +93,13 @@ size_flags_horizontal = 4
 theme_type_variation = &"FlatButton"
 text = "Abandon Quest"
 
+[node name="SkipTutorialButton" type="Button" parent="TabContainer/PauseMenu/VBoxContainer" unique_id=979952363]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Skip Tutorial"
+
 [node name="OptionsButton" type="Button" parent="TabContainer/PauseMenu/VBoxContainer" unique_id=117724427]
 unique_name_in_owner = true
 layout_mode = 2
@@ -135,6 +142,7 @@ metadata/_tab_index = 2
 
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/ResumeButton" to="." method="_on_resume_button_pressed"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/AbandonQuestButton" to="." method="_on_abandon_quest_pressed"]
+[connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/SkipTutorialButton" to="." method="_on_skip_tutorial_pressed"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/OptionsButton" to="." method="_on_options_button_pressed"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/DebugButton" to="TabContainer/DebugSettings" method="show"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/TitleScreenButton" to="." method="_on_title_screen_button_pressed"]

--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -43,7 +43,19 @@ const FILENAME := "quest.tres"
 @export_range(0, 6, 1, "suffix:threads") var threads_to_collect: int = 3
 
 ## Whether this is a lore quest (part of the main storyline).
-@export var is_lore_quest: bool = false
+@export var is_lore_quest: bool = false:
+	set(new_value):
+		is_lore_quest = new_value
+		notify_property_list_changed()
+
+## Whether this quest is skippable (i.e. is the tutorial). Only supported for lore quests.
+@export var skippable: bool = false:
+	set(new_value):
+		skippable = new_value
+		notify_property_list_changed()
+
+## Which abilities to award if the quest is skipped
+@export var skip_abilities: Array[Enums.PlayerAbilities] = []
 
 @export_group("Animation")
 
@@ -83,6 +95,12 @@ func _validate_property(property: Dictionary) -> void:
 				property.hint_string = ",".join(sprite_frames.get_animation_names())
 			else:
 				property.usage |= PROPERTY_USAGE_READ_ONLY
+		"skippable":
+			if not is_lore_quest:
+				property.usage = PROPERTY_USAGE_NONE
+		"skip_abilities":
+			if not (is_lore_quest and skippable):
+				property.usage = PROPERTY_USAGE_NONE
 
 
 func _to_string() -> String:

--- a/scenes/quests/lore_quests/quest_000/quest.tres
+++ b/scenes/quests/lore_quests/quest_000/quest.tres
@@ -7,4 +7,6 @@ script = ExtResource("1_036vf")
 title = "Tutorial"
 first_scene = "uid://ck22vke6i1jyq"
 is_lore_quest = true
+skippable = true
+skip_abilities = Array[int]([1, 16])
 metadata/_custom_type_script = "uid://dts1hwdy3phin"


### PR DESCRIPTION
Unlike abandoning a quest, when we skip the tutorial we must grant the
player the abilities that they would have gained by completing the
tutorial.

This is a bit overengineered but it felt better to list the abilities in
the tutorial's quest.tres rather than to hardcode them in the pause
menu.

Resolves https://github.com/endlessm/threadbare/issues/2160
