### PR TITLE
Refactor game state

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/lore_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/elder/components/lore_quest_starter.dialogue
@@ -9,7 +9,7 @@ if chosen_quest == null:
 	% LoreQuest Elder: Please stay. Our world will perish without your help!
 	% LoreQuest Elder: I hope to see you again. We really need you!
 	% LoreQuest Elder: The people of Threadbare are counting on you. I hope you change your mind!
-elif chosen_quest.resource_path in GameState.completed_quests:
+elif chosen_quest in GameState.global.completed_quests:
 	# Custom dialogues for completed quests
 	if chosen_quest.resource_path == "res://scenes/quests/lore_quests/quest_001/quest.tres":
 		% LoreQuest Elder: Ah, the Song Sanctuary sings once more... a melody you already helped restore.

--- a/scenes/game_elements/characters/npcs/elder/components/story_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/elder/components/story_quest_starter.dialogue
@@ -8,7 +8,7 @@ if chosen_quest == null:
 	% StoryQuest Elder: Please stay. Our world will perish without your help!
 	% StoryQuest Elder: I hope to see you again. We really need you!
 	% StoryQuest Elder: The people of Threadbare are counting on you. I hope you change your mind!
-elif chosen_quest.resource_path in GameState.completed_quests:
+elif chosen_quest in GameState.global.completed_quests:
 	# Custom dialogues for completed quests
 	if chosen_quest.resource_path == "res://scenes/quests/story_quests/el_juguete_perdido/quest.tres":
 		% StoryQuest Elder: You have rescued Apollo before… and thanks to you he returned safe and sound.

--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -74,7 +74,7 @@ var _initial_speeds: CharacterSpeeds
 func _set_mode(new_mode: Mode) -> void:
 	var previous_mode: Mode = mode
 	mode = new_mode
-	if not is_node_ready():
+	if Engine.is_editor_hint() or not is_node_ready():
 		return
 	match mode:
 		Mode.USER_CONTROLLED:
@@ -144,7 +144,18 @@ func _ready() -> void:
 	_set_speeds(speeds)
 	_set_mode(mode)
 	_set_sprite_frames(sprite_frames)
-	GameState.abilities_changed.connect(_on_abilities_changed)
+
+	if Engine.is_editor_hint():
+		return
+
+	GameState.player.abilities_changed.connect(_on_abilities_changed)
+	GameState.player_changed.connect(_on_player_state_changed)
+
+
+func _on_player_state_changed(old: PlayerState, new: PlayerState) -> void:
+	old.abilities_changed.disconnect(_on_abilities_changed)
+	new.abilities_changed.connect(_on_abilities_changed)
+	_on_abilities_changed()
 
 
 func _set_speeds(new_speeds: CharacterSpeeds) -> void:
@@ -195,8 +206,7 @@ func defeat(falling: bool = false) -> void:
 	# Stop moving the player.
 	velocity = Vector2.ZERO
 
-	# Decrement lives and save the new count
-	GameState.decrement_lives()
+	GameState.player.decrement_lives()
 
 	if falling:
 		var tween := create_tween()
@@ -205,7 +215,7 @@ func defeat(falling: bool = false) -> void:
 	await get_tree().create_timer(2.0).timeout
 
 	# Check if player has lives remaining
-	if GameState.current_lives > 0:
+	if GameState.player.lives > 0:
 		# Still have lives - reload current scene/checkpoint
 		SceneSwitcher.reload_with_transition()
 	else:
@@ -222,12 +232,14 @@ func return_control(_controlled_by: Node) -> void:
 
 
 func _toggle_abilities() -> void:
-	var can_repel := GameState.has_ability(Enums.PlayerAbilities.ABILITY_A)
-	var can_grapple := GameState.has_ability(Enums.PlayerAbilities.ABILITY_B)
+	var can_repel := GameState.player.has_ability(Enums.PlayerAbilities.ABILITY_A)
+	var can_grapple := GameState.player.has_ability(Enums.PlayerAbilities.ABILITY_B)
 	_toggle_player_behavior(player_repel, can_repel)
 	_toggle_player_behavior(player_hook, can_grapple)
 	if can_grapple:
-		var has_longer_hook := GameState.has_ability(Enums.PlayerAbilities.ABILITY_B_MODIFIER_1)
+		var has_longer_hook := GameState.player.has_ability(
+			Enums.PlayerAbilities.ABILITY_B_MODIFIER_1
+		)
 		player_hook.string_throw_length = 400.0 if has_longer_hook else 200.0
 		player_hook.string_max_length = 450.0 if has_longer_hook else 250.0
 
@@ -237,19 +249,20 @@ func _on_abilities_changed() -> void:
 		_toggle_abilities()
 
 
-## Handles game over logic: restarts from the beginning of the current challenge
-## with lives reset to 3.
+## Handles game over logic: restarts from the beginning of the current challenge,
+## with lives reset.
 func _handle_game_over() -> void:
-	# Reset lives to 3
-	GameState.reset_lives()
+	GameState.player.reset_lives()
 
 	# Get the start of the current challenge
-	var challenge_start_scene: String = GameState.get_challenge_start_scene()
+	var challenge_start_scene: String
+	if GameState.quest:
+		challenge_start_scene = GameState.quest.challenge_start_scene
 
 	if challenge_start_scene.is_empty():
 		# Fallback: reload current scene if no challenge start is defined
 		# Clear spawn point to start from the beginning of the current scene
-		GameState.set_current_spawn_point(^"")
+		GameState.scene.spawn_point = ^""
 		SceneSwitcher.reload_with_transition()
 	else:
 		# Restart from the challenge start scene

--- a/scenes/game_elements/fx/time_and_weather/components/time_and_weather.gd
+++ b/scenes/game_elements/fx/time_and_weather/components/time_and_weather.gd
@@ -130,7 +130,7 @@ func set_time(new_time: float) -> void:
 
 	# Change game state darkness so artificial lights can turn on/off.
 	var lights_on := new_time < 5 or new_time >= 19
-	GameState.change_lights(lights_on, true)
+	GameState.scene.set_lights_on(lights_on, true)
 	_schedule_timer(lights_off_timer, 5, new_time)
 	_schedule_timer(lights_on_timer, 19, new_time)
 
@@ -182,12 +182,12 @@ func _ready() -> void:
 
 
 func _on_lights_on_timer_timeout() -> void:
-	GameState.change_lights(true)
+	GameState.scene.set_lights_on(true)
 	_schedule_in_one_day(lights_on_timer)
 
 
 func _on_lights_off_timer_timeout() -> void:
-	GameState.change_lights(false)
+	GameState.scene.set_lights_on(false)
 	_schedule_in_one_day(lights_off_timer)
 
 

--- a/scenes/game_elements/props/checkpoint/components/checkpoint.gd
+++ b/scenes/game_elements/props/checkpoint/components/checkpoint.gd
@@ -72,7 +72,9 @@ func _ready() -> void:
 
 ## Makes this the active checkpoint.
 func activate() -> void:
-	GameState.set_current_spawn_point(owner.get_path_to(spawn_point))
+	GameState.scene.spawn_point = owner.get_path_to(spawn_point)
+	GameState.save()
+
 	if sprite.visible:
 		return
 

--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -93,7 +93,7 @@ func _on_interacted(player: Player, _from_right: bool) -> void:
 	animation_player.play("collected")
 	await animation_player.animation_finished
 
-	GameState.add_collected_item(item)
+	GameState.global.add_collected_item(item)
 
 	if collected_dialogue:
 		DialogueManager.show_dialogue_balloon(collected_dialogue, dialogue_title, [self, player])
@@ -103,7 +103,10 @@ func _on_interacted(player: Player, _from_right: bool) -> void:
 	queue_free()
 
 	if next_scene:
-		GameState.set_challenge_start_scene(next_scene)
+		if GameState.quest:
+			GameState.quest.challenge_start_scene = next_scene
+		else:
+			push_warning("Collectible collected while not on a quest")
 		switch()
 
 

--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
@@ -27,22 +27,16 @@ func _ready() -> void:
 	talk_behavior.title = "have_threads" if _have_threads else "no_threads"
 	interact_area.interaction_ended.connect(self._on_interaction_ended)
 
-	if GameState.incorporating_threads:
+	if GameState.quest and GameState.quest.incorporating_threads:
 		if Transitions.is_running():
 			await Transitions.finished
 
-		var elder: Elder
-		if GameState.current_quest:
-			elder = _find_elder(GameState.current_quest)
-		else:
-			push_warning("incorporating_threads was set, but current_quest was null")
-			if elders:
-				# Pick any elder.
-				elder = elders.pick_random()
+		var elder: Elder = _find_elder(GameState.quest.quest)
 		if elder:
 			await elder.congratulate_player()
+		else:
+			push_warning("Could not find elder for %s" % [GameState.quest.quest.resource_path])
 
-		GameState.set_incorporating_threads(false)
 		GameState.mark_quest_completed()
 
 
@@ -59,7 +53,7 @@ func _on_interaction_ended() -> void:
 		if not ProjectSettings.get_setting(ThreadbareProjectSettings.SKIP_SOKOBANS):
 			# Hide interact label during scene transition
 			interact_area.disabled = true
-			GameState.set_incorporating_threads(true)
+			GameState.quest.incorporating_threads = true
 			SceneSwitcher.change_to_file_with_transition(SOKOBANS.pick_random())
 		else:
 			GameState.mark_quest_completed()
@@ -68,12 +62,12 @@ func _on_interaction_ended() -> void:
 func on_offering_succeeded() -> void:
 	loom_offering_animation_player.play(&"loom_offering")
 	await loom_offering_animation_player.animation_finished
-	GameState.clear_inventory()
+	GameState.global.clear_inventory()
 
 
 func is_item_offering_possible() -> bool:
 	return (
-		GameState.current_quest
-		and GameState.current_quest.threads_to_collect > 0
-		and GameState.items_collected().size() >= GameState.current_quest.threads_to_collect
+		GameState.quest
+		and GameState.quest.quest.threads_to_collect > 0
+		and GameState.global.inventory.size() >= GameState.quest.quest.threads_to_collect
 	)

--- a/scenes/game_elements/props/powerup/components/powerup.gd
+++ b/scenes/game_elements/props/powerup/components/powerup.gd
@@ -66,7 +66,7 @@ func _ready() -> void:
 	_set_highlight_color(highlight_color)
 	if Engine.is_editor_hint():
 		return
-	GameState.abilities_changed.connect(_on_abilities_changed)
+	GameState.player.abilities_changed.connect(_on_abilities_changed)
 	_on_abilities_changed()
 
 
@@ -79,7 +79,7 @@ func _notification(what: int) -> void:
 
 
 func _on_abilities_changed() -> void:
-	var has_ability := GameState.has_ability(ability)
+	var has_ability := GameState.player.has_ability(ability)
 	ground_collision.disabled = has_ability
 	interact_collision.disabled = has_ability
 	hookable_collision.disabled = has_ability
@@ -104,7 +104,7 @@ func _on_interact_area_interaction_started(
 		DialogueManager.show_dialogue_balloon(dialogue, "", [self])
 		await DialogueManager.dialogue_ended
 	source.end_interaction()
-	GameState.set_ability(ability, true)
+	GameState.player.set_ability(ability, true)
 	collected.emit()
 
 

--- a/scenes/game_elements/props/spawn_point/components/spawn_point.gd
+++ b/scenes/game_elements/props/spawn_point/components/spawn_point.gd
@@ -21,7 +21,7 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
-	if GameState.current_spawn_point == get_tree().current_scene.get_path_to(self):
+	if GameState.scene.spawn_point == get_tree().current_scene.get_path_to(self):
 		move_player_to_self_position()
 
 

--- a/scenes/game_logic/light2d_behaviors/artificial_light_behavior.gd
+++ b/scenes/game_logic/light2d_behaviors/artificial_light_behavior.gd
@@ -48,9 +48,9 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 	initial_energy = light.energy
-	light.visible = GameState.lights_on
-	light.enabled = GameState.lights_on
-	GameState.lights_changed.connect(_on_lights_changed)
+	light.visible = GameState.scene.lights_on
+	light.enabled = GameState.scene.lights_on
+	GameState.scene.lights_changed.connect(_on_lights_changed)
 
 
 func _on_lights_changed(lights_on: bool, immediate: bool) -> void:

--- a/scenes/game_logic/player_mode.gd
+++ b/scenes/game_logic/player_mode.gd
@@ -25,12 +25,13 @@ enum Mode {
 
 func set_mode(new_mode: Mode) -> void:
 	mode = new_mode
-	GameState.clear_abilities()
 	match mode:
 		Mode.FIGHTING:
-			GameState.set_ability(Enums.PlayerAbilities.ABILITY_A, true)
+			GameState.player.abilities = Enums.PlayerAbilities.ABILITY_A
 		Mode.HOOKING:
-			GameState.set_ability(Enums.PlayerAbilities.ABILITY_B, true)
+			GameState.player.abilities = Enums.PlayerAbilities.ABILITY_B
+		_:
+			GameState.player.abilities = 0
 
 
 func _ready() -> void:

--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -1,50 +1,13 @@
-# gdlint: disable=max-public-methods
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
-@tool
 extends Node
 
-## Emitted when a new item is collected, even if it wasn't added to the
-## inventory due to it being already there.
-signal item_collected(item: InventoryItem)
+## Emitted when [member player] changes to a new [PlayerState] object, due to a
+## quest starting or ending. This is used by the [Player] scene to rebind to
+## signals like [signal PlayerState.abilities_changed].
+signal player_changed(old: PlayerState, new: PlayerState)
 
-## Emitted when a item is consumed, causing it to be removed from the
-## [member inventory].
-signal item_consumed(item: InventoryItem)
-
-## Emitted whenever the items in the inventory change, either by collecting
-## or consuming an item.
-signal collected_items_changed(updated_items: Array[InventoryItem])
-
-## Emitted when the player's lives change.
-signal lives_changed(new_lives: int)
-
-## Emitted when it becomes too dark that artificial lights can turn on, or
-## when darkness goes away so artificial lights should turn off.
-signal lights_changed(lights_on: bool, immediate: bool)
-
-## Emitted when a quest is added or removed from [member completed_quests].
-signal completed_quests_changed
-
-## Emitted when lore or StoryQuest player abilities change.
-signal abilities_changed
-
-const GAME_STATE_PATH := "user://game_state.cfg"
-const INVENTORY_SECTION := "inventory"
-const INVENTORY_ITEMS_KEY := "items_collected"
-const QUEST_SECTION := "quest"
-const QUEST_PATH_KEY := "resource_path"
-const QUEST_CHALLENGE_START_KEY := "challenge_start_scene"
-const QUEST_PLAYER_ABILITIES_KEY := "quest_player_abilities"
-const GLOBAL_SECTION := "global"
-const GLOBAL_INCORPORATING_THREADS_KEY := "incorporating_threads"
-const COMPLETED_QUESTS_KEY := "completed_quests"
-const CURRENTSCENE_KEY := "current_scene"
-const SPAWNPOINT_KEY := "current_spawn_point"
-const GAME_PLAYER_ABILITIES_KEY := "game_player_abilities"
-const LIVES_KEY := "current_lives"
-const MAX_LIVES := 2 ** 53
-const DEBUG_LIVES := false
+const SAVE_PATH := "user://saved_game.tres"
 
 ## The player abilities to have from the beginning
 ## when not running the game from the main scene.
@@ -56,74 +19,58 @@ const DEBUG_PLAYER_ABILITIES := [
 ## Scenes to skip from saving.
 const TRANSIENT_SCENES := [
 	"res://scenes/menus/title/title_screen.tscn",
-	"res://scenes/menus/intro/intro.tscn",
 ]
-
-## Global inventory, used to track the items the player obtains and that
-## can be added to the loom.
-@export var inventory: Array[InventoryItem] = []
-@export var current_spawn_point: NodePath
-
-## Player abilities for the whole game.
-## [br][br]
-## These are flags that enable systems or mechanics for the player progression
-## during the entire game.[br]
-## When involved in a quest, [member quest_player_abilities] are used instead.
-## After completing a lore quest, [member quest_player_abilities] are copied to this and persisted.
-@export var game_player_abilities: int = 0:
-	set = _set_game_player_abilities
-
-## Player abilities for the current quest.
-## [br][br]
-## These are flags that enable systems or mechanics for the quest progression[br]
-## When involved in a lore quest, [member game_player_abilities] are copied to this.
-## When involved in a StoryQuest, this starts in zero (without abilities).
-@export var quest_player_abilities: int = 0:
-	set = _set_quest_player_abilities
-
-## Current number of lives the player has.
-var current_lives: int = MAX_LIVES
-
-## Current state of artificial lights.
-var lights_on: bool
-
-## Set when the loom transports the player to a trio of Sokoban puzzles, so that
-## when the player returns to Fray's End the loom can trigger a brief cutscene.
-var incorporating_threads: bool = false
-
-## Set when any introductory dialogue has been played for the current scene.
-## Cleared when the scene changes.
-var intro_dialogue_shown: bool = false
-
-## The paths to the [Quest]s that the player has completed, in the order that they were completed.
-var completed_quests: Array[String] = []
-
-## The quest that the player is currently playing, or [code]null[/code] if they
-## are not playing a quest. Update this with [method start_quest], [method
-## mark_quest_completed] and [method abandon_quest].
-var current_quest: Quest
 
 ## The progress is persisted only if the game is run normally from the main scene.
 ## Otherwise, it means we are playing a specific scene: the current scene from the editor or
 ## with a direct URL hash to a scene in the web build. In the latter cases, this variable is false.
 var persist_progress: bool
 
-var _state := ConfigFile.new()
+## Game-wide state.
+var global: GlobalState:
+	get():
+		return _saved_game.global if _saved_game else null
+	set(new_value):
+		push_error("Do not set GameState.global")
 
+## State concerning the current quest, or [code]null[/code] if there is no current quest.
+var quest: QuestState:
+	get():
+		return _saved_game.quest if _saved_game else null
+	set(new_value):
+		var old_player_state := player
+		_saved_game.quest = new_value
+		player_changed.emit(old_player_state, player)
 
-func _validate_property(property: Dictionary) -> void:
-	match property["name"]:
-		# Treat the player abilities as bit flags.
-		# The @export_flags would be ideal but it expects constant
-		# strings, and we want to use the PlayerAbilities enum keys
-		# as hint strings.
-		# This also requires this script to be a @tool.
-		"lore_player_abilities", "storyquest_player_abilities":
-			property.hint = PROPERTY_HINT_FLAGS
-			property.hint_string = ",".join(Enums.PlayerAbilities.keys())
+## State concerning the current scene, or [code]null[/code] if there is no current scene
+var scene: PerSceneState:
+	get():
+		return _saved_game.scene if _saved_game else null
+	set(new_value):
+		_saved_game.scene = new_value
+
+## If the player is on a quest, the [member QuestState.player] of [member
+## quest]. Otherwise, the [member GlobalState.player] of [member global]. Use
+## this rather than referring directly to those.
+var player: PlayerState:
+	get():
+		return quest.player if quest else global.player
+	set(new_value):
+		push_error("Do not set GameState.player")
+
+var _saved_game: SavedGame
 
 
 func _ready() -> void:
+	if Engine.is_editor_hint():
+		return
+
+	if ResourceLoader.exists(SAVE_PATH):
+		_saved_game = ResourceLoader.load(SAVE_PATH, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
+
+	if not _saved_game:
+		_saved_game = SavedGame.new()
+
 	var current_scene := get_tree().current_scene
 	var initial_scene_uid := (
 		ResourceLoader.get_resource_uid(current_scene.scene_file_path) if current_scene else -1
@@ -137,45 +84,28 @@ func _ready() -> void:
 			guess_quest(current_scene.scene_file_path)
 		# Grant all debug player abilities:
 		for ability: Enums.PlayerAbilities in DEBUG_PLAYER_ABILITIES:
-			set_ability(ability, true)
+			player.set_ability(ability, true)
 		return
 
-	var err := _state.load(GAME_STATE_PATH)
-	if err != OK and err != ERR_FILE_NOT_FOUND:
-		push_error("Failed to load %s: %s" % [GAME_STATE_PATH, err])
 
-	if DEBUG_LIVES:
-		prints("[LIVES DEBUG] GameState initialized with", current_lives, "lives")
+## Sets [member quest], sets up a new [PlayerState] if necessary, and clears the
+## inventory. Note that this does not actually switch to the first scene of [param
+## new_quest].
+func start_quest(new_quest: Quest) -> void:
+	# TODO: this suggests that the inventory should be part of QuestState
+	global.clear_inventory()
 
-
-## Set the [member incorporating_threads] flag.
-func set_incorporating_threads(new_incorporating_threads: bool) -> void:
-	incorporating_threads = new_incorporating_threads
-	_state.set_value(GLOBAL_SECTION, GLOBAL_INCORPORATING_THREADS_KEY, incorporating_threads)
-	_save()
-
-
-## Set [member current_quest] and clear the [member inventory].
-## Also resets lives to maximum when starting a quest.
-func start_quest(quest: Quest) -> void:
-	_do_clear_inventory()
-	_update_inventory_state()
-	current_quest = quest
-	_state.set_value(QUEST_SECTION, QUEST_PATH_KEY, quest.resource_path)
-	_do_set_scene(quest.first_scene, ^"")
-
-	# Set the challenge start scene to the first scene of the quest
-	_state.set_value(QUEST_SECTION, QUEST_CHALLENGE_START_KEY, quest.first_scene)
-
-	if current_quest.is_lore_quest:
-		quest_player_abilities = game_player_abilities
+	var quest_player_state: PlayerState
+	if new_quest.is_lore_quest:
+		# Duplicate the current global player state. If the quest is completed,
+		# it will be copied back; if abandoned, it will be discarded.
+		quest_player_state = global.player.duplicate()
+		quest_player_state.reset_lives()
 	else:
-		quest_player_abilities = 0
-	_state.set_value(QUEST_SECTION, QUEST_PLAYER_ABILITIES_KEY, quest_player_abilities)
+		# Use a fresh player state for StoryQuests
+		quest_player_state = PlayerState.new()
 
-	# Reset lives when starting a new quest
-	reset_lives()
-	_save()
+	quest = QuestState.new(new_quest, quest_player_state)
 
 
 ## Guess which quest the given scene is part of, and set [member current_quest]
@@ -190,320 +120,61 @@ func guess_quest(scene_path_or_uid: String) -> void:
 	while dir_path != "res://":
 		var quest_path := dir_path.path_join("quest.tres")
 		if ResourceLoader.exists(quest_path, "Resource"):
-			current_quest = ResourceLoader.load(quest_path) as Quest
-			prints("Guessed quest", current_quest.resource_path, "from scene", scene_path)
+			var q := ResourceLoader.load(quest_path) as Quest
+			quest = QuestState.new(q, PlayerState.new())
+			quest.challenge_start_scene = scene_path
+			prints("Guessed quest", quest.resource_path, "from scene", scene_path)
 			return
 
 		dir_path = dir_path.get_base_dir()
 
-	current_quest = null
 
-
-## Set the scene path and [member current_spawn_point].
+## Set the scene path and [member current_spawn_point], and save the game.
 func set_scene(scene_path: String, spawn_point: NodePath = ^"") -> void:
 	if scene_path in TRANSIENT_SCENES:
 		return
 
-	_do_set_scene(scene_path, spawn_point)
-	_save()
+	if not scene or scene.path != scene_path:
+		scene = PerSceneState.new(scene_path)
+
+	scene.spawn_point = spawn_point
+	save()
 
 
-## Set the current spawn point and save it.
-func set_current_spawn_point(spawn_point: NodePath = ^"") -> void:
-	current_spawn_point = spawn_point
-	_state.set_value(GLOBAL_SECTION, SPAWNPOINT_KEY, current_spawn_point)
-	_save()
-
-
-## Set the challenge start scene. This is the scene the player returns to
-## when they run out of lives.
-func set_challenge_start_scene(scene_path: String) -> void:
-	_state.set_value(QUEST_SECTION, QUEST_CHALLENGE_START_KEY, scene_path)
-
-	if DEBUG_LIVES:
-		prints("[LIVES DEBUG] Challenge start set to:", scene_path)
-
-	_save()
-
-
-## Get the challenge start scene, or the first scene of the current quest
-## if no challenge start has been set.
-func get_challenge_start_scene() -> String:
-	var challenge_start: String = _state.get_value(QUEST_SECTION, QUEST_CHALLENGE_START_KEY, "")
-
-	if challenge_start.is_empty() and current_quest:
-		challenge_start = current_quest.first_scene
-
-		if DEBUG_LIVES:
-			prints(
-				"[LIVES DEBUG] No challenge start set, using quest first scene:", challenge_start
-			)
-
-	return challenge_start
-
-
-## Returns [code]true[/code] if the player is currently on a quest; i.e. if
-## [member current_quest] is not [code]null[/code].
-func is_on_quest() -> bool:
-	return current_quest != null
-
-
-## Clear all quest-related state from the config file.
-func _clear_quest_state() -> void:
-	if _state.has_section(QUEST_SECTION):
-		_state.erase_section(QUEST_SECTION)
-
-
-## If [member current_quest] is set, record this quest as having been completed,
-## and unset it. Also resets lives to maximum.
+## Record [member quest] as completed, copying its player state to the global
+## state if it was a LoreQuest, and clear [member quest].
 func mark_quest_completed() -> void:
-	if current_quest:
-		if current_quest.is_lore_quest:
-			# Copy quest abilities to game abilities.
-			game_player_abilities = quest_player_abilities
-			_state.set_value(GLOBAL_SECTION, GAME_PLAYER_ABILITIES_KEY, game_player_abilities)
-		_do_set_quest_completed_state(current_quest, true)
-		current_quest = null
-		_clear_quest_state()
-		_save()
+	assert(quest)
+
+	if quest.quest.is_lore_quest:
+		# Copy quest abilities to game abilities.
+		global.player = quest.player
+
+	global.set_quest_completed_state(quest.quest, true)
+	quest = null
 
 
-## Set the scene path and [member current_spawn_point] without triggering a save.
-func _do_set_scene(scene_path: String, spawn_point: NodePath = ^"") -> void:
-	if get_scene_to_restore() != scene_path:
-		intro_dialogue_shown = false
-
-	current_spawn_point = spawn_point
-	_state.set_value(GLOBAL_SECTION, CURRENTSCENE_KEY, scene_path)
-	_state.set_value(GLOBAL_SECTION, SPAWNPOINT_KEY, current_spawn_point)
-
-
-## Add the [InventoryItem] to the [member inventory].
-func add_collected_item(item: InventoryItem) -> void:
-	inventory.append(item)
-	item_collected.emit(item)
-	collected_items_changed.emit(items_collected())
-	_update_inventory_state()
-	_save()
-
-
-## If [member current_quest] is set, unset it, without recording the quest as
-## having been completed. Also resets lives to maximum.
+## Abandon the current [member quest] without marking it as completed.
 func abandon_quest() -> void:
-	set_incorporating_threads(false)
-	_clear_quest_state()
-	current_quest = null
-	quest_player_abilities = 0
-	clear_inventory()
-
-
-## Updates [member completed_quests] to include [param quest] if [param
-## is_completed] is true, or remove [param quest] if [param is_completed] is
-## false.
-func set_quest_completed_state(quest: Quest, is_completed: bool) -> void:
-	_do_set_quest_completed_state(quest, is_completed)
-	_save()
-
-
-func _do_set_quest_completed_state(quest: Quest, is_completed: bool) -> void:
-	var quest_name := quest.resource_path
-	if is_completed:
-		if quest_name not in completed_quests:
-			completed_quests.append(quest_name)
-			completed_quests_changed.emit()
-	else:
-		while quest_name in completed_quests:
-			completed_quests.erase(quest_name)
-			completed_quests_changed.emit()
-
-
-func _set_game_player_abilities(new_game_player_abilities: int) -> void:
-	if game_player_abilities == new_game_player_abilities:
-		return
-	game_player_abilities = new_game_player_abilities
-	abilities_changed.emit()
-
-
-func _set_quest_player_abilities(new_quest_player_abilities: int) -> void:
-	if quest_player_abilities == new_quest_player_abilities:
-		return
-	quest_player_abilities = new_quest_player_abilities
-	abilities_changed.emit()
-
-
-func _use_global_abilities() -> bool:
-	return current_quest == null
-
-
-## Clear player abilities.
-func clear_abilities() -> void:
-	if _use_global_abilities():
-		game_player_abilities = 0
-	else:
-		quest_player_abilities = 0
-
-
-## Enable or disable a player ability.
-## [br][br]
-## This behaves differently outside quests than when involved in a quest.
-func set_ability(ability: Enums.PlayerAbilities, is_enabled: bool) -> void:
-	if is_enabled:
-		if not has_ability(ability):
-			if _use_global_abilities():
-				game_player_abilities |= ability
-			else:
-				quest_player_abilities |= ability
-	else:
-		if has_ability(ability):
-			if _use_global_abilities():
-				game_player_abilities &= ~ability
-			else:
-				quest_player_abilities &= ~ability
-	if _use_global_abilities():
-		_state.set_value(GLOBAL_SECTION, GAME_PLAYER_ABILITIES_KEY, game_player_abilities)
-	else:
-		_state.set_value(QUEST_SECTION, QUEST_PLAYER_ABILITIES_KEY, quest_player_abilities)
-	_save()
-
-
-## Check if a player ability is enabled.
-## [br][br]
-## This will behave differently in the main "lore" game than in
-## StoryQuests: the lore has player progression that last the whole game,
-## while StoryQuests are narrative units and have their own player progression.
-func has_ability(ability: Enums.PlayerAbilities) -> bool:
-	if _use_global_abilities():
-		return game_player_abilities & ability
-	return quest_player_abilities & ability
-
-
-## Remove all [InventoryItem] from the [member inventory].
-func clear_inventory() -> void:
-	_do_clear_inventory()
-	_update_inventory_state()
-	_save()
-
-
-## Remove all [InventoryItem] from the [member inventory] without triggering a save.
-func _do_clear_inventory() -> void:
-	for item: InventoryItem in inventory.duplicate():
-		inventory.erase(item)
-		item_consumed.emit(item)
-	collected_items_changed.emit(items_collected())
-
-
-## Return all the items collected so far in the [member inventory].
-func items_collected() -> Array[InventoryItem]:
-	return inventory.duplicate()
-
-
-func _update_inventory_state() -> void:
-	_state.set_value(
-		INVENTORY_SECTION,
-		INVENTORY_ITEMS_KEY,
-		inventory.map(func(i: InventoryItem) -> InventoryItem.ItemType: return i.type)
-	)
-
-
-## Decrement the player's lives by 1. Does not go below 0.
-## Saves the new lives count.
-func decrement_lives() -> void:
-	current_lives = max(0, current_lives - 1)
-	_state.set_value(GLOBAL_SECTION, LIVES_KEY, current_lives)
-	_save()
-	lives_changed.emit(current_lives)
-	if DEBUG_LIVES:
-		prints("[LIVES DEBUG] Lives decremented to:", current_lives)
-
-
-## Reset the player's lives to maximum (3).
-## Saves the new lives count.
-func reset_lives() -> void:
-	current_lives = MAX_LIVES
-	_state.set_value(GLOBAL_SECTION, LIVES_KEY, current_lives)
-	_save()
-	lives_changed.emit(current_lives)
-	if DEBUG_LIVES:
-		prints("[LIVES DEBUG] Lives reset to:", current_lives)
-
-
-## Add one life to the player, up to the maximum.
-## This is for future "extra life" pickups.
-func add_life() -> void:
-	if current_lives < MAX_LIVES:
-		current_lives += 1
-		_state.set_value(GLOBAL_SECTION, LIVES_KEY, current_lives)
-		_save()
-		lives_changed.emit(current_lives)
-		if DEBUG_LIVES:
-			prints("[LIVES DEBUG] Life added. Lives now:", current_lives)
-
-
-func change_lights(new_lights_on: bool, immediate: bool = false) -> void:
-	lights_on = new_lights_on
-	lights_changed.emit(lights_on, immediate)
-
-
-## Clear the per-scene state.
-func clear_per_scene_state() -> void:
-	lights_on = false
+	quest = null
+	global.clear_inventory()
 
 
 ## Clear the persisted state.
 func clear() -> void:
-	_state.clear()
-	completed_quests = []
-	game_player_abilities = 0
-	current_lives = MAX_LIVES
-	if DEBUG_LIVES:
-		prints("[LIVES DEBUG] State cleared. Lives reset to:", current_lives)
-	_save()
+	_saved_game = SavedGame.new()
 
 
 ## Check if there is persisted state.
 func can_restore() -> bool:
-	return get_scene_to_restore() != ""
+	return scene != null
 
 
-## If there is a scene to restore, return it.
-func get_scene_to_restore() -> String:
-	return _state.get_value(GLOBAL_SECTION, CURRENTSCENE_KEY, "")
-
-
-## Restore the persisted state.
-func restore() -> Dictionary:
-	inventory.clear()
-	for item_type: InventoryItem.ItemType in _state.get_value(
-		INVENTORY_SECTION, INVENTORY_ITEMS_KEY, []
-	):
-		var item := InventoryItem.with_type(item_type)
-		inventory.append(item)
-
-	if _state.has_section_key(QUEST_SECTION, QUEST_PATH_KEY):
-		current_quest = load(_state.get_value(QUEST_SECTION, QUEST_PATH_KEY)) as Quest
-
-	var scene_path: String = _state.get_value(GLOBAL_SECTION, CURRENTSCENE_KEY, "")
-	current_spawn_point = _state.get_value(GLOBAL_SECTION, SPAWNPOINT_KEY, ^"")
-	incorporating_threads = _state.get_value(
-		GLOBAL_SECTION, GLOBAL_INCORPORATING_THREADS_KEY, false
-	)
-	completed_quests = _state.get_value(GLOBAL_SECTION, COMPLETED_QUESTS_KEY, [] as Array[String])
-
-	game_player_abilities = _state.get_value(GLOBAL_SECTION, GAME_PLAYER_ABILITIES_KEY, 0)
-	quest_player_abilities = _state.get_value(QUEST_SECTION, QUEST_PLAYER_ABILITIES_KEY, 0)
-
-	# Restore lives from saved state, default to MAX_LIVES if not found
-	current_lives = _state.get_value(GLOBAL_SECTION, LIVES_KEY, MAX_LIVES)
-	if DEBUG_LIVES:
-		prints("[LIVES DEBUG] State restored. Lives:", current_lives)
-
-	return {"scene_path": scene_path, "spawn_point": current_spawn_point}
-
-
-func _save() -> void:
+## Save the game state (if [persist_progress] is [code]true[/code])
+func save() -> void:
 	if not persist_progress:
 		return
-	_state.set_value(GLOBAL_SECTION, COMPLETED_QUESTS_KEY, completed_quests)
-	var err := _state.save(GAME_STATE_PATH)
-	if err != OK:
-		push_error("Failed to save settings to %s: %s" % [GAME_STATE_PATH, err])
+
+	var e := ResourceSaver.save(_saved_game, SAVE_PATH)
+	if e != OK:
+		push_error("Failed to save state to %s: %d %s" % [SAVE_PATH, e, error_string(e)])

--- a/scenes/globals/game_state/global_state.gd
+++ b/scenes/globals/game_state/global_state.gd
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name GlobalState
+extends Resource
+
+## Emitted when a new item is collected.
+signal item_collected(item: InventoryItem)
+
+## Emitted when a item is consumed, causing it to be removed from the
+## [member inventory].
+signal item_consumed(item: InventoryItem)
+
+## Emitted when a quest is added or removed from [member completed_quests].
+signal completed_quests_changed
+
+## Inventory of collected threads. Modify with [member add_collected_item] and
+## [member clear_inventory].
+@export var inventory: Array[InventoryItem]
+
+## Types of items in [member inventory], for storage. Use [member inventory]
+## in game code.
+@export_storage var inventory_item_types: Array[String]:
+	get():
+		var types: Array[String]
+		for item: InventoryItem in inventory:
+			types.append(InventoryItem.ItemType.keys()[item.type])
+		return types
+	set(new_value):
+		var items: Array[InventoryItem]
+		for type_name: String in new_value:
+			if InventoryItem.ItemType.has(type_name):
+				items.append(InventoryItem.with_type(InventoryItem.ItemType[type_name]))
+			else:
+				push_warning("Ignoring unknown inventory item type: %s" % type_name)
+		inventory = items
+		changed.emit()
+
+## [Quest]s which the player has previously completed. Modify this with
+## [method set_quest_completed_state].
+@export var completed_quests: Array[Quest]
+
+## Paths to completed quests. This is what is actually stored in the game state,
+## rather than referring to the [Quest] resources directly, so that deleting a
+## quest resource from the game doesn't break loading the save file. Use [member
+## completed_quests] and [method set_quest_completed_state] in game code.
+@export var completed_quest_paths: Array[String]:
+	get():
+		var paths: Array[String]
+		for quest: Quest in completed_quests:
+			paths.append(quest.resource_path)
+		return paths
+	set(new_value):
+		var quests: Array[Quest]
+		for path: String in new_value:
+			if ResourceLoader.exists(path):
+				var quest: Quest = ResourceLoader.load(path)
+				quests.append(quest)
+			else:
+				push_warning("Ignoring unknown quest in save file: %s" % path)
+		completed_quests = quests
+		completed_quests_changed.emit()
+		changed.emit()
+
+## Global player state. During a quest, [member QuestState.player] should be
+## used instead. [GameState.player] always points to the correct instance.
+@export var player: PlayerState = PlayerState.new()
+
+
+func _validate_property(property: Dictionary) -> void:
+	match property.name:
+		"completed_quests", "inventory":
+			property.usage &= ~PROPERTY_USAGE_STORAGE
+
+
+## Add the [InventoryItem] to the [member inventory].
+func add_collected_item(item: InventoryItem) -> void:
+	inventory.append(item)
+	item_collected.emit(item)
+	changed.emit()
+
+
+## Remove all [InventoryItem]s from the [member inventory].
+func clear_inventory() -> void:
+	for item: InventoryItem in inventory.duplicate():
+		inventory.erase(item)
+		item_consumed.emit(item)
+	changed.emit()
+
+
+## Updates [member completed_quests] to include [param quest] if [param
+## is_completed] is true, or remove [param quest] if [param is_completed] is
+## false.
+func set_quest_completed_state(quest: Quest, is_completed: bool) -> void:
+	if is_completed:
+		if quest not in completed_quests:
+			completed_quests.append(quest)
+			completed_quests_changed.emit()
+			changed.emit()
+	else:
+		while quest in completed_quests:
+			completed_quests.erase(quest)
+			completed_quests_changed.emit()
+			changed.emit()

--- a/scenes/globals/game_state/global_state.gd.uid
+++ b/scenes/globals/game_state/global_state.gd.uid
@@ -1,0 +1,1 @@
+uid://d3q7tohvsnbn5

--- a/scenes/globals/game_state/per_scene_state.gd
+++ b/scenes/globals/game_state/per_scene_state.gd
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name PerSceneState
+extends Resource
+## State concerning the current scene in the game.
+##
+## This state is replaced whenever the game changes scene.
+
+## Emitted when it becomes too dark that artificial lights can turn on, or
+## when darkness goes away so artificial lights should turn off. If [param
+## immediate] is true, this should take effect immediately; if false, artificial
+## lights should turn on gradually.
+signal lights_changed(lights_on: bool, immediate: bool)
+
+## The path to the current scene.
+@export var path: String
+
+## Path to the current spawn point within the scene at [member path], or
+## [code]^""[/code] if the player should spawn at the default position when
+## reloading the scene.
+@export var spawn_point: NodePath:
+	set = set_spawn_point
+
+## Set when any introductory dialogue has been played for the current scene.
+@export var intro_dialogue_shown: bool
+
+## Current state of artificial lights. Set with [member set_lights_on]. This is
+## not saved to disk since the lights are controlled programmatically.
+var lights_on: bool
+
+
+func _init(scene_path: String = "") -> void:
+	path = scene_path
+
+
+## Change the state of [member lights_on]. If [param immediate] is [code]
+func set_lights_on(new_value: bool, immediate: bool = false) -> void:
+	# Annoyingly you can't use a method with a second optional parameter as a
+	# property setter.
+	lights_on = new_value
+	lights_changed.emit(new_value, immediate)
+
+
+func set_spawn_point(new_value: NodePath) -> void:
+	spawn_point = new_value
+	changed.emit()

--- a/scenes/globals/game_state/per_scene_state.gd.uid
+++ b/scenes/globals/game_state/per_scene_state.gd.uid
@@ -1,0 +1,1 @@
+uid://d3r76ewcgcxjc

--- a/scenes/globals/game_state/player_state.gd
+++ b/scenes/globals/game_state/player_state.gd
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name PlayerState
+extends Resource
+
+## Emitted when [member abilities] changes
+signal abilities_changed
+
+const MAX_LIVES := 2 ** 53
+
+## Current number of lives the player has.
+@export_range(0, MAX_LIVES, 1) var lives: int = MAX_LIVES:
+	set(value):
+		lives = value
+		changed.emit()
+
+## Bitfield of elements of Enums.PlayerAbilities
+@export var abilities: int:
+	set(value):
+		if abilities != value:
+			abilities = value
+			changed.emit()
+			abilities_changed.emit()
+
+
+func _validate_property(property: Dictionary) -> void:
+	match property.name:
+		"player_abilities":
+			property.hint = PROPERTY_HINT_FLAGS
+			# This is not a constant expression, so we cannot use @export_custom
+			property.hint_string = ",".join(Enums.PlayerAbilities.keys())
+
+
+## Reduces [member lives] by 1.
+func decrement_lives() -> void:
+	lives = max(0, lives - 1)
+
+
+## Resets [member lives] to [const MAX_LIVES].
+func reset_lives() -> void:
+	lives = MAX_LIVES
+
+
+## Enable or disable a player ability.
+func set_ability(ability: Enums.PlayerAbilities, is_enabled: bool) -> void:
+	if is_enabled:
+		abilities |= ability
+	else:
+		abilities &= ~ability
+
+
+## Check if a player ability is enabled.
+## [br][br]
+## This will behave differently in the main "lore" game than in
+## StoryQuests: the lore has player progression that last the whole game,
+## while StoryQuests are narrative units and have their own player progression.
+func has_ability(ability: Enums.PlayerAbilities) -> bool:
+	return abilities & ability

--- a/scenes/globals/game_state/player_state.gd.uid
+++ b/scenes/globals/game_state/player_state.gd.uid
@@ -1,0 +1,1 @@
+uid://cs06npj4vvi1

--- a/scenes/globals/game_state/quest_state.gd
+++ b/scenes/globals/game_state/quest_state.gd
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name QuestState
+extends Resource
+
+@export var quest: Quest
+
+## Resource path of [member quest], which is what is actually saved to disk.
+## Use [member quest] instead.
+@export_storage var quest_path: String:
+	get():
+		return quest.resource_path if quest else ""
+	set(new_value):
+		if ResourceLoader.exists(new_value):
+			quest = ResourceLoader.load(new_value)
+		else:
+			if new_value != "":
+				push_warning("Quest path in saved game does not exist: %s" % new_value)
+			quest = null
+
+## Path to the starting scene of the current challenge, which is where the
+## player returns to if they run out of lives. If not set, defaults to
+## [member quest]'s [Quest.first_scene].
+@export var challenge_start_scene: String:
+	get = get_challenge_start_scene,
+	set = set_challenge_start_scene
+
+## Set when the loom transports the player to a trio of Sokoban puzzles, so that
+## when the player returns to Fray's End the loom can trigger a brief cutscene.
+@export var incorporating_threads: bool
+
+## Player state within [member quest]. If [member Quest.is_lore_quest] is
+## [code]true[/code], this will be initialised as a copy of [member
+## GlobalState.player], and propagated back to [GlobalState] if the quest is
+## completed. For StoryQuests, this is a fresh state at the start of the quest
+## and is discarded at the end.
+@export var player: PlayerState = PlayerState.new()
+
+
+func _init(q: Quest = null, p: PlayerState = null) -> void:
+	quest = q
+	player = p
+
+
+func _validate_property(property: Dictionary) -> void:
+	match property.name:
+		"quest":
+			property.usage &= ~PROPERTY_USAGE_STORAGE
+
+
+func get_challenge_start_scene() -> String:
+	assert(quest != null)
+
+	if challenge_start_scene:
+		return challenge_start_scene
+
+	return quest.first_scene
+
+
+func set_challenge_start_scene(value: String) -> void:
+	challenge_start_scene = ResourceUID.ensure_path(value)
+	changed.emit()

--- a/scenes/globals/game_state/quest_state.gd.uid
+++ b/scenes/globals/game_state/quest_state.gd.uid
@@ -1,0 +1,1 @@
+uid://cyrblqxli2a2h

--- a/scenes/globals/game_state/saved_game.gd
+++ b/scenes/globals/game_state/saved_game.gd
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name SavedGame
+extends Resource
+
+## Game-wide state
+@export var global: GlobalState = GlobalState.new()
+
+## State concerning the quest that the player is currently playing, or
+## [code]null[/code] if they are not playing a quest.
+@export var quest: QuestState
+
+## State concerning the scene that the player is currently playing.
+@export var scene: PerSceneState

--- a/scenes/globals/game_state/saved_game.gd.uid
+++ b/scenes/globals/game_state/saved_game.gd.uid
@@ -1,0 +1,1 @@
+uid://cgaskymgvc652

--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -30,10 +30,10 @@ func toggle_pause() -> void:
 	Input.set_default_cursor_shape(Input.CURSOR_ARROW if new_state else Input.CURSOR_CROSS)
 
 	if new_state:
-		if not GameState.current_quest:
+		if not GameState.quest:
 			skip_tutorial_button.hide()
 			abandon_quest_button.hide()
-		elif GameState.current_quest.skippable:
+		elif GameState.quest.quest.skippable:
 			skip_tutorial_button.show()
 			abandon_quest_button.hide()
 		else:
@@ -53,8 +53,10 @@ func _on_abandon_quest_pressed() -> void:
 
 func _on_skip_tutorial_pressed() -> void:
 	toggle_pause()
-	for ability: Enums.PlayerAbilities in GameState.current_quest.skip_abilities:
-		GameState.set_ability(ability, true)
+	assert(GameState.quest)
+	assert(GameState.quest.quest)
+	for ability: Enums.PlayerAbilities in GameState.quest.quest.skip_abilities:
+		GameState.player.set_ability(ability, true)
 	GameState.mark_quest_completed()
 	SceneSwitcher.change_to_file_with_transition(
 		frays_end, ^"", Transition.Effect.FADE, Transition.Effect.FADE

--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -54,10 +54,10 @@ func _restore_from_hash() -> void:
 		# otherwise, this is an absolute uid:// or res:// path
 
 		if ResourceLoader.exists(path, "PackedScene"):
-			if GameState.can_restore() and GameState.get_scene_to_restore() == path:
-				# Continue if the path matches the saved scene. This would happen
-				# if the player reloads the page while playing.
-				GameState.restore()
+			if GameState.scene and GameState.scene.path == path:
+				# The path matches the saved scene. This would happen
+				# if the player reloads the page while playing. Don't clear the state.
+				pass
 			else:
 				# Otherwise, treat it as the player is debugging a scene from the web.
 				# In that case, do not persist progress and clear the game state.
@@ -66,9 +66,8 @@ func _restore_from_hash() -> void:
 				GameState.persist_progress = false
 				GameState.clear()
 				GameState.guess_quest(path)
-				GameState.set_challenge_start_scene(path)
 				for ability: Enums.PlayerAbilities in GameState.DEBUG_PLAYER_ABILITIES:
-					GameState.set_ability(ability, true)
+					GameState.player.set_ability(ability, true)
 				# TODO: this duplicates code in GameState._ready, find a way to consolidate.
 
 			# In theory, we might like to avoid switching scene if the specified
@@ -101,6 +100,9 @@ func _on_hash_changed(args: Array) -> void:
 		_restore_from_hash()
 
 
+## Change to the scene at [param scene_path], placing the player at [param
+## spawn_point] if provided, with the given transition. The game is saved in the
+## process.
 func change_to_file_with_transition(
 	scene_path: String,
 	spawn_point: NodePath = ^"",
@@ -121,6 +123,8 @@ func change_to_file_with_transition(
 	)
 
 
+## Change to [param scene], placing the player at [param spawn_point] if
+## provided, with the given transition. The game is saved in the process.
 func change_to_packed_with_transition(
 	scene: PackedScene,
 	spawn_point: NodePath = ^"",
@@ -134,13 +138,22 @@ func change_to_packed_with_transition(
 	)
 
 
+## Reload the current scene, with a transition, and save the game.
 func reload_with_transition(
 	enter_transition: Transition.Effect = Transition.Effect.FADE,
 	exit_transition: Transition.Effect = Transition.Effect.FADE,
 ) -> void:
-	Transitions.do_transition(get_tree().reload_current_scene, enter_transition, exit_transition)
+	Transitions.do_transition(_reload, enter_transition, exit_transition)
 
 
+func _reload() -> void:
+	get_tree().reload_current_scene()
+	GameState.save()
+
+
+## Change to the scene at [param scene_path], placing the player at [param
+## spawn_point] if provided, with no transition. The game is saved in the
+## process.
 func change_to_file(scene_path: String, spawn_point: NodePath = ^"") -> void:
 	assert(scene_path != "")
 
@@ -149,11 +162,13 @@ func change_to_file(scene_path: String, spawn_point: NodePath = ^"") -> void:
 		change_to_packed(scene, spawn_point)
 
 
+## Change to [param scene], placing the player at [param spawn_point] if
+## provided, with no transition. The game is saved in the process.
 func change_to_packed(scene: PackedScene, spawn_point: NodePath = ^"") -> void:
 	assert(scene != null)
 
-	GameState.clear_per_scene_state()
-
 	if get_tree().change_scene_to_packed(scene) == OK:
 		_set_hash(scene.resource_path)
+
+		# This saves the game.
 		GameState.set_scene(scene.resource_path, spawn_point)

--- a/scenes/menus/debug/debug_completed_quest_list.gd
+++ b/scenes/menus/debug/debug_completed_quest_list.gd
@@ -21,6 +21,7 @@ func rebuild() -> void:
 		remove_child(child)
 		child.queue_free()
 
+	var completed_quests := GameState.global.completed_quests
 	for dir: String in DirAccess.get_directories_at(QUEST_ROOT):
 		for quest in Quest.enumerate(QUEST_ROOT.path_join(dir)):
 			var bits: Array[String]
@@ -29,10 +30,11 @@ func rebuild() -> void:
 			bits.append(quest.resource_path.get_base_dir().substr(QUEST_ROOT.length() + 1))
 			var button := CheckButton.new()
 			button.text = " · ".join(bits)
-			button.button_pressed = GameState.completed_quests.has(quest.resource_path)
+			button.button_pressed = completed_quests.has(quest)
 			button.toggled.connect(_on_button_toggled.bind(quest))
 			add_child(button)
 
 
 func _on_button_toggled(toggled_on: bool, quest: Quest) -> void:
-	GameState.set_quest_completed_state(quest, toggled_on)
+	GameState.global.set_quest_completed_state(quest, toggled_on)
+	GameState.save()

--- a/scenes/menus/debug/debug_player_abilities_list.gd
+++ b/scenes/menus/debug/debug_player_abilities_list.gd
@@ -22,10 +22,10 @@ func rebuild() -> void:
 		var ability: Enums.PlayerAbilities = Enums.PlayerAbilities[ability_name]
 		var button := CheckButton.new()
 		button.text = ability_name
-		button.button_pressed = GameState.has_ability(ability)
+		button.button_pressed = GameState.player.has_ability(ability)
 		button.toggled.connect(_on_button_toggled.bind(ability))
 		add_child(button)
 
 
 func _on_button_toggled(toggled_on: bool, ability: Enums.PlayerAbilities) -> void:
-	GameState.set_ability(ability, toggled_on)
+	GameState.player.set_ability(ability, toggled_on)

--- a/scenes/menus/title/components/title_screen.gd
+++ b/scenes/menus/title/components/title_screen.gd
@@ -11,9 +11,8 @@ extends Control
 
 func _ready() -> void:
 	if ProjectSettings.get_setting(ThreadbareProjectSettings.SKIP_SPLASH):
-		var saved_scene: Dictionary = GameState.restore()
-		if saved_scene["scene_path"]:
-			SceneSwitcher.change_to_file(saved_scene["scene_path"], saved_scene["spawn_point"])
+		if GameState.can_restore():
+			_on_main_menu_continue_pressed()
 		else:
 			_on_start_pressed()
 
@@ -24,12 +23,11 @@ func _input(event: InputEvent) -> void:
 
 
 func _on_main_menu_continue_pressed() -> void:
-	var saved_scene: Dictionary = GameState.restore()
 	(
 		SceneSwitcher
 		. change_to_file_with_transition(
-			saved_scene["scene_path"],
-			saved_scene["spawn_point"],
+			GameState.scene.path,
+			GameState.scene.spawn_point,
 			Transition.Effect.FADE,
 			Transition.Effect.FADE,
 		)
@@ -37,8 +35,7 @@ func _on_main_menu_continue_pressed() -> void:
 
 
 func _on_start_pressed() -> void:
-	if GameState.can_restore():
-		GameState.clear()
+	GameState.clear()
 
 	GameState.start_quest(tutorial_quest)
 	SceneSwitcher.change_to_file_with_transition(

--- a/scenes/quests/lore_quests/quest_000/3_sequence_puzzle/components/tutorial_sequence_puzzle.gd
+++ b/scenes/quests/lore_quests/quest_000/3_sequence_puzzle/components/tutorial_sequence_puzzle.gd
@@ -2,12 +2,4 @@
 # SPDX-License-Identifier: MPL-2.0
 extends Node2D
 
-@onready var cinematic: Cinematic = %Cinematic
-@onready var tutorial_npc: CharacterBody2D = %TutorialNPC
 @onready var puzzle: SequencePuzzle = %SequencePuzzle
-
-
-func _ready() -> void:
-	await cinematic.cinematic_finished
-
-	tutorial_npc.walk_path()

--- a/scenes/quests/lore_quests/quest_000/3_sequence_puzzle/tutorial_sequence_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_000/3_sequence_puzzle/tutorial_sequence_puzzle.tscn
@@ -248,3 +248,4 @@ exit_transition = 5
 shape = SubResource("RectangleShape2D_ypup5")
 
 [connection signal="solved" from="OnTheGround/SequencePuzzle" to="OnTheGround/Door" method="open"]
+[connection signal="cinematic_finished" from="Cinematic" to="OnTheGround/TutorialNPC" method="walk_path"]

--- a/scenes/quests/lore_quests/quest_000/4_ink_combat/components/tutorial_ink_combat.dialogue
+++ b/scenes/quests/lore_quests/quest_000/4_ink_combat/components/tutorial_ink_combat.dialogue
@@ -6,7 +6,7 @@ Arun: Collect the button powerup, then repel the ink they spray into the jar!
 => END
 
 ~ interact
-if not GameState.has_ability(repel_powerup.ability):
+if not GameState.player.has_ability(repel_powerup.ability):
 	Arun: Collect the button powerup, StoryWeaver!
 else if fill_game_logic.barrels_completed < fill_game_logic.barrels_to_win:
 	Arun: Repel the ink into the barrel!

--- a/scenes/quests/lore_quests/quest_000/4_ink_combat/tutorial_ink_combat.tscn
+++ b/scenes/quests/lore_quests/quest_000/4_ink_combat/tutorial_ink_combat.tscn
@@ -83,6 +83,7 @@ clip = &"cozy"
 metadata/_custom_type_script = "uid://c2lx7gvkonxaa"
 
 [node name="Cinematic" type="Node2D" parent="." unique_id=2113147326]
+unique_name_in_owner = true
 script = ExtResource("3_pagku")
 dialogue = ExtResource("4_4u14d")
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/grappling_hook_powerup.gd
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/grappling_hook_powerup.gd
@@ -6,12 +6,14 @@ var zoom_tween: Tween
 
 
 func _ready() -> void:
-	GameState.abilities_changed.connect(_on_abilities_changed)
+	GameState.player.abilities_changed.connect(_on_abilities_changed)
 	_on_abilities_changed()
 
 
 func _on_abilities_changed() -> void:
-	var has_longer_thread := GameState.has_ability(Enums.PlayerAbilities.ABILITY_B_MODIFIER_1)
+	var has_longer_thread := GameState.player.has_ability(
+		Enums.PlayerAbilities.ABILITY_B_MODIFIER_1
+	)
 	var camera_zoom := Vector2(0.5, 0.5) if has_longer_thread else Vector2(1.0, 1.0)
 	# Zoom out when the player can throw a longer thread:
 	if zoom_tween:

--- a/scenes/quests/lore_quests/quest_002/3_void_grappling/components/void_grapping_round_2.gd
+++ b/scenes/quests/lore_quests/quest_002/3_void_grappling/components/void_grapping_round_2.gd
@@ -9,15 +9,17 @@ var zoom_tween: Tween
 
 
 func _ready() -> void:
-	GameState.abilities_changed.connect(_on_abilities_changed)
+	GameState.player.abilities_changed.connect(_on_abilities_changed)
 
 	# TODO: This level removes the longer thread modifier when started.
 	# Otherwise the Void chase can't be triggered.
-	GameState.set_ability(Enums.PlayerAbilities.ABILITY_B_MODIFIER_1, false)
+	GameState.player.set_ability(Enums.PlayerAbilities.ABILITY_B_MODIFIER_1, false)
 
 
 func _on_abilities_changed() -> void:
-	var has_longer_thread := GameState.has_ability(Enums.PlayerAbilities.ABILITY_B_MODIFIER_1)
+	var has_longer_thread := GameState.player.has_ability(
+		Enums.PlayerAbilities.ABILITY_B_MODIFIER_1
+	)
 	var camera_zoom := Vector2(0.5, 0.5) if has_longer_thread else Vector2(1.0, 1.0)
 	# Zoom out when the player can throw a longer thread:
 	if zoom_tween:

--- a/scenes/quests/lore_quests/quest_002/4_closing_transition/components/closing_cinematic.dialogue
+++ b/scenes/quests/lore_quests/quest_002/4_closing_transition/components/closing_cinematic.dialogue
@@ -11,7 +11,7 @@ do animation_player.play("retreat")
 do animation_player.animation_finished
 Flaxfred: Stranger, you have helped us more than you know!
 Flaxfred: It feels like LinenVille’s spirit has come back to us. Here: take this thread as a parting gift.
-do GameState.add_collected_item(InventoryItem.with_type(InventoryItem.ItemType.SPIRIT))
+do GameState.global.add_collected_item(InventoryItem.with_type(InventoryItem.ItemType.SPIRIT))
 do animation_player.play("leave")
 do wait(1.0)
 => END

--- a/scenes/quests/story_quests/after_the_tremor/2_colegiojuego/puzzlemanager.gd
+++ b/scenes/quests/story_quests/after_the_tremor/2_colegiojuego/puzzlemanager.gd
@@ -3,9 +3,9 @@
 extends Node
 
 @export var zone_nodes: Array[AllHooked] = []
-@export var timer_node: NodePath                    
-@export var timer_seconds: int = 180                
-@export var timer_label: NodePath = NodePath("")    
+@export var timer_node: NodePath
+@export var timer_seconds: int = 180
+@export var timer_label: NodePath = NodePath("")
 @export var auto_start_on_first_zone: bool = true
 @export var final_collectible: NodePath
 @export var final_dialogue: DialogueResource
@@ -18,7 +18,7 @@ extends Node
 signal puzzle_succeeded
 signal puzzle_failed
 
-var _zones_done: Dictionary = {}   
+var _zones_done: Dictionary = {}
 var _timer: Timer = null
 var _running: bool = false
 
@@ -131,7 +131,7 @@ func _on_timer_timeout() -> void:
 			lab.text = "Tiempo agotado. Reiniciando..."
 
 	await get_tree().create_timer(0.8).timeout
-	get_tree().reload_current_scene()
+	SceneSwitcher.reload_with_transition()
 
 
 func _reset_zones_state() -> void:

--- a/scenes/quests/story_quests/el_ojo_revelador/4_outro/outro_components/el_ojo_revelador_outro.dialogue
+++ b/scenes/quests/story_quests/el_ojo_revelador/4_outro/outro_components/el_ojo_revelador_outro.dialogue
@@ -1,16 +1,16 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-do GameState.add_collected_item(InventoryItem.with_type(InventoryItem.ItemType.SPIRIT))
-Jeremy, envuelto en polvo y con la ropa rota, mira salir el deslumbrante sol. 
-Por primera vez en su vida , no se siente apurado ni ansioso por lo que venga después. 
-Está disfrutando del silencio, el aire y la luz. El Ojo Revelador mostró su alma. le permitió 
-reconocer su ambición desenfrenada y comprender que los tesoros más valiosos no están ocultos 
-en templos... solo se hallan en uno mismo. Decidió dejar el fragmento del diamante en la cima 
+do GameState.global.add_collected_item(InventoryItem.with_type(InventoryItem.ItemType.SPIRIT))
+Jeremy, envuelto en polvo y con la ropa rota, mira salir el deslumbrante sol.
+Por primera vez en su vida , no se siente apurado ni ansioso por lo que venga después.
+Está disfrutando del silencio, el aire y la luz. El Ojo Revelador mostró su alma. le permitió
+reconocer su ambición desenfrenada y comprender que los tesoros más valiosos no están ocultos
+en templos... solo se hallan en uno mismo. Decidió dejar el fragmento del diamante en la cima
 de una roca, como una señal de respeto.
 
 
-Jeremy (pensativo): "Pasé toda mi vida buscando tesoros... pero nunca entendí que la verdadera 
+Jeremy (pensativo): "Pasé toda mi vida buscando tesoros... pero nunca entendí que la verdadera
 reliquia era el tiempo que dejé pasar."
 
 El aventurero mira el horizonte, dejando caer el fragmento del diamante sobre una roca.

--- a/scenes/quests/story_quests/shjourney/4_Laberinto/kaenamanto.gd
+++ b/scenes/quests/story_quests/shjourney/4_Laberinto/kaenamanto.gd
@@ -17,7 +17,7 @@ var can_attack: bool = true
 var has_screamed: bool = false  # <- control de grito por detección
 
 func _ready() -> void:
-	$CollisionShape2D.disabled = false  
+	$CollisionShape2D.disabled = false
 	vision_area.body_entered.connect(_on_body_entered)
 	vision_area.body_exited.connect(_on_body_exited)
 	attack_area.body_entered.connect(_on_attack_area_entered)
@@ -65,7 +65,7 @@ func _on_attack_area_entered(body: Node2D) -> void:
 		sprite.play("attack")
 
 		await get_tree().create_timer(0.5).timeout
-		get_tree().reload_current_scene()
+		SceneSwitcher.reload_with_transition()
 
 func _on_attack_timeout() -> void:
 	can_attack = true

--- a/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
+++ b/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=4 uid="uid://hb6ekertaof8"]
 
 [ext_resource type="Script" uid="uid://dnp0tjloec2d7" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_hmya5"]
+[ext_resource type="Script" uid="uid://pk3ucq7e2eah" path="res://scenes/game_logic/player_mode.gd" id="1_pm753"]
 [ext_resource type="Material" uid="uid://64aeyjitacv3" path="res://scenes/game_elements/props/void/void_chromakey_material.tres" id="2_446rl"]
 [ext_resource type="TileSet" uid="uid://ciq5guijvlyb0" path="res://tiles/void_chromakey.tres" id="3_fcgc7"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="3_qvtgt"]
@@ -23,7 +24,6 @@
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="16_0ownb"]
 [ext_resource type="Resource" uid="uid://fgepu5pdp6wu" path="res://scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_firekeeper.dialogue" id="16_rlkm0"]
 [ext_resource type="SpriteFrames" uid="uid://dktcbyom7px88" path="res://scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_firekeeper.tres" id="17_0ownb"]
-[ext_resource type="Script" uid="uid://pk3ucq7e2eah" path="res://scenes/game_logic/player_mode.gd" id="1_pm753"]
 
 [sub_resource type="Curve2D" id="Curve2D_vnsq3"]
 _data = {
@@ -494,9 +494,9 @@ debug_color = Color(0, 0, 0, 0.42)
 
 [node name="CollectibleItem" parent="." unique_id=1494033634 instance=ExtResource("8_jobnx")]
 position = Vector2(451, 775)
-next_scene = "uid://bfr7svwx5hqkf"
 item = SubResource("Resource_idy4y")
 collected_dialogue = ExtResource("12_rlkm0")
+next_scene = "uid://bfr7svwx5hqkf"
 
 [node name="Flame" type="AnimatedSprite2D" parent="." unique_id=968837256]
 position = Vector2(448, 675)

--- a/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_stealth.dialogue
+++ b/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_stealth.dialogue
@@ -1,7 +1,5 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-if str(GameState.current_spawn_point) != ""
-	=> END
 Stella’s journey takes her deep into the heart of Guatemala, where she finds a Mayan firekeeper tending hearth in a village.
 => END

--- a/scenes/quests/story_quests/verso/2_verso_stealth_sadness/verso_stealth_components/verso_stealth.dialogue
+++ b/scenes/quests/story_quests/verso/2_verso_stealth_sadness/verso_stealth_components/verso_stealth.dialogue
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-# From the Stella branch to avoid repeating dialogue
-if str(GameState.current_spawn_point) != ""
-	=> END
 After Nora begins to calm down from battling with their school supplies, they begin feeling ashamed.
 In retrospect, it might have been a slight overreaction to the confusing homework...
 They can only imagine how their classmates and teachers would judge them for their behavior.

--- a/scenes/ui_elements/cinematic/cinematic.gd
+++ b/scenes/ui_elements/cinematic/cinematic.gd
@@ -25,15 +25,18 @@ signal cinematic_finished
 func _ready() -> void:
 	super._ready()
 
+	if Engine.is_editor_hint():
+		return
+
 	if autostart:
 		start()
 
 
 func start() -> void:
-	if not GameState.intro_dialogue_shown:
+	if not GameState.scene.intro_dialogue_shown:
 		DialogueManager.show_dialogue_balloon(dialogue, "", [self])
 		await DialogueManager.dialogue_ended
-		GameState.intro_dialogue_shown = true
+		GameState.scene.intro_dialogue_shown = true
 
 	cinematic_finished.emit()
 	switch()

--- a/scenes/ui_elements/story_quest_progress/components/story_quest_progress.gd
+++ b/scenes/ui_elements/story_quest_progress/components/story_quest_progress.gd
@@ -8,26 +8,27 @@ const ITEM_SLOT: PackedScene = preload("uid://1mjm4atk2j6e")
 
 
 func _ready() -> void:
-	if not GameState.current_quest:
-		return
+	var n := 0
+	if GameState.quest:
+		n = GameState.quest.quest.threads_to_collect
 
-	if GameState.current_quest.threads_to_collect == 0:
+	if n == 0:
 		visible = false
 		return
 
 	# Add one slot for each item in the current quest
-	for _i: int in GameState.current_quest.threads_to_collect:
+	for _i: int in n:
 		items_container.add_child(ITEM_SLOT.instantiate())
 
 	# On ready, the HUD is populated with the items that were collected so
 	# far in the quest.
-	var items_collected := GameState.items_collected()
-	for i: int in min(items_collected.size(), GameState.current_quest.threads_to_collect):
+	var items_collected := GameState.global.inventory
+	for i: int in min(items_collected.size(), n):
 		items_container.get_child(i).start_as_filled(items_collected[i])
 
 	# Then, when each new item is collected, it is added to the progress UI
-	GameState.item_collected.connect(self._on_item_collected)
-	GameState.item_consumed.connect(self._on_item_consumed)
+	GameState.global.item_collected.connect(self._on_item_collected)
+	GameState.global.item_consumed.connect(self._on_item_consumed)
 
 
 func _on_item_collected(item: InventoryItem) -> void:
@@ -43,3 +44,4 @@ func _on_item_consumed(item: InventoryItem) -> void:
 		var item_slot := child as ItemSlot
 		if item_slot.is_filled_with_same_item_type_as(item):
 			item_slot.free_slot()
+			return

--- a/scenes/world_map/components/frays_end.gd
+++ b/scenes/world_map/components/frays_end.gd
@@ -8,11 +8,9 @@ extends Node2D
 
 func _ready() -> void:
 	_update_story_quest_progress_visibility()
-	GameState.collected_items_changed.connect(_update_story_quest_progress_visibility)
-
-	# Restore lives to maximum when entering Fray's End
-	GameState.reset_lives()
+	GameState.global.item_collected.connect(_update_story_quest_progress_visibility)
+	GameState.global.item_consumed.connect(_update_story_quest_progress_visibility)
 
 
-func _update_story_quest_progress_visibility(_new_items: Array[InventoryItem] = []) -> void:
+func _update_story_quest_progress_visibility(_item: InventoryItem = null) -> void:
 	hud.change_story_quest_progress_visibility(eternal_loom.is_item_offering_possible())

--- a/scenes/world_map/components/quest_progress_unlocker.gd
+++ b/scenes/world_map/components/quest_progress_unlocker.gd
@@ -41,7 +41,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 func _ready() -> void:
 	_connect_targets()
 
-	GameState.completed_quests_changed.connect(_on_completed_quests_changed)
+	GameState.global.completed_quests_changed.connect(_on_completed_quests_changed)
 
 	# To ensure the targets are ready, we do a "call_deferred"
 	_initialize_toggle_state.call_deferred()
@@ -64,8 +64,7 @@ func _on_completed_quests_changed() -> void:
 ## Returns whether all quests in [member required_quests] have been completed.
 func is_satisfied() -> bool:
 	for quest: Quest in required_quests:
-		# TODO: would be better if completed_quests held the Quest resources...
-		if quest.resource_path not in GameState.completed_quests:
+		if quest not in GameState.global.completed_quests:
 			return false
 
 	return true


### PR DESCRIPTION
GameState mixes the actual load/save logic with the state itself, and
also is based on a mixture of directly accessing the contents of a
ConfigFile object and fields of the GameState node.

State API
---------

Factor all the state itself out to a (shallow) tree of Resource subclasses:

- SavedGame
  - GlobalState
    - PlayerState
  - QuestState (nullable)
    - Quest-specific PlayerState instance
  - PerSceneState

Expose the GlobalState, QuestState, and PerSceneState resources on
GameState with short names to save on typing when referring to them. Add
a special GameState.player property which is a proxy for the
quest-specific PlayerState when on a quest and the global PlayerState
otherwise. Update all code in the game to refer to these.

Remove `@tool` from GameState, and instead short-circuit in other
scripts which need to be `@tool` but refer to GameState.

Storage
-------

Replace the ConfigFile-based load and save logic with ResourceLoader and
ResourceSaver. This avoids writing bespoke serialisation code & makes it
relatively easy to add new saved fields – drop an `@export` into the
appropriate state class – at the cost of coupling the savegame format to
these Resource subclasses existing at these exact paths. This is the
approach recommended, among others, by GDQuest.

https://www.gdquest.com/library/save_game_godot4/

The state conceptually needs to refer to Quest resources. Storing these
as resources would mean that the `saved_game.tres` would have an
`ext_resource` header for each quest.tres being referred to, and moving
a quest elsewhere in the source tree (or deleting it) will cause the
whole `saved_game.tres` to fail to load. Mark the Quest and Array[Quest]
as not to be stored, and define stored proxy properties that convert to
and from resource_path strings. This matches how these were previously
stored.

Similarly, the inventory is in terms of InventoryItem resources. Unlike
Quests we don't store these in the game repo but define them inline
wherever they are used. I think this is a bad design - it would be
better to use just the ItemType enum throughout given that we hardcode
exactly 3 items and 2 textures for each - but to avoid this PR getting
even further out of hand, translate these to and from the ItemType enum
member name when storing, as before.

The result of jumping through these hoops is that the `saved_game.tres`
only refers to the scripts that define aspects of the game state. I
think that's acceptable coupling. I am disappointed to have to write
quite a bit of what amounts to custom serialisation code - I was hoping
to avoid that by using ResourceLoader/ResourceSaver - but it's still a
net improvement I think.

I did not make any attempt to migrate the old save game format to the
new one. This game is small, the state has little impact, and this will
also mean more people see the tutorial. :)

Saving
------

Only save the state in a few specific places, rather than whenever parts
of the state change (if we remembered to add a _save() call):

- When a checkpoint is activated (so that if you quit the game with
  Alt+F4 after activating a checkpoint, it is kept);
- When reloading the current scene, typically due to being defeated, to
  record the loss of life;
- When switching to a new scene;
- When you use the debug menu to tweak the completed quests.

Resolves https://github.com/endlessm/threadbare/issues/2016

