### PR TITLE
Camera utility function

### DIFF
--- a/scenes/game_elements/characters/player/components/player_hook.gd
+++ b/scenes/game_elements/characters/player/components/player_hook.gd
@@ -144,22 +144,6 @@ func _new_hook_string() -> Line2D:
 	return new_hook_string
 
 
-## Return the absolute path to the limit target of the current active camera, if it has one.
-func _get_phantom_camera_limit_target() -> NodePath:
-	var phantom_camera_hosts := PhantomCameraManager.phantom_camera_hosts
-	if not phantom_camera_hosts:
-		return ""
-	var active_pcam := phantom_camera_hosts[0].get_active_pcam() as PhantomCamera2D
-	if not active_pcam:
-		return ""
-	if not active_pcam.limit_target:
-		return ""
-	if active_pcam.limit_target.is_absolute():
-		return active_pcam.limit_target
-	var absolute_target_path := active_pcam.get_node(active_pcam.limit_target).get_path()
-	return absolute_target_path
-
-
 ## Called when the area was hooked.
 ## [br][br]
 ## Part of group hook_listener.
@@ -168,9 +152,7 @@ func hooked(_new_hooked_to: HookableArea, is_loop: bool) -> void:
 	if not hook_string:
 		hook_string = _new_hook_string()
 	hook_string.add_point(p, 0)
-	var limit_target := _get_phantom_camera_limit_target()
-	if limit_target:
-		phantom_camera_2d.limit_target = limit_target
+	CameraUtilities.copy_current_camera_limits(phantom_camera_2d)
 	phantom_camera_2d.priority = 20
 	hook_ending.global_position = p
 	areas_hooked.append(_new_hooked_to)

--- a/scenes/globals/camera_utilities/camera_utilities.gd
+++ b/scenes/globals/camera_utilities/camera_utilities.gd
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name CameraUtilities
+
+
+## Return the absolute path to the limit target of the current active camera, if it has one.
+static func _get_phantom_camera_limit_target() -> NodePath:
+	var phantom_camera_hosts := PhantomCameraManager.phantom_camera_hosts
+	if not phantom_camera_hosts:
+		return ""
+	var active_pcam := phantom_camera_hosts[0].get_active_pcam() as PhantomCamera2D
+	if not active_pcam:
+		return ""
+	if not active_pcam.limit_target:
+		return ""
+	if active_pcam.limit_target.is_absolute():
+		return active_pcam.limit_target
+	var absolute_target_path := active_pcam.get_node(active_pcam.limit_target).get_path()
+	return absolute_target_path
+
+
+## Assign the camera limits of the current active camera to this camera.
+static func copy_current_camera_limits(camera: PhantomCamera2D) -> void:
+	var limit_target := _get_phantom_camera_limit_target()
+	if limit_target:
+		camera.limit_target = limit_target

--- a/scenes/globals/camera_utilities/camera_utilities.gd.uid
+++ b/scenes/globals/camera_utilities/camera_utilities.gd.uid
@@ -1,0 +1,1 @@
+uid://bplxjqdeu6w3n

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/extra_needles.gd
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/extra_needles.gd
@@ -5,8 +5,6 @@ extends Node
 @export var extra_needles: Array[Node2D]
 @onready var helper_camera: PhantomCamera2D = %HelperCamera
 
-# signal needles_animation_finished
-
 
 func _ready() -> void:
 	for n in extra_needles:
@@ -15,6 +13,7 @@ func _ready() -> void:
 
 
 func add_extra_needles() -> void:
+	CameraUtilities.copy_current_camera_limits(helper_camera)
 	helper_camera.priority = 20
 	await get_tree().create_timer(1.0).timeout
 	for n in extra_needles:
@@ -22,3 +21,4 @@ func add_extra_needles() -> void:
 		n.process_mode = Node.PROCESS_MODE_INHERIT
 		await get_tree().create_timer(1.0).timeout
 	helper_camera.priority = 0
+	await get_tree().create_timer(1.0).timeout

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_needles.tscn
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_needles.tscn
@@ -44,6 +44,7 @@ size = Vector2(52, 61)
 
 [sub_resource type="Resource" id="Resource_pi753"]
 script = ExtResource("16_dysib")
+transition = 1
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_41yfr"]
 size = Vector2(140.5, 194.5)
@@ -464,7 +465,7 @@ position = Vector2(0, -72)
 
 [node name="HelperCamera" type="Node2D" parent="OnTheGround/Helper" unique_id=190625804]
 unique_name_in_owner = true
-position = Vector2(217, 255)
+position = Vector2(292, 275)
 script = ExtResource("15_374sg")
 tween_resource = SubResource("Resource_pi753")
 draw_limits = true


### PR DESCRIPTION
### grappling_hook_needles: Copy camera limits before the animation

Otherwise part of the scene outside the limits can be seen during the
transition. Also:

- Remove an unwanted comment
- Add 1 second delay before displaying the dialogue again
- Use sine transition for the tween resource of the PhantomCamera2D

### Add utility script for camera

The Phantom Camera addon doesn't have a way to keep the same limits as the
active camera before switching. So this has to be done though scripting.

Move the function in player_hook.gd into a utility script, and make it static.
