### PR TITLE
ci: Update setup-uv to v8.1.0

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         cache-dependency-glob: ".github/workflows/checks.yaml"
     - name: Check REUSE compliance


### PR DESCRIPTION
Since v8.0.0, major version tags like v8 are no longer created.
Dependabot will not propose an upgrade from a vX tag to a vX.Y.Z tag so
this one-time manual change is needed.
