### PR TITLE
Go to bottom of Fray's End after tutorial

### DIFF
--- a/scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn
+++ b/scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn
@@ -233,10 +233,12 @@ position = Vector2(-865, 781)
 
 [node name="ImaginationThread" parent="OnTheGround" unique_id=1678374994 instance=ExtResource("12_s8bcj")]
 position = Vector2(-575, 315)
-next_scene = "uid://cufkthb25mpxy"
 item = SubResource("Resource_u8qfb")
 collected_dialogue = ExtResource("21_x2ecx")
 dialogue_title = &"thread_collected"
+next_scene = "uid://cufkthb25mpxy"
+spawn_point_path = NodePath("SpawnPointAfterIntro")
+exit_transition = 1
 
 [node name="Sign" parent="OnTheGround" unique_id=1579530966 instance=ExtResource("14_o5vgf")]
 position = Vector2(183, 215)


### PR DESCRIPTION
The old intro used to take the player to the bottom island of Fray's End
rather than taking them to right outside the loom. This was removed in
the new tutorial because CollectibleItem didn't have a way to specify a
spawn point in the target scene.

Now it does: do so.

Helps https://github.com/endlessm/threadbare/issues/2186
