### PR TITLE
Cinematic: Always emit cinematic_finished

### DIFF
--- a/scenes/quests/lore_quests/quest_000/3_sequence_puzzle/components/tutorial_sequence_puzzle.gd
+++ b/scenes/quests/lore_quests/quest_000/3_sequence_puzzle/components/tutorial_sequence_puzzle.gd
@@ -8,7 +8,6 @@ extends Node2D
 
 
 func _ready() -> void:
-	if not GameState.intro_dialogue_shown:
-		await cinematic.cinematic_finished
+	await cinematic.cinematic_finished
 
 	tutorial_npc.walk_path()

--- a/scenes/ui_elements/cinematic/cinematic.gd
+++ b/scenes/ui_elements/cinematic/cinematic.gd
@@ -38,8 +38,9 @@ func start() -> void:
 	if not GameState.intro_dialogue_shown:
 		DialogueManager.show_dialogue_balloon(dialogue, "", [self])
 		await DialogueManager.dialogue_ended
-		cinematic_finished.emit()
 		GameState.intro_dialogue_shown = true
+
+	cinematic_finished.emit()
 
 	if next_scene:
 		(


### PR DESCRIPTION
Previously, `Cinematic.cinematic_finished` was only emitted if `intro_dialogue_shown` was false.

This makes it very easy to break game scenes: if you connect `Cinematic.cinematic_finished` to `FillGameLogic.start`, the scene works when the player first reaches it, but if they exit to title then continue the fill game never starts and so can't be finished.

Resolves https://github.com/endlessm/threadbare/issues/2244
