### PR TITLE
music puzzle: Only reveal thread when you talk to musician

### DIFF
--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
+if thread.revealed:
+	=> collect_the_thread
+
 if puzzle.is_solved():
 	=> item_hint
 
@@ -88,6 +91,8 @@ match get_hint_level()
 Musician: You did it!... That's the magical melody... how wonderful. It's been so long since I heard it.
 Musician: You have opened the portal to the Ink Well. Let's go there to collect ink so songs and stories can be written again.
 Musician: But we must be careful, InkDrinkers dwell there!
+do thread.reveal()
+~ collect_the_thread
 Musician: The melody awakened the memory of song. Collect the Memory threads before you go!
 => END
 

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
@@ -3,6 +3,7 @@
 extends Node2D
 
 @onready var background_music: BackgroundMusic = %BackgroundMusic
+@onready var thread: CollectibleItem = %CollectibleItem
 
 
 func _on_sequence_puzzle_step_solved(step_index: int) -> void:

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1476,6 +1476,7 @@ sequence = [NodePath("../../Rocks/C"), NodePath("../../Rocks/Bb"), NodePath("../
 hint_sign = NodePath("../../Bonfires/BonfireSign4")
 
 [node name="CollectibleItem" parent="OnTheGround/SequencePuzzle" unique_id=530712613 instance=ExtResource("14_src2c")]
+unique_name_in_owner = true
 position = Vector2(-726, 43)
 revealed = false
 item = SubResource("Resource_dp3eg")
@@ -1570,5 +1571,4 @@ script = ExtResource("45_ps6xw")
 stream = ExtResource("47_orlow")
 metadata/_custom_type_script = "uid://c8405c212rbn6"
 
-[connection signal="solved" from="OnTheGround/SequencePuzzle" to="OnTheGround/SequencePuzzle/CollectibleItem" method="reveal"]
 [connection signal="step_solved" from="OnTheGround/SequencePuzzle" to="." method="_on_sequence_puzzle_step_solved"]


### PR DESCRIPTION
Previously the thread was revealed as soon as you solved the puzzle.
This let you collect it without talking to the musician and getting the
exposition about where we're going next.

Don't reveal the thread immediately. The musician's animation changing
to the eye-catching celebration animation should indicate that you can
talk to him again. Reveal the thread during that conversation.

Resolves https://github.com/endlessm/threadbare/issues/1347

