### PR TITLE
Storybook: Handle playing NO_EDIT/quest.tres correctly

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -181,7 +181,10 @@ func _on_quest_button_pressed(button: Button) -> void:
 
 
 func _on_storybook_page_selected(quest: Quest) -> void:
-	selected.emit(quest)
+	if quest == TEMPLATE_QUEST_METADATA:
+		selected.emit(STORY_QUEST_TEMPLATE)
+	else:
+		selected.emit(quest)
 
 
 func _on_back_button_pressed() -> void:


### PR DESCRIPTION
Because scenes/quests/template_quests/NO_EDIT/quest.tres is
intentionally blank, the storybook handles it specially, displaying the
contents of scenes/menus/storybook/components/template_quest.tres
instead. However, previously the Storybook.selected() signal was emitted
with the latter, not the former.

The problem with that is that the logic in eternal_loom.gd that handles
being congratulated by the appropriate elder when returning from a
refreshing game of Sokoban tries to find the correct elder by matching
the quest's path against each elder's quest directory.
scenes/menus/storybook/components/template_quest.tres is not within any
elder's quest directory, so the "thank you, StoryWeaver" dialogue is
skipped.

Map the replacement Quest back to the real NO_EDIT one when emitting
Storybook.selected().
