### PR TITLE
sheep: Shake during interaction

### DIFF
--- a/scenes/game_elements/props/decoration/sheep/sheep.tscn
+++ b/scenes/game_elements/props/decoration/sheep/sheep.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="SpriteFrames" uid="uid://b0ba41utstkyk" path="res://scenes/game_elements/characters/components/sprite_frames/sheep.tres" id="1_hj6il"]
 [ext_resource type="Script" uid="uid://cms2wqtbxjl1h" path="res://scenes/game_logic/sprite_behaviors/random_frame_sprite_behavior.gd" id="2_jsyxc"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/interact_area.gd" id="3_5wm27"]
+[ext_resource type="Script" uid="uid://dunsvrhq42214" path="res://scenes/game_elements/fx/shaker/shaker.gd" id="3_pcfmk"]
 [ext_resource type="Script" uid="uid://djeshbrs3vwnb" path="res://scenes/game_elements/characters/npcs/cat/components/pet_interaction.gd" id="4_pcfmk"]
 [ext_resource type="AudioStream" uid="uid://dtf82j11434vb" path="res://scenes/game_elements/props/decoration/sheep/components/sheep_baa.wav" id="5_5wm27"]
 
@@ -33,6 +34,13 @@ script = ExtResource("2_jsyxc")
 sprite = NodePath("..")
 metadata/_custom_type_script = "uid://cms2wqtbxjl1h"
 
+[node name="Shaker" type="Node2D" parent="AnimatedSprite2D" unique_id=817185224 node_paths=PackedStringArray("target")]
+script = ExtResource("3_pcfmk")
+target = NodePath("..")
+shake_intensity = 5.0
+duration = 0.7
+metadata/_custom_type_script = "uid://dunsvrhq42214"
+
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=2118837157]
 rotation = -1.5708
 shape = SubResource("CapsuleShape2D_hj6il")
@@ -58,3 +66,5 @@ miaow_player = NodePath("AudioStreamPlayer2D")
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="PetInteraction" unique_id=1930789457]
 stream = SubResource("AudioStreamRandomizer_3vki4")
 bus = &"SFX"
+
+[connection signal="interaction_started" from="InteractArea" to="AnimatedSprite2D/Shaker" method="shake" unbinds=2]


### PR DESCRIPTION
Make the sheep wobble a little when you interact with it, as a visual counterpart to the “baa” sound. Particularly if the game is muted, this makes annoying the sheep have a slightly more tangible effect.

Helps #2220 