### PR TITLE
void_spreading_enemy: Reduce walking speed slightly

### DIFF
--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/void_spreading_enemy.tscn
@@ -21,7 +21,7 @@ metadata/_custom_type_script = "uid://csev4hv57utxv"
 
 [sub_resource type="Resource" id="Resource_pumxu"]
 script = ExtResource("3_45we0")
-walk_speed = 270.0
+walk_speed = 250.0
 metadata/_custom_type_script = "uid://csev4hv57utxv"
 
 [sub_resource type="Animation" id="Animation_o4sxw"]
@@ -137,6 +137,7 @@ unique_name_in_owner = true
 script = ExtResource("2_31awk")
 speeds = SubResource("Resource_pumxu")
 agent = NodePath("../NavigationAgent2D")
+running_distance = 256.0
 character = NodePath("..")
 metadata/_custom_type_script = "uid://r1kriwyodjlt"
 


### PR DESCRIPTION
The enemy runs when it is more than a certain distance from the player,
and walks when it is close. This makes it possible to outrun the enemy
without sprinting, and gives a sense of urgency while also giving you a
bit of grace if you need to pause and grapple.

Tweak both values slightly to make it a bit easier:

- Walk when the player is within 256 px (4 horizontal tiles), not 192 px
  (3 horizontal tiles);
- Reduce the walk speed, which was already a little lower than the
  player's.

This should make the initial void runner sequences much less
challenging, and the last void_grappling sequence a bit fairer.
