### PR TITLE
Elders: Handle empty quest directory gracefully

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -57,6 +57,10 @@ func _get_configuration_warnings() -> PackedStringArray:
 	return warnings
 
 
+func has_quests() -> bool:
+	return _storybook and _storybook.has_quests()
+
+
 ## Show a storybook to the player, and wait for them to select a story or close the book.
 func show_storybook() -> void:
 	if not _storybook:
@@ -81,6 +85,10 @@ func congratulate_player() -> void:
 func _before_dialogue() -> void:
 	if eternal_loom and eternal_loom.is_item_offering_possible():
 		talk_behavior.title = "go_to_loom"
+	elif not _storybook or not _storybook.has_quests():
+		talk_behavior.title = "no_quests"
+	else:
+		talk_behavior.title = ""
 
 
 func _on_interaction_ended() -> void:

--- a/scenes/game_elements/characters/npcs/elder/components/lore_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/elder/components/lore_quest_starter.dialogue
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
+
 LoreQuest Elder: [[Hi|Hello|Greetings]], StoryWeaver. We've been waiting for you. Our world is unraveling!
 LoreQuest Elder: We need you to recover the Sacred Elements: the threads of Memory, Imagination, and Spirit! Will you help us?
 do show_storybook()
@@ -34,4 +35,7 @@ LoreQuest Elder: Go on, StoryWeaver: take the threads to the Eternal Loom.
 ~ threads_incorporated
 LoreQuest Elder: Thank you, StoryWeaver! The fabric of the world slowly heals!
 LoreQuest Elder: Go forth: our world still needs your help.
+=> END
+~ no_quests
+LoreQuest Elder: I don't have any quests for you. Talk to my fellow Elders.
 => END

--- a/scenes/game_elements/characters/npcs/elder/components/story_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/elder/components/story_quest_starter.dialogue
@@ -40,3 +40,6 @@ StoryQuest Elder: Go on, StoryWeaver: take the threads to the Eternal Loom.
 StoryQuest Elder: Thank you, StoryWeaver! The fabric of the world slowly heals!
 StoryQuest Elder: Go forth: our world still needs your help.
 => END
+~ no_quests
+StoryQuest Elder: I don't have any quests for you. Talk to my fellow Elders.
+=> END

--- a/scenes/game_elements/characters/npcs/elder/components/template_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/elder/components/template_quest_starter.dialogue
@@ -18,3 +18,6 @@ Template Elder: Go on, StoryWeaver: take the threads to the Eternal Loom.
 Template Elder: Thank you, StoryWeaver! The fabric of the world slowly heals!
 Template Elder: Go forth: our world still needs your help.
 => END
+~ no_quests
+Template Elder: I don't have any quests for you. Talk to my fellow Elders.
+=> END

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -24,7 +24,8 @@ const QUEST_RESOURCE_NAME := "quest.tres"
 
 ## Directory to scan for quests. This directory should have 1 or more subdirectories, each of which
 ## have a [code]quest.tres[/code] file within.
-@export_dir var quest_directory: String = "res://scenes/quests/story_quests"
+@export_dir var quest_directory: String = "res://scenes/quests/story_quests":
+	set = _set_quest_directory
 
 var _quests: Array[Quest] = []
 var _current_spread_index: int = -1
@@ -49,10 +50,13 @@ func _enumerate_quests() -> Array[Quest]:
 	return quests
 
 
+func _set_quest_directory(new_value: String) -> void:
+	quest_directory = new_value
+	_quests = _enumerate_quests()
+
+
 func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
-
-	_quests = _enumerate_quests()
 
 	var previous_button: Button = null
 	for i in _quests.size():
@@ -186,3 +190,7 @@ func _on_back_button_pressed() -> void:
 
 func reset_focus() -> void:
 	_switch_to_page(0)
+
+
+func has_quests() -> bool:
+	return not _quests.is_empty()


### PR DESCRIPTION
Currently all three elders always have quests, but I am experimenting
with stripping out parts of the game to make the project smaller for a
game jam.

Make the elders check whether they actually have any quests for the
player, and say so if they don't.

