### PR TITLE
Fit logo animation sprite sheet under 4096×4096

### DIFF
--- a/assets/first_party/logo/threadbare-logo-animation.png
+++ b/assets/first_party/logo/threadbare-logo-animation.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2374de48d38f3124413c32a0149a1c0967ccc74c037229428de0051b76b9f3a
-size 388499
+oid sha256:175d99e6af50a08c6f3a8f2f86b0daa65820f1fa54411aa1ea79756a06b5bb61
+size 320486

--- a/scenes/menus/title/components/logos/threadbare_logo_animation.tres
+++ b/scenes/menus/title/components/logos/threadbare_logo_animation.tres
@@ -2,134 +2,134 @@
 
 [ext_resource type="Texture2D" uid="uid://djtwhx3j8di" path="res://assets/first_party/logo/threadbare-logo-animation.png" id="1_ko1xx"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_68a5i"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_2ucsa"]
 atlas = ExtResource("1_ko1xx")
 region = Rect2(0, 0, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_q86al"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_4brot"]
 atlas = ExtResource("1_ko1xx")
 region = Rect2(768, 0, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_l8ymi"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_ojjs6"]
 atlas = ExtResource("1_ko1xx")
 region = Rect2(1536, 0, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_xkbot"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_gfl5b"]
 atlas = ExtResource("1_ko1xx")
 region = Rect2(2304, 0, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_a00we"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_ouncg"]
 atlas = ExtResource("1_ko1xx")
 region = Rect2(3072, 0, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_shy76"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_ah2fs"]
 atlas = ExtResource("1_ko1xx")
 region = Rect2(3840, 0, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_46u6r"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_27w0d"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(4608, 0, 768, 768)
+region = Rect2(0, 768, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_02i4c"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_n1n0u"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(5376, 0, 768, 768)
+region = Rect2(768, 768, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_w4s5t"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_y0m1b"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(6144, 0, 768, 768)
+region = Rect2(1536, 768, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_7oqoo"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_3pvvb"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(6912, 0, 768, 768)
+region = Rect2(2304, 768, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_0wk6b"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_hsrta"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(7680, 0, 768, 768)
+region = Rect2(3072, 768, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_eneyu"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_ts3p4"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(8448, 0, 768, 768)
+region = Rect2(3840, 768, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_skuqp"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_7d7mc"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(9216, 0, 768, 768)
+region = Rect2(0, 1536, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_fo7js"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_lhhrp"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(9984, 0, 768, 768)
+region = Rect2(768, 1536, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_1mk7p"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_recp5"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(10752, 0, 768, 768)
+region = Rect2(1536, 1536, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_vwpf6"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_bmbvp"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(11520, 0, 768, 768)
+region = Rect2(2304, 1536, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_bneys"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_kvigo"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(12288, 0, 768, 768)
+region = Rect2(3072, 1536, 768, 768)
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_xa8xa"]
+[sub_resource type="AtlasTexture" id="AtlasTexture_3yfxn"]
 atlas = ExtResource("1_ko1xx")
-region = Rect2(13056, 0, 768, 768)
+region = Rect2(3840, 1536, 768, 768)
 
 [resource]
 animations = [{
 "frames": [{
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_68a5i")
+"texture": SubResource("AtlasTexture_2ucsa")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_q86al")
+"texture": SubResource("AtlasTexture_4brot")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_l8ymi")
+"texture": SubResource("AtlasTexture_ojjs6")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_xkbot")
+"texture": SubResource("AtlasTexture_gfl5b")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_a00we")
+"texture": SubResource("AtlasTexture_ouncg")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_shy76")
+"texture": SubResource("AtlasTexture_ah2fs")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_46u6r")
+"texture": SubResource("AtlasTexture_27w0d")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_02i4c")
+"texture": SubResource("AtlasTexture_n1n0u")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_w4s5t")
+"texture": SubResource("AtlasTexture_y0m1b")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_7oqoo")
+"texture": SubResource("AtlasTexture_3pvvb")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_0wk6b")
+"texture": SubResource("AtlasTexture_hsrta")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_eneyu")
+"texture": SubResource("AtlasTexture_ts3p4")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_skuqp")
+"texture": SubResource("AtlasTexture_7d7mc")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_fo7js")
+"texture": SubResource("AtlasTexture_lhhrp")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_1mk7p")
+"texture": SubResource("AtlasTexture_recp5")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_vwpf6")
+"texture": SubResource("AtlasTexture_bmbvp")
 }, {
 "duration": 1.0,
-"texture": SubResource("AtlasTexture_bneys")
+"texture": SubResource("AtlasTexture_kvigo")
 }, {
 "duration": 5.0,
-"texture": SubResource("AtlasTexture_xa8xa")
+"texture": SubResource("AtlasTexture_3yfxn")
 }],
 "loop": false,
 "name": &"appear",


### PR DESCRIPTION
Previously it was a single-row 18×1 sprite sheet, 13824x768, which did
not display correctly on mobile devices where textures must be at most
4096×4096.

Reëxport it with three rows of 6 frames. Update the SpriteFrames
resource.

Resolves https://github.com/endlessm/threadbare/issues/2195
