### PR TITLE
Fix running Storybook scene directly

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -24,7 +24,7 @@ const QUEST_RESOURCE_NAME := "quest.tres"
 
 ## Directory to scan for quests. This directory should have 1 or more subdirectories, each of which
 ## have a [code]quest.tres[/code] file within.
-@export_dir var quest_directory: String = "res://scenes/quests/story_quests":
+@export_dir var quest_directory: String:
 	set = _set_quest_directory
 
 var _quests: Array[Quest] = []

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -268,6 +268,7 @@ grow_vertical = 2
 size_flags_horizontal = 4
 theme = ExtResource("1_m2ghf")
 script = ExtResource("1_gw8hn")
+quest_directory = "res://scenes/quests/story_quests/"
 
 [node name="Panel" type="PanelContainer" parent="." unique_id=802233687]
 layout_mode = 1


### PR DESCRIPTION
Previously the default value for `Storybook.quest_directory` was
`res://scenes/quests/story_quests`.

In commit 226ff248b I moved the call to `_enumerate_quests()` (which
scans that folder to feast on the quests within) from `_ready()` (which
is only called once the node enters the tree – but the Elder wants to
check if there are any quests before showing the book) to the setter of
the `quest_directory` property.

This broke running the scene directly because of a GDScript quirk that
it's taken me nearly two years to notice: setters are not called for
default values!

The StoryQuest Elder only works because it explicitly re-sets the
`quest_directory` property rather than relying on the default.

Change the default value in the script to empty string. Set it to
`res://scenes/quests/story_quests` in storybook.tscn instead.
