### PR TITLE
RandomTextureSpriteBehavior: Get path from AtlasTexture.atlas

### DIFF
--- a/scenes/game_logic/sprite_behaviors/random_texture_sprite_behavior.gd
+++ b/scenes/game_logic/sprite_behaviors/random_texture_sprite_behavior.gd
@@ -27,8 +27,16 @@ func _get_offset_from_spriteframes_filename(new_sprite_frames: SpriteFrames) -> 
 	if sprite_frame_filename:
 		filename = sprite_frame_filename
 	elif "idle" in new_sprite_frames.get_animation_names():
-		filename = new_sprite_frames.get_frame_texture(&"idle", 0).resource_path
+		var idle_texture := new_sprite_frames.get_frame_texture(&"idle", 0)
+		if idle_texture is AtlasTexture:
+			idle_texture = idle_texture.atlas
+		filename = idle_texture.resource_path.get_file()
+
 	var offset := Vector2.ZERO
+	if not filename:
+		push_warning("%s: Can't find filename for %s" % [get_path(), new_sprite_frames])
+		return offset
+
 	# TODO: Use regular expressions.
 	for part: String in filename.split("."):
 		var data := part.split("_")


### PR DESCRIPTION
RandomTextureSpriteBehavior: Get path from AtlasTexture.atlas

This script works by selecting one of an array of SpriteFrames resources
at random, then offsetting the sprite based on information encoded in
the filename. For example, the names of
townie-body_003.dx_-4.dy_-16.tres and its underlying texture atlas
townie-idle-body_003.dx_-4.dy_-16.png encode that the sprite should be
offset by Vector2(-4, -16). This allows different randomly-generated
townies to be different sizes.

We have some code that tries to find the path to the chosen SpriteFrames
resource, or failing that the path of the underlying texture. In practice,
`new_sprite_frames.resource_path.get_file()` is always `""` (for unknown
reasons) so we always use the second path, looking at the path of the
first frame of the idle texture.

Previously this was:

    filename = new_sprite_frames.get_frame_texture(&"idle", 0).resource_path

But the behaviour differs between running the game in the editor and in
release builds. In the editor, this gives
`res://scenes/game_elements/characters/components/sprite_frames/townie-legs_002.dy_-6.tres::AtlasTexture_s8pun`,
while in the exported game we get
`res://scenes/game_elements/characters/npcs/townie.tscn::AtlasTexture_s8pun`.

I can't quite explain this but my guess is that the SpriteFrames in
`townie-legs_002.dy_-1.tres` is getting inlined into the exported binary
`townie.scn`. But if we walk one step deeper, resolving the AtlasTexture
to its underlying Texture2D, whose resource_path is
`res://scenes/game_elements/characters/npcs/components/townie-idle-legs_002.dy_-6.png`
as hoped.

Also add a missing .get_file() to convert from the full path to the
filename in this code path.

Resolves https://github.com/endlessm/threadbare/issues/2216
