### PR TITLE
ci: Export with Godot 4.6.3

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Export web build
         uses: endlessm/godot-export-action@v2
         with:
-          godot_version: "4.6.2"
+          godot_version: "4.6.3"
           export_preset: "Web"
 
       - name: Upload web artifact


### PR DESCRIPTION
ci: Export with Godot 4.6.3

https://godotengine.org/article/maintenance-release-godot-4-6-3/

Nothing particularly relevant but you never know which bug fix will matter!
