### PR TITLE
gitattributes: Track Backstitch launcher binaries in LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,7 @@
 *.zip filter=lfs diff=lfs merge=lfs -text
 *.ogv filter=lfs diff=lfs merge=lfs -text
 *.mp3 filter=lfs diff=lfs merge=lfs -text
+
+backstitch-launcher-linux filter=lfs diff=lfs merge=lfs -text
+backstitch-launcher-windows.exe filter=lfs diff=lfs merge=lfs -text
+backstitch-launcher-macos.app/Contents/MacOS/backstitch-launcher filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
gitattributes: Track Backstitch launcher binaries in LFS

Although we don't (currently!) have these launchers upstream, it is
useful to avoid accidentally pushing them to regular Git when working in
hybrid git/backstitch projects.
