### PR TITLE
report_bug_button: Use full git describe --tags version

### DIFF
--- a/scenes/globals/pause/report_bug_button.gd
+++ b/scenes/globals/pause/report_bug_button.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 func _on_pressed() -> void:
 	var url := URL_BASE
 
-	var version := Version.get_version()
+	var version := Version.get_full_version()
 	if version:
 		url += "&version=" + version.uri_encode()
 


### PR DESCRIPTION
Since commit 848a9f607fd399c766774dec65b6c830185cc724 the version number
used when opening the bug report form has unintentionally been in the
simplified x.y.z.w form required by the Windows export, rather than the
`git describe --tags` output.
