### PR TITLE
Use left-stick not dpad in input hints

### DIFF
--- a/scenes/game_elements/props/hint/resources/playstation.tres
+++ b/scenes/game_elements/props/hint/resources/playstation.tres
@@ -2,19 +2,19 @@
 
 [ext_resource type="Texture2D" uid="uid://r06g4evpyol4" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_r_down.tres" id="1_jq3td"]
 [ext_resource type="Script" uid="uid://c0haweg5svww1" path="res://scenes/game_elements/props/hint/resources/joypadButtonTextures.gd" id="1_omqst"]
-[ext_resource type="Texture2D" uid="uid://c0begoe6gm8p4" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_dpad_down_outline.tres" id="1_v2nbk"]
 [ext_resource type="Texture2D" uid="uid://c6ekh500uvx62" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_r_left.tres" id="2_q4gi2"]
-[ext_resource type="Texture2D" uid="uid://6oqfr6cl2whc" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_dpad_left_outline.tres" id="2_w33ub"]
 [ext_resource type="Texture2D" uid="uid://m7gwu5x4b18n" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_r_right.tres" id="3_q0mrv"]
-[ext_resource type="Texture2D" uid="uid://brbujbm4a0thb" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_dpad_right_outline.tres" id="3_vbn2r"]
 [ext_resource type="Script" uid="uid://dhgm1dl0ohox5" path="res://scenes/game_elements/props/hint/resources/directional_input_textures.gd" id="4_cghs7"]
-[ext_resource type="Texture2D" uid="uid://bttej8tuucutx" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_dpad_none.tres" id="4_dgptc"]
 [ext_resource type="Texture2D" uid="uid://dspkrq3jsh26x" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_r.tres" id="5_jo447"]
-[ext_resource type="Texture2D" uid="uid://b5k4atvuhf6xp" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_dpad_up_outline.tres" id="5_oi6ek"]
 [ext_resource type="Texture2D" uid="uid://d2fkhf81x8u6d" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_r_up.tres" id="6_q44m7"]
 [ext_resource type="Texture2D" uid="uid://cjhshus64ytpq" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_cross_outline.tres" id="7_kkpem"]
-[ext_resource type="Texture2D" uid="uid://c8cfu7jw7nnbs" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_trigger_r1_outline.tres" id="13_rd2vx"]
-[ext_resource type="Texture2D" uid="uid://co0m0w1t84na8" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_trigger_l1_outline.tres" id="14_wqnvl"]
+[ext_resource type="Texture2D" uid="uid://gl2oph5lu3vf" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_l_down.tres" id="8_kkpem"]
+[ext_resource type="Texture2D" uid="uid://ebywfq5mjmva" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_l_left.tres" id="9_rd2vx"]
+[ext_resource type="Texture2D" uid="uid://crppxlnqwyodo" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_l_right.tres" id="10_wqnvl"]
+[ext_resource type="Texture2D" uid="uid://4mymfklw6qx0" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_l.tres" id="11_y4fr0"]
+[ext_resource type="Texture2D" uid="uid://dkx6qnqk6mpbq" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_stick_l_up.tres" id="12_8wf4n"]
+[ext_resource type="Texture2D" uid="uid://disylcjq2hh8n" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_trigger_r1_alternative_outline.tres" id="13_0nat0"]
+[ext_resource type="Texture2D" uid="uid://dfbsi8lsnorsm" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_trigger_l1_alternative_outline.tres" id="14_kkpem"]
 [ext_resource type="Texture2D" uid="uid://dltoru1w8ue7w" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_square_outline.tres" id="16_y4fr0"]
 [ext_resource type="Texture2D" uid="uid://d3rhotqp5gg7h" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_triangle_outline.tres" id="17_8wf4n"]
 [ext_resource type="Texture2D" uid="uid://7qdppn7p05b1" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/playstation/playstation_button_circle_outline.tres" id="18_0nat0"]
@@ -31,20 +31,20 @@ metadata/_custom_type_script = "uid://dhgm1dl0ohox5"
 
 [sub_resource type="Resource" id="Resource_kkpem"]
 script = ExtResource("4_cghs7")
-unpressed = ExtResource("4_dgptc")
-up = ExtResource("5_oi6ek")
-down = ExtResource("1_v2nbk")
-left = ExtResource("2_w33ub")
-right = ExtResource("3_vbn2r")
+unpressed = ExtResource("11_y4fr0")
+up = ExtResource("12_8wf4n")
+down = ExtResource("8_kkpem")
+left = ExtResource("9_rd2vx")
+right = ExtResource("10_wqnvl")
 metadata/_custom_type_script = "uid://dhgm1dl0ohox5"
 
 [resource]
 script = ExtResource("1_omqst")
 move = SubResource("Resource_kkpem")
 aim = SubResource("Resource_emb5i")
-running = ExtResource("14_wqnvl")
+running = ExtResource("14_kkpem")
 interact = ExtResource("7_kkpem")
-repel = ExtResource("13_rd2vx")
+repel = ExtResource("13_0nat0")
 throw = ExtResource("19_khsdn")
 sokoban_undo = ExtResource("18_0nat0")
 sokoban_reset = ExtResource("16_y4fr0")

--- a/scenes/game_elements/props/hint/resources/steamdeck.tres
+++ b/scenes/game_elements/props/hint/resources/steamdeck.tres
@@ -1,18 +1,18 @@
 [gd_resource type="Resource" script_class="JoypadButtonTextures" format=3 uid="uid://d61nj6kkhso8"]
 
 [ext_resource type="Script" uid="uid://c0haweg5svww1" path="res://scenes/game_elements/props/hint/resources/joypadButtonTextures.gd" id="1_aumst"]
-[ext_resource type="Texture2D" uid="uid://bpdpv7xmnjhm2" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_dpad_down_outline.tres" id="1_i4hh4"]
 [ext_resource type="Texture2D" uid="uid://bcc6utb34kw0q" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_r_down.tres" id="1_ujmsw"]
-[ext_resource type="Texture2D" uid="uid://b0geohrxwy1m2" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_dpad_left_outline.tres" id="2_fldbm"]
 [ext_resource type="Texture2D" uid="uid://bg811w2o1vd0b" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_r_left.tres" id="2_qp4xm"]
 [ext_resource type="Texture2D" uid="uid://c78lbnnvqj0iv" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_r_right.tres" id="3_00uab"]
-[ext_resource type="Texture2D" uid="uid://bt76s1b7qsiv5" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_dpad_right_outline.tres" id="3_bjijf"]
 [ext_resource type="Script" uid="uid://dhgm1dl0ohox5" path="res://scenes/game_elements/props/hint/resources/directional_input_textures.gd" id="4_3qkoy"]
-[ext_resource type="Texture2D" uid="uid://t1ybibt6skmn" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_dpad_none.tres" id="4_e280y"]
-[ext_resource type="Texture2D" uid="uid://bsxgtg4k28e61" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_dpad_up_outline.tres" id="5_1ctii"]
 [ext_resource type="Texture2D" uid="uid://b01qu3gqd3ctu" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_r.tres" id="5_3pkdl"]
 [ext_resource type="Texture2D" uid="uid://7ob6261vwokk" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_r_up.tres" id="6_poinc"]
 [ext_resource type="Texture2D" uid="uid://d223ajwmavjy8" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_a_outline.tres" id="7_wb6ss"]
+[ext_resource type="Texture2D" uid="uid://d0ctvjhjsnlh1" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_l_down.tres" id="8_wb6ss"]
+[ext_resource type="Texture2D" uid="uid://cr7apytq0ymgt" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_l_left.tres" id="9_enqan"]
+[ext_resource type="Texture2D" uid="uid://b31h2ox8rjo8v" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_l_right.tres" id="10_hxnoe"]
+[ext_resource type="Texture2D" uid="uid://cvwctj0rjjxof" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_l.tres" id="11_va1ks"]
+[ext_resource type="Texture2D" uid="uid://dgbafqal5huq6" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_stick_l_up.tres" id="12_vbsy4"]
 [ext_resource type="Texture2D" uid="uid://b7rygdiqbuuik" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_r1_outline.tres" id="13_enqan"]
 [ext_resource type="Texture2D" uid="uid://c2dy27tlmsigy" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_l1_outline.tres" id="14_hxnoe"]
 [ext_resource type="Texture2D" uid="uid://rrbih026ixaf" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/steam-deck/steamdeck_button_x_outline.tres" id="16_va1ks"]
@@ -31,11 +31,11 @@ metadata/_custom_type_script = "uid://dhgm1dl0ohox5"
 
 [sub_resource type="Resource" id="Resource_wb6ss"]
 script = ExtResource("4_3qkoy")
-unpressed = ExtResource("4_e280y")
-up = ExtResource("5_1ctii")
-down = ExtResource("1_i4hh4")
-left = ExtResource("2_fldbm")
-right = ExtResource("3_bjijf")
+unpressed = ExtResource("11_va1ks")
+up = ExtResource("12_vbsy4")
+down = ExtResource("8_wb6ss")
+left = ExtResource("9_enqan")
+right = ExtResource("10_hxnoe")
 metadata/_custom_type_script = "uid://dhgm1dl0ohox5"
 
 [resource]

--- a/scenes/game_elements/props/hint/resources/switch.tres
+++ b/scenes/game_elements/props/hint/resources/switch.tres
@@ -1,18 +1,18 @@
 [gd_resource type="Resource" script_class="JoypadButtonTextures" format=3 uid="uid://bgws80h0nu2qd"]
 
 [ext_resource type="Script" uid="uid://c0haweg5svww1" path="res://scenes/game_elements/props/hint/resources/joypadButtonTextures.gd" id="1_feeyu"]
-[ext_resource type="Texture2D" uid="uid://cnvwqloudh46v" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_dpad_down_outline.tres" id="1_h2gqh"]
 [ext_resource type="Texture2D" uid="uid://ctub2y7xvjfid" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_r_down.tres" id="1_jbq6g"]
-[ext_resource type="Texture2D" uid="uid://1am03g38qdqd" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_dpad_left_outline.tres" id="2_56m3b"]
 [ext_resource type="Texture2D" uid="uid://1sxmapx0bics" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_r_left.tres" id="2_xytoi"]
 [ext_resource type="Texture2D" uid="uid://bij5kl1836xxn" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_r_right.tres" id="3_3gm8v"]
-[ext_resource type="Texture2D" uid="uid://tgckmwsad3b4" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_dpad_right_outline.tres" id="3_c5mv4"]
 [ext_resource type="Script" uid="uid://dhgm1dl0ohox5" path="res://scenes/game_elements/props/hint/resources/directional_input_textures.gd" id="4_56m3b"]
-[ext_resource type="Texture2D" uid="uid://doch6hjoe0ra1" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_dpad_none.tres" id="4_haxeg"]
 [ext_resource type="Texture2D" uid="uid://bk5kfa10mmwlb" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_r.tres" id="5_3yvyh"]
-[ext_resource type="Texture2D" uid="uid://cbfuj8bkq6seu" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_dpad_up_outline.tres" id="5_mujfa"]
 [ext_resource type="Texture2D" uid="uid://cnnufqepabnm2" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_r_up.tres" id="6_0s2bm"]
 [ext_resource type="Texture2D" uid="uid://cw4b0a55wdndp" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_b_outline.tres" id="7_nqwbi"]
+[ext_resource type="Texture2D" uid="uid://bypxkvoeghm8j" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_l_down.tres" id="8_nqwbi"]
+[ext_resource type="Texture2D" uid="uid://bfioueerbov32" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_l_left.tres" id="9_x12kq"]
+[ext_resource type="Texture2D" uid="uid://cdfm1pjym87fy" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_l_right.tres" id="10_lbflk"]
+[ext_resource type="Texture2D" uid="uid://but0gw4abvvui" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_l.tres" id="11_yfmui"]
+[ext_resource type="Texture2D" uid="uid://v6fe5pgy2qxx" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_stick_l_up.tres" id="12_buody"]
 [ext_resource type="Texture2D" uid="uid://cren16wfvch5p" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_r_outline.tres" id="13_x12kq"]
 [ext_resource type="Texture2D" uid="uid://bfestobnif7sl" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_l_outline.tres" id="14_lbflk"]
 [ext_resource type="Texture2D" uid="uid://bkeqno6623dcj" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/nintendo_switch/switch_button_y_outline.tres" id="16_yfmui"]
@@ -31,11 +31,11 @@ metadata/_custom_type_script = "uid://dhgm1dl0ohox5"
 
 [sub_resource type="Resource" id="Resource_c5mv4"]
 script = ExtResource("4_56m3b")
-unpressed = ExtResource("4_haxeg")
-up = ExtResource("5_mujfa")
-down = ExtResource("1_h2gqh")
-left = ExtResource("2_56m3b")
-right = ExtResource("3_c5mv4")
+unpressed = ExtResource("11_yfmui")
+up = ExtResource("12_buody")
+down = ExtResource("8_nqwbi")
+left = ExtResource("9_x12kq")
+right = ExtResource("10_lbflk")
 
 [resource]
 script = ExtResource("1_feeyu")

--- a/scenes/game_elements/props/hint/resources/xbox.tres
+++ b/scenes/game_elements/props/hint/resources/xbox.tres
@@ -1,18 +1,18 @@
 [gd_resource type="Resource" script_class="JoypadButtonTextures" format=3 uid="uid://d3g6qqk3ecy56"]
 
-[ext_resource type="Texture2D" uid="uid://bhsb0vxietscg" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_dpad_down_outline.tres" id="1_4bq17"]
 [ext_resource type="Script" uid="uid://c0haweg5svww1" path="res://scenes/game_elements/props/hint/resources/joypadButtonTextures.gd" id="1_bisyu"]
 [ext_resource type="Texture2D" uid="uid://sspsfmxufg4i" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_r_down.tres" id="1_ltgn4"]
 [ext_resource type="Script" uid="uid://dhgm1dl0ohox5" path="res://scenes/game_elements/props/hint/resources/directional_input_textures.gd" id="1_qwpf8"]
 [ext_resource type="Texture2D" uid="uid://dbh5eeeifmwuj" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_r_left.tres" id="2_06knx"]
-[ext_resource type="Texture2D" uid="uid://bxq6kmvknhcde" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_dpad_left_outline.tres" id="2_qwpf8"]
-[ext_resource type="Texture2D" uid="uid://ybsaowrva1oi" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_dpad_right_outline.tres" id="3_nh82o"]
 [ext_resource type="Texture2D" uid="uid://cmvoq7oqljxyj" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_r_right.tres" id="3_tkqa6"]
-[ext_resource type="Texture2D" uid="uid://bmy2sq18qdmxv" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_dpad_none.tres" id="4_edsua"]
 [ext_resource type="Texture2D" uid="uid://ci1j0k8leqa3o" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_r.tres" id="5_g15f5"]
-[ext_resource type="Texture2D" uid="uid://bcwquyrkyor4j" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_dpad_up_outline.tres" id="5_kariy"]
 [ext_resource type="Texture2D" uid="uid://b45ky4pi3jety" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_r_up.tres" id="6_tv03i"]
 [ext_resource type="Texture2D" uid="uid://csbx81u4w37rp" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_a_outline.tres" id="7_tskv1"]
+[ext_resource type="Texture2D" uid="uid://chh0ch6umgbsa" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_l_down.tres" id="8_tskv1"]
+[ext_resource type="Texture2D" uid="uid://dtyo3cld4pnsc" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_l_left.tres" id="9_fvgft"]
+[ext_resource type="Texture2D" uid="uid://cdgpy54l4dskw" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_l_right.tres" id="10_pukp1"]
+[ext_resource type="Texture2D" uid="uid://bshnys13rm2be" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_l.tres" id="11_5vyqi"]
+[ext_resource type="Texture2D" uid="uid://10k63bbb464q" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_stick_l_up.tres" id="12_snkap"]
 [ext_resource type="Texture2D" uid="uid://m1fgpc7ru2b5" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_rb_outline.tres" id="13_fvgft"]
 [ext_resource type="Texture2D" uid="uid://dvkwc3688asij" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_lb_outline.tres" id="14_pukp1"]
 [ext_resource type="Texture2D" uid="uid://b8oqqn2re8bb4" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/xbox/xbox_button_x_outline.tres" id="16_5vyqi"]
@@ -31,11 +31,11 @@ metadata/_custom_type_script = "uid://dhgm1dl0ohox5"
 
 [sub_resource type="Resource" id="Resource_qwpf8"]
 script = ExtResource("1_qwpf8")
-unpressed = ExtResource("4_edsua")
-up = ExtResource("5_kariy")
-down = ExtResource("1_4bq17")
-left = ExtResource("2_qwpf8")
-right = ExtResource("3_nh82o")
+unpressed = ExtResource("11_5vyqi")
+up = ExtResource("12_snkap")
+down = ExtResource("8_tskv1")
+left = ExtResource("9_fvgft")
+right = ExtResource("10_pukp1")
 
 [resource]
 script = ExtResource("1_bisyu")


### PR DESCRIPTION
Also adjust the Playstation L1/R1 hints to the "alternative" version,
which looks a little truer to life.

The one downside of showing the left-stick rather than dpad is that the
stick works poorly in Sokoban
(https://github.com/endlessm/threadbare/issues/1186) but that is just a
bug to fix.
