### PR TITLE
Add & use bunny & capycorn decoration scenes

### DIFF
--- a/scenes/game_elements/props/decoration/bunny/bunny.tscn
+++ b/scenes/game_elements/props/decoration/bunny/bunny.tscn
@@ -1,0 +1,20 @@
+[gd_scene format=3 uid="uid://djmdhrse34vgq"]
+
+[ext_resource type="Script" uid="uid://jllabtpjc46i" path="res://scenes/game_elements/props/decoration/animated_decoration.gd" id="1_ubben"]
+[ext_resource type="SpriteFrames" uid="uid://dvgkthnd2qo4y" path="res://scenes/game_elements/characters/components/sprite_frames/bunny_pink.tres" id="2_poc3p"]
+[ext_resource type="Script" uid="uid://cms2wqtbxjl1h" path="res://scenes/game_logic/sprite_behaviors/random_frame_sprite_behavior.gd" id="3_ju0ou"]
+
+[node name="Bunny" type="Node2D" unique_id=398073521]
+script = ExtResource("1_ubben")
+sprite_frames = ExtResource("2_poc3p")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="." unique_id=1456881412]
+unique_name_in_owner = true
+sprite_frames = ExtResource("2_poc3p")
+animation = &"idle"
+offset = Vector2(2, -8)
+
+[node name="RandomFrameSpriteBehavior" type="Node2D" parent="AnimatedSprite2D" unique_id=63344388 node_paths=PackedStringArray("sprite")]
+script = ExtResource("3_ju0ou")
+sprite = NodePath("..")
+metadata/_custom_type_script = "uid://cms2wqtbxjl1h"

--- a/scenes/game_elements/props/decoration/capycorn/capycorn.tscn
+++ b/scenes/game_elements/props/decoration/capycorn/capycorn.tscn
@@ -1,0 +1,20 @@
+[gd_scene format=3 uid="uid://de2aceqqvj7dr"]
+
+[ext_resource type="Script" uid="uid://jllabtpjc46i" path="res://scenes/game_elements/props/decoration/animated_decoration.gd" id="1_o87cb"]
+[ext_resource type="Script" uid="uid://cms2wqtbxjl1h" path="res://scenes/game_logic/sprite_behaviors/random_frame_sprite_behavior.gd" id="2_71p58"]
+[ext_resource type="SpriteFrames" uid="uid://d0sqoy5x0tfum" path="res://scenes/game_elements/characters/components/sprite_frames/capycorn_light_brown.tres" id="2_o87cb"]
+
+[node name="Capycorn" type="Node2D" unique_id=398073521]
+script = ExtResource("1_o87cb")
+sprite_frames = ExtResource("2_o87cb")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="." unique_id=1456881412]
+unique_name_in_owner = true
+sprite_frames = ExtResource("2_o87cb")
+animation = &"idle"
+offset = Vector2(2, -14)
+
+[node name="RandomFrameSpriteBehavior" type="Node2D" parent="AnimatedSprite2D" unique_id=63344388 node_paths=PackedStringArray("sprite")]
+script = ExtResource("2_71p58")
+sprite = NodePath("..")
+metadata/_custom_type_script = "uid://cms2wqtbxjl1h"

--- a/scenes/quests/lore_quests/quest_002/4_closing_transition/closing_transition.tscn
+++ b/scenes/quests/lore_quests/quest_002/4_closing_transition/closing_transition.tscn
@@ -28,11 +28,10 @@
 [ext_resource type="PackedScene" uid="uid://crqjcicx0vdu" path="res://scenes/game_elements/props/decoration/bush/bush.tscn" id="21_y3es2"]
 [ext_resource type="SpriteFrames" uid="uid://bapks76u4hipj" path="res://scenes/game_elements/props/decoration/bush/components/bush_spriteframes_green_small.tres" id="22_2yns8"]
 [ext_resource type="SpriteFrames" uid="uid://we3g65bpiba4" path="res://scenes/game_elements/characters/components/sprite_frames/capycorn_purple.tres" id="23_2yns8"]
-[ext_resource type="Script" uid="uid://cms2wqtbxjl1h" path="res://scenes/game_logic/sprite_behaviors/random_frame_sprite_behavior.gd" id="24_5c5pq"]
-[ext_resource type="SpriteFrames" uid="uid://b0ba41utstkyk" path="res://scenes/game_elements/characters/components/sprite_frames/sheep.tres" id="24_43hb3"]
-[ext_resource type="SpriteFrames" uid="uid://dvgkthnd2qo4y" path="res://scenes/game_elements/characters/components/sprite_frames/bunny_pink.tres" id="25_16jok"]
-[ext_resource type="SpriteFrames" uid="uid://d0sqoy5x0tfum" path="res://scenes/game_elements/characters/components/sprite_frames/capycorn_light_brown.tres" id="25_c4nxe"]
+[ext_resource type="PackedScene" uid="uid://de2aceqqvj7dr" path="res://scenes/game_elements/props/decoration/capycorn/capycorn.tscn" id="25_5uden"]
 [ext_resource type="SpriteFrames" uid="uid://bq7qvwju02mtx" path="res://scenes/game_elements/characters/components/sprite_frames/bunny_brown.tres" id="25_o57pd"]
+[ext_resource type="PackedScene" uid="uid://djmdhrse34vgq" path="res://scenes/game_elements/props/decoration/bunny/bunny.tscn" id="26_sxtjt"]
+[ext_resource type="PackedScene" uid="uid://c4vbokn408f2c" path="res://scenes/game_elements/props/decoration/sheep/sheep.tscn" id="27_5uden"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_e2p5u"]
 size = Vector2(90, 86)
@@ -567,51 +566,21 @@ position = Vector2(971, 246)
 [node name="Animals" type="Node2D" parent="OnTheGround" unique_id=502881433]
 y_sort_enabled = true
 
-[node name="AnimatedSprite2D6" type="AnimatedSprite2D" parent="OnTheGround/Animals" unique_id=668378154]
-position = Vector2(936, 216)
-sprite_frames = ExtResource("25_c4nxe")
-animation = &"idle"
-autoplay = "idle"
-flip_h = true
+[node name="Capycorn" parent="OnTheGround/Animals" unique_id=398073521 instance=ExtResource("25_5uden")]
+position = Vector2(938, 230)
+rotation = 3.1415927
+scale = Vector2(1, -1)
 
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/Animals/AnimatedSprite2D6" unique_id=290214502 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
+[node name="Bunny" parent="OnTheGround/Animals" unique_id=20056684 instance=ExtResource("26_sxtjt")]
+position = Vector2(702, 264)
 
-[node name="AnimatedSprite2D7" type="AnimatedSprite2D" parent="OnTheGround/Animals" unique_id=404320947]
-position = Vector2(704, 256)
-sprite_frames = ExtResource("25_16jok")
-animation = &"idle"
-autoplay = "idle"
+[node name="Sheep" parent="OnTheGround/Animals" unique_id=629956524 instance=ExtResource("27_5uden")]
+position = Vector2(256, 470)
+rotation = 3.1415927
+scale = Vector2(1, -1)
 
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/Animals/AnimatedSprite2D7" unique_id=121310299 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
-
-[node name="AnimatedSprite2D8" type="AnimatedSprite2D" parent="OnTheGround/Animals" unique_id=2003367543]
-position = Vector2(256, 456)
-sprite_frames = ExtResource("24_43hb3")
-animation = &"idle"
-autoplay = "idle"
-flip_h = true
-
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/Animals/AnimatedSprite2D8" unique_id=380327128 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
-
-[node name="AnimatedSprite2D9" type="AnimatedSprite2D" parent="OnTheGround/Animals" unique_id=1044349689]
-position = Vector2(200, 488)
-sprite_frames = ExtResource("24_43hb3")
-animation = &"idle"
-autoplay = "idle"
-
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/Animals/AnimatedSprite2D9" unique_id=208961258 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
+[node name="Sheep2" parent="OnTheGround/Animals" unique_id=367348483 instance=ExtResource("27_5uden")]
+position = Vector2(200, 502)
 
 [node name="PropsHidden" type="Node2D" parent="OnTheGround" unique_id=576116804]
 modulate = Color(1, 1, 1, 0)
@@ -650,84 +619,32 @@ sprite_frames = ExtResource("22_2yns8")
 [node name="Bush11" parent="OnTheGround/PropsHidden" unique_id=2044569790 instance=ExtResource("21_y3es2")]
 position = Vector2(288, 671)
 
-[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="OnTheGround/PropsHidden" unique_id=735367860]
-position = Vector2(824, 688)
+[node name="Capycorn" parent="OnTheGround/PropsHidden" unique_id=2037025097 instance=ExtResource("25_5uden")]
+position = Vector2(822, 702)
 sprite_frames = ExtResource("23_2yns8")
-animation = &"idle"
-autoplay = "idle"
 
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/PropsHidden/AnimatedSprite2D" unique_id=1536633519 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
-
-[node name="AnimatedSprite2D5" type="AnimatedSprite2D" parent="OnTheGround/PropsHidden" unique_id=1738558372]
-position = Vector2(913, 687)
+[node name="Bunny" parent="OnTheGround/PropsHidden" unique_id=315805950 instance=ExtResource("26_sxtjt")]
+position = Vector2(915, 695)
+rotation = 3.1415927
+scale = Vector2(1, -1)
 sprite_frames = ExtResource("25_o57pd")
-animation = &"idle"
-autoplay = "idle"
-flip_h = true
 
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/PropsHidden/AnimatedSprite2D5" unique_id=158093101 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
+[node name="Sheep" parent="OnTheGround/PropsHidden" unique_id=2113680453 instance=ExtResource("27_5uden")]
+position = Vector2(1064, 622)
 
-[node name="AnimatedSprite2D2" type="AnimatedSprite2D" parent="OnTheGround/PropsHidden" unique_id=943134949]
-position = Vector2(1064, 608)
-sprite_frames = ExtResource("24_43hb3")
-animation = &"idle"
-autoplay = "idle"
+[node name="Sheep2" parent="OnTheGround/PropsHidden" unique_id=781437296 instance=ExtResource("27_5uden")]
+position = Vector2(1032, 646)
 
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/PropsHidden/AnimatedSprite2D2" unique_id=581013323 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
+[node name="Sheep3" parent="OnTheGround/PropsHidden" unique_id=836391868 instance=ExtResource("27_5uden")]
+position = Vector2(1152, 638)
+rotation = 3.1415927
+scale = Vector2(1, -1)
 
-[node name="AnimatedSprite2D3" type="AnimatedSprite2D" parent="OnTheGround/PropsHidden" unique_id=1740347437]
-position = Vector2(1032, 632)
-sprite_frames = ExtResource("24_43hb3")
-animation = &"idle"
-autoplay = "idle"
+[node name="Sheep4" parent="OnTheGround/PropsHidden" unique_id=307661823 instance=ExtResource("27_5uden")]
+position = Vector2(640, 758)
 
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/PropsHidden/AnimatedSprite2D3" unique_id=83849283 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
-
-[node name="AnimatedSprite2D4" type="AnimatedSprite2D" parent="OnTheGround/PropsHidden" unique_id=455756012]
-position = Vector2(1152, 624)
-sprite_frames = ExtResource("24_43hb3")
-animation = &"idle"
-autoplay = "idle"
-flip_h = true
-
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/PropsHidden/AnimatedSprite2D4" unique_id=1232128331 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
-
-[node name="AnimatedSprite2D6" type="AnimatedSprite2D" parent="OnTheGround/PropsHidden" unique_id=2130944958]
-position = Vector2(640, 744)
-sprite_frames = ExtResource("24_43hb3")
-animation = &"idle"
-autoplay = "idle"
-
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/PropsHidden/AnimatedSprite2D6" unique_id=353533677 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
-
-[node name="AnimatedSprite2D7" type="AnimatedSprite2D" parent="OnTheGround/PropsHidden" unique_id=1560640793]
-position = Vector2(456, 680)
-sprite_frames = ExtResource("24_43hb3")
-animation = &"idle"
-autoplay = "idle"
-
-[node name="RandomFrameSpriteBehavior" type="Node2D" parent="OnTheGround/PropsHidden/AnimatedSprite2D7" unique_id=156746617 node_paths=PackedStringArray("sprite")]
-script = ExtResource("24_5c5pq")
-sprite = NodePath("..")
-metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
+[node name="Sheep5" parent="OnTheGround/PropsHidden" unique_id=910301965 instance=ExtResource("27_5uden")]
+position = Vector2(456, 694)
 
 [node name="HUD" parent="." unique_id=1203174168 instance=ExtResource("3_nphcy")]
 


### PR DESCRIPTION
Like the sheep scene, these are just props with no physics.

Update the Void quest closing cutscene to use these and the sheep. There should be no visible change.