### PR TITLE
Fray's End: Small fix for positions and scales

### DIFF
--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -75,7 +75,6 @@ metadata/_edit_lock_ = true
 stream = ExtResource("2_epsnn")
 
 [node name="TileMapLayers" type="Node2D" parent="." unique_id=1722660259]
-position = Vector2(0, 8)
 
 [node name="Water" type="TileMapLayer" parent="TileMapLayers" unique_id=1840175252]
 tile_map_data = PackedByteArray("AAABABcAAAAAAAAAAAABABYAAAAAAAAAAAACABcAAAAAAAAAAAACABYAAAAAAAAAAAACABUAAAAAAAAAAAADABUAAAAAAAAAAAAEABUAAAAAAAAAAAADABYAAAAAAAAAAAAEABYAAAAAAAAAAAAFABYAAAAAAAAAAAAFABUAAAAAAAAAAAAGABYAAAAAAAAAAAAGABUAAAAAAAAAAAAHABUAAAAAAAAAAAAHABYAAAAAAAAAAAAIABUAAAAAAAAAAAAIABQAAAAAAAAAAAAJABQAAAAAAAAAAAAKABQAAAAAAAAAAAAKABUAAAAAAAAAAAAJABUAAAAAAAAAAAALABUAAAAAAAAAAAAMABUAAAAAAAAAAAANABUAAAAAAAAAAAANABQAAAAAAAAAAAAMABQAAAAAAAAAAAALABQAAAAAAAAAAAAOABQAAAAAAAAAAAAOABUAAAAAAAAAAAAQABUAAAAAAAAAAAARABUAAAAAAAAAAAARABQAAAAAAAAAAAAQABQAAAAAAAAAAAASABQAAAAAAAAAAAATABQAAAAAAAAAAAAUABQAAAAAAAAAAAAVABQAAAAAAAAAAAAWABQAAAAAAAAAAAAXABQAAAAAAAAAAAAYABQAAAAAAAAAAAAZABQAAAAAAAAAAAAaABQAAAAAAAAAAAAaABUAAAAAAAAAAAAZABUAAAAAAAAAAAAYABUAAAAAAAAAAAAXABUAAAAAAAAAAAAWABUAAAAAAAAAAAAVABUAAAAAAAAAAAAUABUAAAAAAAAAAAATABUAAAAAAAAAAAASABUAAAAAAAAAAAAZABYAAAAAAAAAAAAaABYAAAAAAAAAAAAaABcAAAAAAAAAAAAbABcAAAAAAAAAAAAcABcAAAAAAAAAAAAbABgAAAAAAAAAAAAcABgAAAAAAAAAAAAdABgAAAAAAAAAAAAcABkAAAAAAAAAAAAdABkAAAAAAAAAAAAeABkAAAAAAAAAAAAfABkAAAAAAAAAAAAdABoAAAAAAAAAAAAeABoAAAAAAAAAAAAfABoAAAAAAAAAAAADABcAAAAAAAAAAAAEABcAAAAAAAAAAAAFABcAAAAAAAAAAAAGABcAAAAAAAAAAAAHABcAAAAAAAAAAAAIABYAAAAAAAAAAAAJABYAAAAAAAAAAAAKABYAAAAAAAAAAAALABYAAAAAAAAAAAAMABYAAAAAAAAAAAANABYAAAAAAAAAAAAOABYAAAAAAAAAAAAQABYAAAAAAAAAAAARABYAAAAAAAAAAAASABYAAAAAAAAAAAATABYAAAAAAAAAAAAUABYAAAAAAAAAAAAVABYAAAAAAAAAAAAWABYAAAAAAAAAAAAXABYAAAAAAAAAAAAYABYAAAAAAAAAAAAZABcAAAAAAAAAAAAaABgAAAAAAAAAAAAaABkAAAAAAAAAAAAbABkAAAAAAAAAAAAbABoAAAAAAAAAAAAcABoAAAAAAAAAAAAcABQAAAAAAAAAAAAdABQAAAAAAAAAAAAcABUAAAAAAAAAAAAdABUAAAAAAAAAAAAeABUAAAAAAAAAAAAfABUAAAAAAAAAAAAfABYAAAAAAAAAAAAeABYAAAAAAAAAAAAdABYAAAAAAAAAAAAcABYAAAAAAAAAAAAdABcAAAAAAAAAAAAeABcAAAAAAAAAAAAfABcAAAAAAAAAAAAeABgAAAAAAAAAAAAfABgAAAAAAAAAAAAWABcAAAAAAAAAAAAWABgAAAAAAAAAAAAXABgAAAAAAAAAAAAYABgAAAAAAAAAAAAYABcAAAAAAAAAAAAXABcAAAAAAAAAAAAYABkAAAAAAAAAAAAXABkAAAAAAAAAAAAYABoAAAAAAAAAAAAZABkAAAAAAAAAAAAZABgAAAAAAAAAAAAZABoAAAAAAAAAAAAaABoAAAAAAAAAAAAXABoAAAAAAAAAAAAYABsAAAAAAAAAAAAZABsAAAAAAAAAAAAaABsAAAAAAAAAAAAbABsAAAAAAAAAAAAcABsAAAAAAAAAAAAdABsAAAAAAAAAAQAeABsAAAAAAAAAAQAfABsAAAAAAAAAAQAdABwAAAAAAAAAAQAeABwAAAAAAAAAAAAfABwAAAAAAAAAAAAAABYAAAAAAAAAAAAAABcAAAAAAAAAAAABABUAAAAAAAAAAgAAABUAAAAAAAAAAgAbABYAAAAAAAAAAgD//xcAAAAAAAAAAAD//xgAAAAAAAAAAAD//xkAAAAAAAAAAAD//xoAAAAAAAAAAAD//xsAAAAAAAAAAAD//xwAAAAAAAAAAAAPABQAAAAAAAAAAQAPABUAAAAAAAAAAQAPABYAAAAAAAAAAQAbABQAAAAAAAAAAQAbABUAAAAAAAAAAQAAABgAAAAAAAAAAQABABgAAAAAAAAAAQACABgAAAAAAAAAAQADABgAAAAAAAAAAQAEABgAAAAAAAAAAQAFABgAAAAAAAAAAQAGABgAAAAAAAAAAQAHABgAAAAAAAAAAQAIABcAAAAAAAAAAQAJABcAAAAAAAAAAQAKABcAAAAAAAAAAQALABcAAAAAAAAAAQAMABcAAAAAAAAAAQANABcAAAAAAAAAAQAOABcAAAAAAAAAAQAPABcAAAAAAAAAAQAQABcAAAAAAAAAAQARABcAAAAAAAAAAQASABcAAAAAAAAAAQATABcAAAAAAAAAAQAUABcAAAAAAAAAAQAVABcAAAAAAAAAAQAVABgAAAAAAAAAAQAWABkAAAAAAAAAAQAWABoAAAAAAAAAAQAXABsAAAAAAAAAAQAXABwAAAAAAAAAAQAYABwAAAAAAAAAAQAZABwAAAAAAAAAAQAaABwAAAAAAAAAAQAbABwAAAAAAAAAAQAcABwAAAAAAAAAAQA=")
@@ -87,7 +86,6 @@ canvas_item = NodePath("..")
 metadata/_custom_type_script = "uid://ctko5bdas16ah"
 
 [node name="Foam" type="TileMapLayer" parent="TileMapLayers" unique_id=632936150]
-scale = Vector2(1.00113, 1)
 tile_map_data = PackedByteArray("AAAAABUAAgAAAAAAAAABABUAAgAAAAAAAAACABUAAgAAAAAAAAADABUAAgAAAAAAAAAEABUAAgAAAAAAAAAFABUAAgAAAAAAAAAGABUAAgAAAAAAAAAHABUAAgAAAAAAAAAHABQAAgAAAAAAAAAIABQAAgAAAAAAAAAJABQAAgAAAAAAAAAKABQAAgAAAAAAAAALABQAAgAAAAAAAAAMABQAAgAAAAAAAAANABQAAgAAAAAAAAAOABQAAgAAAAAAAAAPABQAAgAAAAAAAAAQABQAAgAAAAAAAAARABQAAgAAAAAAAAASABQAAgAAAAAAAAATABQAAgAAAAAAAAAUABQAAgAAAAAAAAAVABQAAgAAAAAAAAAWABQAAgAAAAAAAAAXABQAAgAAAAAAAAAYABQAAgAAAAAAAAAZABQAAgAAAAAAAAAaABQAAgAAAAAAAAAbABQAAgAAAAAAAAAcABQAAgAAAAAAAAAdABQAAgAAAAAAAAAeABQAAgAAAAAAAAAeABUAAgAAAAAAAAAfABUAAgAAAAAAAAAVABgAAgAAAAAAAAAAABkAAgAAAAAAAAAAABoAAgAAAAAAAAAAABsAAgAAAAAAAAAAABwAAgAAAAAAAAAAAB0AAgAAAAAAAAAAAB4AAgAAAAAAAAAAAB8AAgAAAAAAAAAVABkAAgAAAAAAAAAWABoAAgAAAAAAAAAVABoAAgAAAAAAAAAWABsAAgAAAAAAAAAfABwAAgAAAAAAAAAfAB0AAgAAAAAAAAAfAB4AAgAAAAAAAAAfAB8AAgAAAAAAAAA=")
 tile_set = ExtResource("5_ppslc")
 
@@ -161,7 +159,7 @@ target = NodePath(".")
 y_sort_enabled = true
 
 [node name="Player" parent="OnTheGround" unique_id=322121009 instance=ExtResource("3_tp7qs")]
-position = Vector2(985, 871)
+position = Vector2(985, 863)
 player_name = "StoryWeaver"
 sprite_frames = ExtResource("6_06x6x")
 
@@ -178,7 +176,7 @@ y_sort_enabled = true
 
 [node name="Flowerbed" type="Area2D" parent="OnTheGround/Props" unique_id=1756580895]
 y_sort_enabled = true
-position = Vector2(1358.05, 1693.82)
+position = Vector2(1358.05, 1685.82)
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="OnTheGround/Props/Flowerbed" unique_id=1572957504]
 polygon = PackedVector2Array(80.9502, -52.8169, 81.9502, 73.1831, 145.95, 74.1831, 146.95, 134.183, 476.95, 136.183, 480.95, 204.183, -87.05, 210.18, -91.05, -178.82, 10.95, -176.82, 11.649, -54.5072)
@@ -241,124 +239,124 @@ position = Vector2(290.57, 206.026)
 position = Vector2(465.862, 159.547)
 
 [node name="HidingMushroom" parent="OnTheGround/Props" unique_id=806733559 instance=ExtResource("11_jqkod")]
-position = Vector2(906, 1516)
+position = Vector2(906, 1508)
 
 [node name="HidingMushroom2" parent="OnTheGround/Props" unique_id=320834486 instance=ExtResource("11_jqkod")]
-position = Vector2(1061, 1643)
+position = Vector2(1061, 1635)
 
 [node name="HidingMushroom3" parent="OnTheGround/Props" unique_id=47733831 instance=ExtResource("11_jqkod")]
-position = Vector2(929, 1235)
+position = Vector2(929, 1227)
 
 [node name="HidingMushroom4" parent="OnTheGround/Props" unique_id=631928334 instance=ExtResource("11_jqkod")]
-position = Vector2(1049, 1193)
+position = Vector2(1049, 1185)
 
 [node name="Books" parent="OnTheGround/Props" unique_id=605503809 instance=ExtResource("12_06x6x")]
-position = Vector2(616, 611)
+position = Vector2(616, 603)
 flip_h = true
 
 [node name="Books2" parent="OnTheGround/Props" unique_id=684398653 instance=ExtResource("12_06x6x")]
-position = Vector2(584, 597)
+position = Vector2(584, 589)
 
 [node name="Books3" parent="OnTheGround/Props" unique_id=78212091 instance=ExtResource("12_06x6x")]
-position = Vector2(625, 587)
+position = Vector2(625, 579)
 
 [node name="Books4" parent="OnTheGround/Props" unique_id=1621819696 instance=ExtResource("12_06x6x")]
-position = Vector2(615, 611)
+position = Vector2(615, 603)
 texture = ExtResource("13_xt3dw")
 offset = Vector2(0, -32)
 
 [node name="Books5" parent="OnTheGround/Props" unique_id=392060181 instance=ExtResource("12_06x6x")]
-position = Vector2(1390, 607)
+position = Vector2(1390, 599)
 texture = ExtResource("13_xt3dw")
 flip_h = true
 
 [node name="Books6" parent="OnTheGround/Props" unique_id=2006272186 instance=ExtResource("12_06x6x")]
-position = Vector2(1380, 606)
+position = Vector2(1380, 598)
 offset = Vector2(0, -38.745)
 
 [node name="Books7" parent="OnTheGround/Props" unique_id=895530811 instance=ExtResource("12_06x6x")]
-position = Vector2(1217, 596)
+position = Vector2(1217, 588)
 texture = ExtResource("13_xt3dw")
 
 [node name="Books8" parent="OnTheGround/Props" unique_id=109380584 instance=ExtResource("12_06x6x")]
-position = Vector2(1247, 583)
+position = Vector2(1247, 575)
 flip_h = true
 
 [node name="Books9" parent="OnTheGround/Props" unique_id=725853317 instance=ExtResource("12_06x6x")]
-position = Vector2(764, 593)
+position = Vector2(764, 585)
 texture = ExtResource("13_xt3dw")
 flip_h = true
 
 [node name="Books10" parent="OnTheGround/Props" unique_id=275297103 instance=ExtResource("12_06x6x")]
-position = Vector2(781, 614)
+position = Vector2(781, 606)
 
 [node name="Mushroom" type="Sprite2D" parent="OnTheGround/Props" unique_id=1958366461]
-position = Vector2(501, 679)
+position = Vector2(501, 671)
 texture = ExtResource("28_6r0j2")
 
 [node name="Buildings" type="Node2D" parent="OnTheGround" unique_id=1875429791]
 y_sort_enabled = true
 
 [node name="House_1" parent="OnTheGround/Buildings" unique_id=1159586657 instance=ExtResource("5_5jg1p")]
-position = Vector2(1600, 815)
+position = Vector2(1600, 807)
 texture = ExtResource("5_uhynt")
 
 [node name="House_2" parent="OnTheGround/Buildings" unique_id=821648560 instance=ExtResource("15_uhynt")]
-position = Vector2(1760, 810)
+position = Vector2(1760, 802)
 texture = ExtResource("5_uojly")
 
 [node name="House_3" parent="OnTheGround/Buildings" unique_id=2108055439 instance=ExtResource("5_5jg1p")]
-position = Vector2(316, 1043)
+position = Vector2(316, 1035)
 
 [node name="House_4" parent="OnTheGround/Buildings" unique_id=1336347029 instance=ExtResource("15_uhynt")]
-position = Vector2(352, 673)
+position = Vector2(352, 665)
 texture = ExtResource("6_uhynt")
 
 [node name="House_5" parent="OnTheGround/Buildings" unique_id=32389067 instance=ExtResource("5_5jg1p")]
-position = Vector2(176, 626)
+position = Vector2(176, 618)
 texture = ExtResource("6_ojp30")
 
 [node name="House_6" parent="OnTheGround/Buildings" unique_id=1538226071 instance=ExtResource("5_5jg1p")]
-position = Vector2(227, 832)
+position = Vector2(227, 824)
 texture = ExtResource("5_uhynt")
 
 [node name="House_7" parent="OnTheGround/Buildings" unique_id=2109293750 instance=ExtResource("5_5jg1p")]
-position = Vector2(1565, 1110)
+position = Vector2(1565, 1102)
 
 [node name="House_8" parent="OnTheGround/Buildings" unique_id=2122984790 instance=ExtResource("15_uhynt")]
-position = Vector2(480, 1043)
+position = Vector2(480, 1035)
 
 [node name="House_9" parent="OnTheGround/Buildings" unique_id=679799188 instance=ExtResource("5_5jg1p")]
-position = Vector2(781, 1095)
+position = Vector2(781, 1087)
 texture = ExtResource("5_uhynt")
 
 [node name="House_10" parent="OnTheGround/Buildings" unique_id=1796299989 instance=ExtResource("5_5jg1p")]
-position = Vector2(1758, 1185)
+position = Vector2(1758, 1177)
 texture = ExtResource("5_uhynt")
 
 [node name="NPCs" type="Node2D" parent="OnTheGround" unique_id=1415886134]
 y_sort_enabled = true
 
 [node name="LoreQuestElder" parent="OnTheGround/NPCs" unique_id=1976657330 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_xt3dw")]
-position = Vector2(690, 600)
+position = Vector2(690, 592)
 eternal_loom = NodePath("../../EternalLoom")
 
 [node name="StoryQuestElder" parent="OnTheGround/NPCs" unique_id=481001643 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_jqkod")]
-position = Vector2(1310, 598)
+position = Vector2(1310, 590)
 eternal_loom = NodePath("../../EternalLoom")
 
 [node name="TemplateElder" parent="OnTheGround/NPCs" unique_id=45322364 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("43_ppslc")]
-position = Vector2(1455, 493)
+position = Vector2(1455, 485)
 eternal_loom = NodePath("../../EternalLoom")
 
 [node name="Axeman" parent="OnTheGround/NPCs" unique_id=1020611644 instance=ExtResource("17_0a1i7")]
-position = Vector2(1506, 1263)
+position = Vector2(1506, 1255)
 
 [node name="Hammerman" parent="OnTheGround/NPCs" unique_id=1228849708 instance=ExtResource("19_yntpr")]
-position = Vector2(1663, 1102)
+position = Vector2(1663, 1094)
 
 [node name="Farmer" parent="OnTheGround/NPCs" unique_id=1098678013 instance=ExtResource("54_duxxr")]
-position = Vector2(1625, 625)
+position = Vector2(1625, 617)
 scale = Vector2(-1, 1)
 character_seed = 3442244821
 look_at_side = 1
@@ -382,13 +380,13 @@ shape = SubResource("RectangleShape2D_duxxr")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
 [node name="FarmersPartner" parent="OnTheGround/NPCs" unique_id=1246028381 instance=ExtResource("54_duxxr")]
-position = Vector2(1638, 841)
+position = Vector2(1638, 833)
 scale = Vector2(-1, 1)
 character_seed = 3260235337
 look_at_side = 1
 
 [node name="GardenerA" parent="OnTheGround/NPCs" unique_id=1887606289 instance=ExtResource("54_duxxr")]
-position = Vector2(199, 899)
+position = Vector2(199, 891)
 character_seed = 2422434786
 
 [node name="TalkBehavior" type="Node" parent="OnTheGround/NPCs/GardenerA" unique_id=1669484224 node_paths=PackedStringArray("interact_area", "extra_context")]
@@ -412,21 +410,21 @@ shape = SubResource("RectangleShape2D_duxxr")
 debug_color = Color(0.600391, 0.54335, 0, 0.42)
 
 [node name="GardenerB" parent="OnTheGround/NPCs" unique_id=514890698 instance=ExtResource("54_duxxr")]
-position = Vector2(268, 894)
+position = Vector2(268, 886)
 scale = Vector2(-1, 1)
 character_seed = 3363471871
 look_at_side = 1
 
 [node name="Cat" parent="OnTheGround/NPCs" unique_id=1091997689 instance=ExtResource("52_ppslc")]
-position = Vector2(267, 650)
+position = Vector2(267, 642)
 
 [node name="EternalLoom" parent="OnTheGround" unique_id=17061783 instance=ExtResource("16_ojp30")]
 unique_name_in_owner = true
-position = Vector2(993, 485)
+position = Vector2(993, 477)
 scale = Vector2(0.9, 0.9)
 
 [node name="ForestLimit" type="StaticBody2D" parent="OnTheGround" unique_id=1908977889]
-position = Vector2(972, 2047)
+position = Vector2(972, 2039)
 scale = Vector2(1.10441, 1.00725)
 collision_layer = 16
 collision_mask = 0
@@ -446,263 +444,263 @@ y_sort_enabled = true
 metadata/_edit_lock_ = true
 
 [node name="Tree" parent="OnTheGround/Trees" unique_id=1932501761 instance=ExtResource("7_7v00g")]
-position = Vector2(1376, 405)
+position = Vector2(1376, 397)
 scale = Vector2(1.001, 1.001)
 
 [node name="Tree3" parent="OnTheGround/Trees" unique_id=1678596388 instance=ExtResource("7_7v00g")]
-position = Vector2(323.669, 1963.03)
+position = Vector2(323.669, 1955.03)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree4" parent="OnTheGround/Trees" unique_id=530347632 instance=ExtResource("7_7v00g")]
-position = Vector2(689.696, 2027.02)
+position = Vector2(689.696, 2019.02)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree5" parent="OnTheGround/Trees" unique_id=1674843860 instance=ExtResource("7_7v00g")]
-position = Vector2(552.436, 1940.99)
+position = Vector2(552.436, 1932.99)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree6" parent="OnTheGround/Trees" unique_id=79446423 instance=ExtResource("7_7v00g")]
-position = Vector2(802.62, 1968.27)
+position = Vector2(802.62, 1960.27)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree7" parent="OnTheGround/Trees" unique_id=649963827 instance=ExtResource("7_7v00g")]
-position = Vector2(948.642, 1993.45)
+position = Vector2(948.642, 1985.45)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree8" parent="OnTheGround/Trees" unique_id=500116567 instance=ExtResource("7_7v00g")]
-position = Vector2(1178.38, 2021.78)
+position = Vector2(1178.38, 2013.78)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree10" parent="OnTheGround/Trees" unique_id=1207688304 instance=ExtResource("7_7v00g")]
-position = Vector2(1064.49, 2012.34)
+position = Vector2(1064.49, 2004.34)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree11" parent="OnTheGround/Trees" unique_id=1813349792 instance=ExtResource("7_7v00g")]
-position = Vector2(1669.99, 253.919)
+position = Vector2(1669.99, 245.919)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree12" parent="OnTheGround/Trees" unique_id=142989831 instance=ExtResource("7_7v00g")]
-position = Vector2(1083.96, 1949.38)
+position = Vector2(1083.96, 1941.38)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree13" parent="OnTheGround/Trees" unique_id=831282679 instance=ExtResource("7_7v00g")]
-position = Vector2(1234.84, 2008.14)
+position = Vector2(1234.84, 2000.14)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree14" parent="OnTheGround/Trees" unique_id=1307485281 instance=ExtResource("7_7v00g")]
-position = Vector2(1875.39, 905.457)
+position = Vector2(1875.39, 897.457)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree15" parent="OnTheGround/Trees" unique_id=2053677081 instance=ExtResource("7_7v00g")]
-position = Vector2(1389.63, 1982.96)
+position = Vector2(1389.63, 1974.96)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree16" parent="OnTheGround/Trees" unique_id=2124166383 instance=ExtResource("7_7v00g")]
-position = Vector2(403.493, 416.541)
+position = Vector2(403.493, 408.541)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree17" parent="OnTheGround/Trees" unique_id=1427257925 instance=ExtResource("7_7v00g")]
-position = Vector2(402.52, 467.951)
+position = Vector2(402.52, 459.951)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree74" parent="OnTheGround/Trees" unique_id=1148920514 instance=ExtResource("7_7v00g")]
-position = Vector2(702, 529)
+position = Vector2(702, 521)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree18" parent="OnTheGround/Trees" unique_id=1024302850 instance=ExtResource("7_7v00g")]
-position = Vector2(479.425, 461.655)
+position = Vector2(479.425, 453.655)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree19" parent="OnTheGround/Trees" unique_id=549093584 instance=ExtResource("7_7v00g")]
-position = Vector2(489.16, 403.951)
+position = Vector2(489.16, 395.951)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree73" parent="OnTheGround/Trees" unique_id=202446030 instance=ExtResource("7_7v00g")]
-position = Vector2(489.16, 403.951)
+position = Vector2(489.16, 395.951)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree20" parent="OnTheGround/Trees" unique_id=1987312795 instance=ExtResource("7_7v00g")]
-position = Vector2(747.132, 464.803)
+position = Vector2(747.132, 456.803)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree21" parent="OnTheGround/Trees" unique_id=1909086150 instance=ExtResource("7_7v00g")]
-position = Vector2(548.542, 376.672)
+position = Vector2(548.542, 368.672)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree23" parent="OnTheGround/Trees" unique_id=565373046 instance=ExtResource("7_7v00g")]
-position = Vector2(559.25, 445.918)
+position = Vector2(559.25, 437.918)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree71" parent="OnTheGround/Trees" unique_id=508746342 instance=ExtResource("7_7v00g")]
-position = Vector2(1322, 535)
+position = Vector2(1322, 527)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree24" parent="OnTheGround/Trees" unique_id=1413823818 instance=ExtResource("7_7v00g")]
-position = Vector2(411.281, 1993.45)
+position = Vector2(411.281, 1985.45)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree25" parent="OnTheGround/Trees" unique_id=622131440 instance=ExtResource("7_7v00g")]
-position = Vector2(1426.62, 377.721)
+position = Vector2(1426.62, 369.721)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree26" parent="OnTheGround/Trees" unique_id=1149585713 instance=ExtResource("7_7v00g")]
-position = Vector2(878.552, 2013.39)
+position = Vector2(878.552, 2005.39)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree30" parent="OnTheGround/Trees" unique_id=1360494059 instance=ExtResource("7_7v00g")]
-position = Vector2(960.324, 2041.72)
+position = Vector2(960.324, 2033.72)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree31" parent="OnTheGround/Trees" unique_id=217219671 instance=ExtResource("7_7v00g")]
-position = Vector2(1377.95, 1170.9)
+position = Vector2(1377.95, 1162.9)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree32" parent="OnTheGround/Trees" unique_id=921811469 instance=ExtResource("7_7v00g")]
-position = Vector2(1160.86, 1940.99)
+position = Vector2(1160.86, 1932.99)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree33" parent="OnTheGround/Trees" unique_id=275476476 instance=ExtResource("7_7v00g")]
-position = Vector2(1744.95, 308.476)
+position = Vector2(1744.95, 300.476)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree36" parent="OnTheGround/Trees" unique_id=1997957129 instance=ExtResource("7_7v00g")]
-position = Vector2(1510.34, 380.869)
+position = Vector2(1510.34, 372.869)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree37" parent="OnTheGround/Trees" unique_id=1733761308 instance=ExtResource("7_7v00g")]
-position = Vector2(1579.46, 346.246)
+position = Vector2(1579.46, 338.246)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree38" parent="OnTheGround/Trees" unique_id=794097989 instance=ExtResource("7_7v00g")]
-position = Vector2(78.3536, 2020.73)
+position = Vector2(78.3536, 2012.73)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree39" parent="OnTheGround/Trees" unique_id=1427896511 instance=ExtResource("7_7v00g")]
-position = Vector2(1289.36, 410.246)
+position = Vector2(1289.36, 402.246)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree41" parent="OnTheGround/Trees" unique_id=1126274595 instance=ExtResource("7_7v00g")]
-position = Vector2(1093.69, 352.541)
+position = Vector2(1093.69, 344.541)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree42" parent="OnTheGround/Trees" unique_id=1219058508 instance=ExtResource("7_7v00g")]
-position = Vector2(240.926, 446.967)
+position = Vector2(240.926, 438.967)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree45" parent="OnTheGround/Trees" unique_id=1331885057 instance=ExtResource("7_7v00g")]
-position = Vector2(343.138, 414.443)
+position = Vector2(343.138, 406.443)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree46" parent="OnTheGround/Trees" unique_id=1299102072 instance=ExtResource("7_7v00g")]
-position = Vector2(281.807, 405)
+position = Vector2(281.807, 397)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree47" parent="OnTheGround/Trees" unique_id=1431325735 instance=ExtResource("7_7v00g")]
-position = Vector2(743.238, 1993.45)
+position = Vector2(743.238, 1985.45)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree48" parent="OnTheGround/Trees" unique_id=512917549 instance=ExtResource("7_7v00g")]
-position = Vector2(129.945, 1990.3)
+position = Vector2(129.945, 1982.3)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree49" parent="OnTheGround/Trees" unique_id=984311786 instance=ExtResource("7_7v00g")]
-position = Vector2(1439, 1255)
+position = Vector2(1439, 1247)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree76" parent="OnTheGround/Trees" unique_id=371398351 instance=ExtResource("7_7v00g")]
-position = Vector2(740.431, 174.365)
+position = Vector2(740.431, 166.365)
 scale = Vector2(1.003, 1.003)
 
 [node name="Tree50" parent="OnTheGround/Trees" unique_id=1448306675 instance=ExtResource("7_7v00g")]
-position = Vector2(1249.45, 467.951)
+position = Vector2(1249.45, 459.951)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree51" parent="OnTheGround/Trees" unique_id=1240948872 instance=ExtResource("7_7v00g")]
-position = Vector2(1339.01, 374.574)
+position = Vector2(1339.01, 366.574)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree52" parent="OnTheGround/Trees" unique_id=233056165 instance=ExtResource("7_7v00g")]
-position = Vector2(224.37, 2044.86)
+position = Vector2(224.37, 2036.86)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree53" parent="OnTheGround/Trees" unique_id=1003033914 instance=ExtResource("7_7v00g")]
-position = Vector2(614.738, 1989.25)
+position = Vector2(614.738, 1981.25)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree54" parent="OnTheGround/Trees" unique_id=2052048686 instance=ExtResource("7_7v00g")]
-position = Vector2(1807.25, 354.64)
+position = Vector2(1807.25, 346.64)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree55" parent="OnTheGround/Trees" unique_id=539355872 instance=ExtResource("7_7v00g")]
-position = Vector2(1610.61, 248.673)
+position = Vector2(1610.61, 240.673)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree56" parent="OnTheGround/Trees" unique_id=1903601485 instance=ExtResource("7_7v00g")]
-position = Vector2(1850, 829)
+position = Vector2(1850, 821)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree57" parent="OnTheGround/Trees" unique_id=1346125759 instance=ExtResource("7_7v00g")]
-position = Vector2(1464.59, 1990.3)
+position = Vector2(1464.59, 1982.3)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree58" parent="OnTheGround/Trees" unique_id=2117949852 instance=ExtResource("7_7v00g")]
-position = Vector2(1318.56, 1994.5)
+position = Vector2(1318.56, 1986.5)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree59" parent="OnTheGround/Trees" unique_id=1111374746 instance=ExtResource("7_7v00g")]
-position = Vector2(1617.42, 1995.55)
+position = Vector2(1617.42, 1987.55)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree60" parent="OnTheGround/Trees" unique_id=1733767052 instance=ExtResource("7_7v00g")]
-position = Vector2(1494.76, 1998.69)
+position = Vector2(1494.76, 1990.69)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree61" parent="OnTheGround/Trees" unique_id=1069014224 instance=ExtResource("7_7v00g")]
-position = Vector2(1816.99, 1967.22)
+position = Vector2(1816.99, 1959.22)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree62" parent="OnTheGround/Trees" unique_id=161458005 instance=ExtResource("7_7v00g")]
-position = Vector2(1758.58, 1981.91)
+position = Vector2(1758.58, 1973.91)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree63" parent="OnTheGround/Trees" unique_id=2128417183 instance=ExtResource("7_7v00g")]
-position = Vector2(695.537, 431.229)
+position = Vector2(695.537, 423.229)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree64" parent="OnTheGround/Trees" unique_id=1470271340 instance=ExtResource("7_7v00g")]
-position = Vector2(630.314, 421.787)
+position = Vector2(630.314, 413.787)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree65" parent="OnTheGround/Trees" unique_id=1237537773 instance=ExtResource("7_7v00g")]
-position = Vector2(873.684, 459.557)
+position = Vector2(873.684, 451.557)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree66" parent="OnTheGround/Trees" unique_id=192479901 instance=ExtResource("7_7v00g")]
-position = Vector2(814.302, 473.196)
+position = Vector2(814.302, 465.196)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree72" parent="OnTheGround/Trees" unique_id=30595985 instance=ExtResource("7_7v00g")]
-position = Vector2(138.704, 1164.6)
+position = Vector2(138.704, 1156.6)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree75" parent="OnTheGround/Trees" unique_id=1265010944 instance=ExtResource("7_7v00g")]
-position = Vector2(384.998, 1028.21)
+position = Vector2(384.998, 1020.21)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree67" parent="OnTheGround/Trees" unique_id=1384953353 instance=ExtResource("7_7v00g")]
-position = Vector2(1951, 552)
+position = Vector2(1951, 544)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree68" parent="OnTheGround/Trees" unique_id=2100997314 instance=ExtResource("7_7v00g")]
-position = Vector2(478.451, 1988.2)
+position = Vector2(478.451, 1980.2)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree69" parent="OnTheGround/Trees" unique_id=877766008 instance=ExtResource("7_7v00g")]
-position = Vector2(176.672, 2049.05)
+position = Vector2(176.672, 2041.05)
 scale = Vector2(1.002, 1.002)
 
 [node name="Tree70" parent="OnTheGround/Trees" unique_id=1280154167 instance=ExtResource("7_7v00g")]
-position = Vector2(1173.52, 441.721)
+position = Vector2(1173.52, 433.721)
 scale = Vector2(1.002, 1.002)
 
 [node name="Bushes" type="Node2D" parent="OnTheGround" unique_id=2142789308]
@@ -710,331 +708,331 @@ y_sort_enabled = true
 metadata/_edit_lock_ = true
 
 [node name="Bush" parent="OnTheGround/Bushes" unique_id=691594667 instance=ExtResource("18_yntpr")]
-position = Vector2(720, 1111)
+position = Vector2(720, 1103)
 
 [node name="Bush2" parent="OnTheGround/Bushes" unique_id=674809064 instance=ExtResource("18_yntpr")]
-position = Vector2(702, 1128)
+position = Vector2(702, 1120)
 scale = Vector2(0.4, 0.4)
 
 [node name="Bush3" parent="OnTheGround/Bushes" unique_id=1790836883 instance=ExtResource("18_yntpr")]
-position = Vector2(1813, 1197)
+position = Vector2(1813, 1189)
 
 [node name="Bush4" parent="OnTheGround/Bushes" unique_id=685970372 instance=ExtResource("18_yntpr")]
-position = Vector2(1828, 1225)
+position = Vector2(1828, 1217)
 scale = Vector2(0.8, 0.8)
 
 [node name="Bush5" parent="OnTheGround/Bushes" unique_id=1814837063 instance=ExtResource("18_yntpr")]
-position = Vector2(1803, 1275)
+position = Vector2(1803, 1267)
 scale = Vector2(0.6, 0.6)
 
 [node name="Bush6" parent="OnTheGround/Bushes" unique_id=681414570 instance=ExtResource("18_yntpr")]
-position = Vector2(225, 469)
+position = Vector2(225, 461)
 
 [node name="Bush7" parent="OnTheGround/Bushes" unique_id=507391137 instance=ExtResource("18_yntpr")]
-position = Vector2(242, 480)
+position = Vector2(242, 472)
 scale = Vector2(0.6, 0.6)
 
 [node name="Bush8" parent="OnTheGround/Bushes" unique_id=113159105 instance=ExtResource("18_yntpr")]
-position = Vector2(364, 480)
+position = Vector2(364, 472)
 scale = Vector2(0.6, 0.6)
 
 [node name="Bush9" parent="OnTheGround/Bushes" unique_id=991872612 instance=ExtResource("18_yntpr")]
-position = Vector2(192, 521)
+position = Vector2(192, 513)
 scale = Vector2(0.6, 0.6)
 
 [node name="Bush10" parent="OnTheGround/Bushes" unique_id=1741388599 instance=ExtResource("18_yntpr")]
-position = Vector2(383, 485)
+position = Vector2(383, 477)
 scale = Vector2(0.6, 0.6)
 
 [node name="Bush11" parent="OnTheGround/Bushes" unique_id=258553976 instance=ExtResource("18_yntpr")]
-position = Vector2(593, 402)
+position = Vector2(593, 394)
 
 [node name="Bush12" parent="OnTheGround/Bushes" unique_id=331374579 instance=ExtResource("18_yntpr")]
-position = Vector2(618, 392)
+position = Vector2(618, 384)
 
 [node name="Bush13" parent="OnTheGround/Bushes" unique_id=1819127771 instance=ExtResource("18_yntpr")]
-position = Vector2(703, 401)
+position = Vector2(703, 393)
 
 [node name="Bush14" parent="OnTheGround/Bushes" unique_id=1799152780 instance=ExtResource("18_yntpr")]
-position = Vector2(838, 479)
+position = Vector2(838, 471)
 
 [node name="Bush15" parent="OnTheGround/Bushes" unique_id=907391532 instance=ExtResource("18_yntpr")]
-position = Vector2(777, 572)
+position = Vector2(777, 564)
 scale = Vector2(0.8, 0.8)
 
 [node name="Bush17" parent="OnTheGround/Bushes" unique_id=2079878338 instance=ExtResource("18_yntpr")]
-position = Vector2(346, 1052)
+position = Vector2(346, 1044)
 scale = Vector2(0.5, 0.5)
 
 [node name="Bush18" parent="OnTheGround/Bushes" unique_id=500874609 instance=ExtResource("18_yntpr")]
-position = Vector2(346, 1066)
+position = Vector2(346, 1058)
 scale = Vector2(0.4, 0.4)
 
 [node name="Bush19" parent="OnTheGround/Bushes" unique_id=920262933 instance=ExtResource("18_yntpr")]
-position = Vector2(363, 1057)
+position = Vector2(363, 1049)
 scale = Vector2(0.6, 0.6)
 
 [node name="Bush20" parent="OnTheGround/Bushes" unique_id=39430491 instance=ExtResource("18_yntpr")]
-position = Vector2(287, 1050)
+position = Vector2(287, 1042)
 scale = Vector2(0.5, 0.5)
 
 [node name="Bush21" parent="OnTheGround/Bushes" unique_id=1989598020 instance=ExtResource("18_yntpr")]
-position = Vector2(265, 1047)
+position = Vector2(265, 1039)
 scale = Vector2(0.65, 0.65)
 
 [node name="Bush22" parent="OnTheGround/Bushes" unique_id=1585214049 instance=ExtResource("18_yntpr")]
-position = Vector2(255, 1033)
+position = Vector2(255, 1025)
 scale = Vector2(0.5, 0.5)
 
 [node name="Bush23" parent="OnTheGround/Bushes" unique_id=1086059623 instance=ExtResource("18_yntpr")]
-position = Vector2(370, 1035)
+position = Vector2(370, 1027)
 scale = Vector2(0.5, 0.5)
 
 [node name="Bush16" parent="OnTheGround/Bushes" unique_id=1299614484 instance=ExtResource("18_yntpr")]
-position = Vector2(663, 439)
+position = Vector2(663, 431)
 scale = Vector2(0.3, 0.3)
 
 [node name="Bush24" parent="OnTheGround/Bushes" unique_id=2096690297 instance=ExtResource("18_yntpr")]
-position = Vector2(298, 691)
+position = Vector2(298, 683)
 scale = Vector2(1.1, 1.1)
 
 [node name="Bush25" parent="OnTheGround/Bushes" unique_id=1620262277 instance=ExtResource("18_yntpr")]
-position = Vector2(263, 991)
+position = Vector2(263, 983)
 scale = Vector2(1.1, 1.1)
 
 [node name="Bush26" parent="OnTheGround/Bushes" unique_id=1628581492 instance=ExtResource("18_yntpr")]
-position = Vector2(127, 1149)
+position = Vector2(127, 1141)
 scale = Vector2(1.1, 1.1)
 
 [node name="Bush27" parent="OnTheGround/Bushes" unique_id=825955768 instance=ExtResource("18_yntpr")]
-position = Vector2(1054, 1520)
+position = Vector2(1054, 1512)
 scale = Vector2(1.1, 1.1)
 
 [node name="Bush30" parent="OnTheGround/Bushes" unique_id=1876568460 instance=ExtResource("18_yntpr")]
 y_sort_enabled = true
-position = Vector2(1166, 1155)
+position = Vector2(1166, 1147)
 scale = Vector2(1.1, 1.1)
 
 [node name="Bush31" parent="OnTheGround/Bushes" unique_id=274647831 instance=ExtResource("18_yntpr")]
 y_sort_enabled = true
-position = Vector2(1150, 1120)
+position = Vector2(1150, 1112)
 scale = Vector2(0.9, 0.9)
 
 [node name="Bush32" parent="OnTheGround/Bushes" unique_id=1448795033 instance=ExtResource("18_yntpr")]
 y_sort_enabled = true
-position = Vector2(1253, 1134)
+position = Vector2(1253, 1126)
 scale = Vector2(1.1, 1.1)
 
 [node name="Bush28" parent="OnTheGround/Bushes" unique_id=2046022114 instance=ExtResource("18_yntpr")]
-position = Vector2(1074, 1548)
+position = Vector2(1074, 1540)
 scale = Vector2(0.8, 0.8)
 
 [node name="Bush29" parent="OnTheGround/Bushes" unique_id=1996658338 instance=ExtResource("18_yntpr")]
-position = Vector2(280, 1698)
+position = Vector2(280, 1690)
 scale = Vector2(1.1, 1.1)
 
 [node name="Bush65" parent="OnTheGround/Bushes" unique_id=1084107524 instance=ExtResource("18_yntpr")]
-position = Vector2(270, 1729)
+position = Vector2(270, 1721)
 scale = Vector2(0.8, 0.8)
 
 [node name="Tomatoes" type="Node2D" parent="OnTheGround" unique_id=1216935970]
 y_sort_enabled = true
 
 [node name="Tomato" parent="OnTheGround/Tomatoes" unique_id=1417180670 instance=ExtResource("39_ljovl")]
-position = Vector2(1571, 619)
+position = Vector2(1571, 611)
 
 [node name="Tomato2" parent="OnTheGround/Tomatoes" unique_id=414353665 instance=ExtResource("39_ljovl")]
-position = Vector2(310, 807)
+position = Vector2(310, 799)
 
 [node name="Tomato3" parent="OnTheGround/Tomatoes" unique_id=563242510 instance=ExtResource("39_ljovl")]
-position = Vector2(348, 819)
+position = Vector2(348, 811)
 
 [node name="Carrots" type="Node2D" parent="OnTheGround" unique_id=1524389710]
 y_sort_enabled = true
 
 [node name="Carrot" parent="OnTheGround/Carrots" unique_id=1056869770 instance=ExtResource("42_ljovl")]
-position = Vector2(1563, 417)
+position = Vector2(1563, 409)
 
 [node name="Carrot2" parent="OnTheGround/Carrots" unique_id=1916365556 instance=ExtResource("42_ljovl")]
-position = Vector2(1700, 417)
+position = Vector2(1700, 409)
 
 [node name="Carrot3" parent="OnTheGround/Carrots" unique_id=2132997827 instance=ExtResource("42_ljovl")]
-position = Vector2(1667, 417)
+position = Vector2(1667, 409)
 
 [node name="Carrot4" parent="OnTheGround/Carrots" unique_id=109758211 instance=ExtResource("42_ljovl")]
-position = Vector2(1632, 417)
+position = Vector2(1632, 409)
 
 [node name="Carrot5" parent="OnTheGround/Carrots" unique_id=610508846 instance=ExtResource("42_ljovl")]
-position = Vector2(1599, 417)
+position = Vector2(1599, 409)
 
 [node name="Carrot6" parent="OnTheGround/Carrots" unique_id=1940457300 instance=ExtResource("42_ljovl")]
-position = Vector2(1667, 468)
+position = Vector2(1667, 460)
 
 [node name="Carrot7" parent="OnTheGround/Carrots" unique_id=222111516 instance=ExtResource("42_ljovl")]
-position = Vector2(1599, 443)
+position = Vector2(1599, 435)
 
 [node name="Carrot8" parent="OnTheGround/Carrots" unique_id=844021272 instance=ExtResource("42_ljovl")]
-position = Vector2(1700, 443)
+position = Vector2(1700, 435)
 
 [node name="Carrot9" parent="OnTheGround/Carrots" unique_id=1267982260 instance=ExtResource("42_ljovl")]
-position = Vector2(1632, 443)
+position = Vector2(1632, 435)
 
 [node name="Carrot10" parent="OnTheGround/Carrots" unique_id=1863703007 instance=ExtResource("42_ljovl")]
-position = Vector2(1632, 468)
+position = Vector2(1632, 460)
 
 [node name="Carrot11" parent="OnTheGround/Carrots" unique_id=1394205731 instance=ExtResource("42_ljovl")]
-position = Vector2(1667, 443)
+position = Vector2(1667, 435)
 
 [node name="Carrot12" parent="OnTheGround/Carrots" unique_id=1624450720 instance=ExtResource("42_ljovl")]
-position = Vector2(1700, 469)
+position = Vector2(1700, 461)
 
 [node name="Carrot13" parent="OnTheGround/Carrots" unique_id=1059663737 instance=ExtResource("42_ljovl")]
-position = Vector2(1632, 495)
+position = Vector2(1632, 487)
 
 [node name="Carrot14" parent="OnTheGround/Carrots" unique_id=418701471 instance=ExtResource("42_ljovl")]
-position = Vector2(1563, 495)
+position = Vector2(1563, 487)
 
 [node name="Carrot15" parent="OnTheGround/Carrots" unique_id=1760950291 instance=ExtResource("42_ljovl")]
-position = Vector2(1599, 495)
+position = Vector2(1599, 487)
 
 [node name="Carrot16" parent="OnTheGround/Carrots" unique_id=1488315489 instance=ExtResource("42_ljovl")]
-position = Vector2(1563, 443)
+position = Vector2(1563, 435)
 
 [node name="Carrot17" parent="OnTheGround/Carrots" unique_id=1581919746 instance=ExtResource("42_ljovl")]
-position = Vector2(1700, 495)
+position = Vector2(1700, 487)
 
 [node name="Carrot18" parent="OnTheGround/Carrots" unique_id=911076394 instance=ExtResource("42_ljovl")]
-position = Vector2(1668, 495)
+position = Vector2(1668, 487)
 
 [node name="Carrot19" parent="OnTheGround/Carrots" unique_id=44580834 instance=ExtResource("42_ljovl")]
-position = Vector2(1563, 469)
+position = Vector2(1563, 461)
 
 [node name="Carrot20" parent="OnTheGround/Carrots" unique_id=1299594892 instance=ExtResource("42_ljovl")]
-position = Vector2(1599, 468)
+position = Vector2(1599, 460)
 
 [node name="BarleyField" type="Node2D" parent="OnTheGround" unique_id=1870831195]
 y_sort_enabled = true
 
 [node name="Barley" parent="OnTheGround/BarleyField" unique_id=1837240364 instance=ExtResource("42_eodqy")]
-position = Vector2(400, 1176)
+position = Vector2(400, 1168)
 
 [node name="Barley2" parent="OnTheGround/BarleyField" unique_id=1289698623 instance=ExtResource("42_eodqy")]
-position = Vector2(432, 1176)
+position = Vector2(432, 1168)
 
 [node name="Barley3" parent="OnTheGround/BarleyField" unique_id=1975880228 instance=ExtResource("42_eodqy")]
-position = Vector2(464, 1176)
+position = Vector2(464, 1168)
 
 [node name="Barley4" parent="OnTheGround/BarleyField" unique_id=839588657 instance=ExtResource("42_eodqy")]
-position = Vector2(496, 1176)
+position = Vector2(496, 1168)
 
 [node name="Barley5" parent="OnTheGround/BarleyField" unique_id=224088482 instance=ExtResource("42_eodqy")]
-position = Vector2(400, 1208)
+position = Vector2(400, 1200)
 
 [node name="Barley6" parent="OnTheGround/BarleyField" unique_id=1934226171 instance=ExtResource("42_eodqy")]
-position = Vector2(432, 1208)
+position = Vector2(432, 1200)
 
 [node name="Barley7" parent="OnTheGround/BarleyField" unique_id=549737272 instance=ExtResource("42_eodqy")]
-position = Vector2(464, 1208)
+position = Vector2(464, 1200)
 
 [node name="Barley8" parent="OnTheGround/BarleyField" unique_id=2045741632 instance=ExtResource("42_eodqy")]
-position = Vector2(496, 1208)
+position = Vector2(496, 1200)
 
 [node name="Barley9" parent="OnTheGround/BarleyField" unique_id=538175638 instance=ExtResource("42_eodqy")]
-position = Vector2(416, 1192)
+position = Vector2(416, 1184)
 
 [node name="Barley10" parent="OnTheGround/BarleyField" unique_id=1071950050 instance=ExtResource("42_eodqy")]
-position = Vector2(448, 1192)
+position = Vector2(448, 1184)
 
 [node name="Barley11" parent="OnTheGround/BarleyField" unique_id=1825484614 instance=ExtResource("42_eodqy")]
-position = Vector2(480, 1192)
+position = Vector2(480, 1184)
 
 [node name="Barley12" parent="OnTheGround/BarleyField" unique_id=375805475 instance=ExtResource("42_eodqy")]
-position = Vector2(512, 1192)
+position = Vector2(512, 1184)
 
 [node name="Barley13" parent="OnTheGround/BarleyField" unique_id=471895812 instance=ExtResource("42_eodqy")]
-position = Vector2(528, 1176)
+position = Vector2(528, 1168)
 
 [node name="Barley15" parent="OnTheGround/BarleyField" unique_id=685489223 instance=ExtResource("42_eodqy")]
-position = Vector2(560, 1176)
+position = Vector2(560, 1168)
 
 [node name="Barley16" parent="OnTheGround/BarleyField" unique_id=1341055599 instance=ExtResource("42_eodqy")]
-position = Vector2(592, 1176)
+position = Vector2(592, 1168)
 
 [node name="Barley17" parent="OnTheGround/BarleyField" unique_id=87788605 instance=ExtResource("42_eodqy")]
-position = Vector2(624, 1176)
+position = Vector2(624, 1168)
 
 [node name="Barley18" parent="OnTheGround/BarleyField" unique_id=1352773935 instance=ExtResource("42_eodqy")]
-position = Vector2(528, 1208)
+position = Vector2(528, 1200)
 
 [node name="Barley19" parent="OnTheGround/BarleyField" unique_id=79238951 instance=ExtResource("42_eodqy")]
-position = Vector2(560, 1208)
+position = Vector2(560, 1200)
 
 [node name="Barley20" parent="OnTheGround/BarleyField" unique_id=751860807 instance=ExtResource("42_eodqy")]
-position = Vector2(592, 1208)
+position = Vector2(592, 1200)
 
 [node name="Barley21" parent="OnTheGround/BarleyField" unique_id=1102146350 instance=ExtResource("42_eodqy")]
-position = Vector2(624, 1208)
+position = Vector2(624, 1200)
 
 [node name="Barley22" parent="OnTheGround/BarleyField" unique_id=614595146 instance=ExtResource("42_eodqy")]
-position = Vector2(544, 1192)
+position = Vector2(544, 1184)
 
 [node name="Barley23" parent="OnTheGround/BarleyField" unique_id=198452717 instance=ExtResource("42_eodqy")]
-position = Vector2(576, 1192)
+position = Vector2(576, 1184)
 
 [node name="Barley24" parent="OnTheGround/BarleyField" unique_id=835543798 instance=ExtResource("42_eodqy")]
-position = Vector2(608, 1192)
+position = Vector2(608, 1184)
 
 [node name="Barley25" parent="OnTheGround/BarleyField" unique_id=526955960 instance=ExtResource("42_eodqy")]
-position = Vector2(640, 1192)
+position = Vector2(640, 1184)
 
 [node name="Barley14" parent="OnTheGround/BarleyField" unique_id=83830217 instance=ExtResource("42_eodqy")]
-position = Vector2(656, 1176)
+position = Vector2(656, 1168)
 
 [node name="Barley26" parent="OnTheGround/BarleyField" unique_id=2072105437 instance=ExtResource("42_eodqy")]
-position = Vector2(688, 1176)
+position = Vector2(688, 1168)
 
 [node name="Barley27" parent="OnTheGround/BarleyField" unique_id=1155363070 instance=ExtResource("42_eodqy")]
-position = Vector2(656, 1208)
+position = Vector2(656, 1200)
 
 [node name="Barley28" parent="OnTheGround/BarleyField" unique_id=1542366425 instance=ExtResource("42_eodqy")]
-position = Vector2(688, 1208)
+position = Vector2(688, 1200)
 
 [node name="Barley29" parent="OnTheGround/BarleyField" unique_id=1961323276 instance=ExtResource("42_eodqy")]
-position = Vector2(672, 1192)
+position = Vector2(672, 1184)
 
 [node name="Rocks" type="Node2D" parent="OnTheGround" unique_id=1924548706]
 y_sort_enabled = true
 
 [node name="Rock" parent="OnTheGround/Rocks" unique_id=890604313 instance=ExtResource("18_jbsab")]
-position = Vector2(91, 1256)
+position = Vector2(91, 1248)
 
 [node name="Rock2" parent="OnTheGround/Rocks" unique_id=762180858 instance=ExtResource("18_jbsab")]
-position = Vector2(97, 1240)
+position = Vector2(97, 1232)
 scale = Vector2(1.1, 1.1)
 
 [node name="Rock3" parent="OnTheGround/Rocks" unique_id=1836828759 instance=ExtResource("18_jbsab")]
-position = Vector2(97, 1240)
+position = Vector2(97, 1232)
 rotation = -1.04809
 scale = Vector2(1.1, 1.1)
 
 [node name="Rock4" parent="OnTheGround/Rocks" unique_id=1590479870 instance=ExtResource("18_jbsab")]
-position = Vector2(422, 1045)
+position = Vector2(422, 1037)
 scale = Vector2(0.9, 0.9)
 
 [node name="Rock5" parent="OnTheGround/Rocks" unique_id=626363495 instance=ExtResource("18_jbsab")]
-position = Vector2(1720, 513)
+position = Vector2(1720, 505)
 scale = Vector2(0.9, 0.9)
 
 [node name="Rock6" parent="OnTheGround/Rocks" unique_id=2113232597 instance=ExtResource("18_jbsab")]
-position = Vector2(1960, 1075)
+position = Vector2(1960, 1067)
 scale = Vector2(0.9, 0.9)
 
 [node name="Rock7" parent="OnTheGround/Rocks" unique_id=861958038 instance=ExtResource("18_jbsab")]
-position = Vector2(1948, 1063)
+position = Vector2(1948, 1055)
 scale = Vector2(1.1, 1.1)
 
 [node name="Rock8" parent="OnTheGround/Rocks" unique_id=307232558 instance=ExtResource("18_jbsab")]
-position = Vector2(1529, 828)
+position = Vector2(1529, 820)
 scale = Vector2(1.05, 1.05)
 
 [node name="WaterRocks" type="Node2D" parent="OnTheGround" unique_id=493156613]
@@ -1042,22 +1040,22 @@ editor_description = "Holds rocks that are in the water."
 y_sort_enabled = true
 
 [node name="WaterRock" parent="OnTheGround/WaterRocks" unique_id=198443660 instance=ExtResource("38_jqkod")]
-position = Vector2(931, 1378)
+position = Vector2(931, 1370)
 
 [node name="WaterRock2" parent="OnTheGround/WaterRocks" unique_id=286434874 instance=ExtResource("38_jqkod")]
-position = Vector2(708, 1437)
+position = Vector2(708, 1429)
 
 [node name="WaterRock3" parent="OnTheGround/WaterRocks" unique_id=1901788172 instance=ExtResource("38_jqkod")]
-position = Vector2(1578, 1477)
+position = Vector2(1578, 1469)
 
 [node name="WaterRock4" parent="OnTheGround/WaterRocks" unique_id=1688358840 instance=ExtResource("38_jqkod")]
-position = Vector2(1689, 1694)
+position = Vector2(1689, 1686)
 
 [node name="Tutorial" type="Node2D" parent="OnTheGround" unique_id=1760774148]
 y_sort_enabled = true
 
 [node name="TutorialGuy" parent="OnTheGround/Tutorial" unique_id=618221375 instance=ExtResource("54_duxxr")]
-position = Vector2(514, 1613)
+position = Vector2(514, 1605)
 scale = Vector2(-1, 1)
 character_seed = 2433932515
 look_at_side = 1
@@ -1092,13 +1090,13 @@ targets = [NodePath("../../../TileMapLayers/WestPathBarrierVoid")]
 required_quests = Array[ExtResource("59_qgpx3")]([ExtResource("60_6b07c")])
 
 [node name="SpawnPointWestPath" type="Marker2D" parent="OnTheGround/WestPath" unique_id=730185770 groups=["spawn_point"]]
-position = Vector2(57, 719)
+position = Vector2(57, 711)
 script = ExtResource("61_6b07c")
 look_at_side_on_spawn = 1
 metadata/_custom_type_script = "uid://0enyu5v4ra34"
 
 [node name="Teleporter" type="Area2D" parent="OnTheGround/WestPath" unique_id=39493186]
-position = Vector2(-63, 712)
+position = Vector2(-63, 704)
 collision_layer = 4
 script = ExtResource("62_t7c6s")
 next_scene = "uid://c3pi5sjiy5tlg"
@@ -1109,7 +1107,7 @@ metadata/_custom_type_script = "uid://hqdquinbimce"
 shape = SubResource("RectangleShape2D_ulm71")
 
 [node name="Sign" parent="OnTheGround/WestPath" unique_id=1579530966 instance=ExtResource("64_uxfrp")]
-position = Vector2(95, 664)
+position = Vector2(95, 656)
 text = "West End"
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="." unique_id=1752283368]


### PR DESCRIPTION
Remove scale from foam tilemap layer.

Remove 8 pixels vertical offset from the Node2D that contains all tilemap layers. Adjust OnTheGround nodes accordingly.