### PR TITLE
Player hook: Fix cancelling when player is on wall

### DIFF
--- a/scenes/game_elements/characters/player/components/player_hook.gd
+++ b/scenes/game_elements/characters/player/components/player_hook.gd
@@ -381,11 +381,12 @@ func _process_pulling(_delta: float) -> void:
 			return
 
 	character.velocity = player_distance.normalized() * pull_velocity * weight
-	var player_collided := character.move_and_slide()
+	if weight != 0:
+		var player_collided := character.move_and_slide()
 
-	if player_collided:
-		if character.get_real_velocity().length_squared() <= stuck_speed * stuck_speed:
-			stop_pulling()
+		if player_collided:
+			if character.get_real_velocity().length_squared() <= stuck_speed * stuck_speed:
+				stop_pulling()
 
 	if target is CharacterBody2D:
 		target.velocity = target_distance.normalized() * pull_velocity * (1 - weight)


### PR DESCRIPTION
Do not call move_and_slide() and do not check if it is stuck when the thing being hooked has zero weight, which means the thing is pulled toward the player and the player doesn't move.

There logic for "being stuck" should be revisited in the future. Because a character that isn't tring to move (has no velocity) shouldn't be considered stuck.

This fixes a bug in which trying to pick a button when the player is next to a wall, moves the button a little because the hooking is cancelled.

Fix https://github.com/endlessm/threadbare/issues/1807