### PR TITLE
Redesign dialogue balloon

### DIFF
--- a/scenes/game_elements/props/powerup/components/default_powerup.dialogue
+++ b/scenes/game_elements/props/powerup/components/default_powerup.dialogue
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
-[wave amp=25 freq=5]You got a new ability! [b]{{ability_name}}[/b][/wave]
+[center][wave amp=25 freq=5]You got a new ability! [b]{{ability_name}}[/b][/wave][/center]
 => END

--- a/scenes/ui_elements/components/theme.tres
+++ b/scenes/ui_elements/components/theme.tres
@@ -9,6 +9,7 @@
 [ext_resource type="Texture2D" uid="uid://ccavio2v8sk7c" path="res://assets/third_party/tiny-swords/UI/Banners/Carved_3Slides.png" id="5_7k42u"]
 [ext_resource type="Texture2D" uid="uid://c3yokak1jgx7" path="res://assets/third_party/tiny-swords/UI/Banners/Banner_Vertical.png" id="5_mu1ca"]
 [ext_resource type="Texture2D" uid="uid://1po5xmfs16ot" path="res://assets/third_party/tiny-swords/UI/Ribbons/Ribbon_BlueLight_3Slides.png" id="7_mtpqe"]
+[ext_resource type="Texture2D" uid="uid://dh4tixu06hfwt" path="res://assets/third_party/tiny-swords/UI/Banners/Carved_9Slides.png" id="8_iqqbk"]
 [ext_resource type="FontFile" uid="uid://db8kp7xkv7gyn" path="res://assets/third_party/fonts/jersey/Jersey15-Regular.ttf" id="9_ig61n"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_iy6d2"]
@@ -118,6 +119,20 @@ texture_margin_right = 64.0
 axis_stretch_horizontal = 2
 axis_stretch_vertical = 2
 
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_iqqbk"]
+content_margin_left = 0.0
+content_margin_top = 0.0
+content_margin_right = 0.0
+content_margin_bottom = 0.0
+texture = ExtResource("8_iqqbk")
+texture_margin_left = 32.0
+texture_margin_top = 32.0
+texture_margin_right = 32.0
+texture_margin_bottom = 32.0
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+modulate_color = Color(0.28, 0.28, 0.28, 1)
+
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_mu1ca"]
 content_margin_left = 64.0
 content_margin_top = 48.0
@@ -201,6 +216,12 @@ MarginContainer/constants/margin_right = 16
 MarginContainer/constants/margin_top = 16
 NPCRibbon/base_type = &"PanelContainer"
 NPCRibbon/styles/panel = SubResource("StyleBoxTexture_7k42u")
+NextButton/base_type = &"Button"
+NextButton/styles/disabled = SubResource("StyleBoxTexture_iqqbk")
+NextButton/styles/focus = SubResource("StyleBoxTexture_iqqbk")
+NextButton/styles/hover = SubResource("StyleBoxTexture_iqqbk")
+NextButton/styles/normal = SubResource("StyleBoxTexture_iqqbk")
+NextButton/styles/pressed = SubResource("StyleBoxTexture_iqqbk")
 PanelContainer/styles/panel = SubResource("StyleBoxTexture_mu1ca")
 PlayerRibbon/base_type = &"PanelContainer"
 PlayerRibbon/styles/panel = SubResource("StyleBoxTexture_qmeow")

--- a/scenes/ui_elements/dialogue/balloon.tscn
+++ b/scenes/ui_elements/dialogue/balloon.tscn
@@ -44,11 +44,14 @@ unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = -1
 anchor_left = 0.5
+anchor_top = 1.0
 anchor_right = 0.5
+anchor_bottom = 1.0
 offset_left = -384.0
+offset_top = 4096.0
 offset_right = 384.0
-offset_bottom = 151.0
 grow_horizontal = 2
+grow_vertical = 0
 pivot_offset_ratio = Vector2(0.5, 0.5)
 theme_override_constants/separation = -38
 

--- a/scenes/ui_elements/dialogue/balloon.tscn
+++ b/scenes/ui_elements/dialogue/balloon.tscn
@@ -1,80 +1,144 @@
 [gd_scene format=3 uid="uid://dhydhpp43urah"]
 
-[ext_resource type="Script" uid="uid://n1guv6m28qbw" path="res://scenes/ui_elements/dialogue/components/balloon.gd" id="1_36de5"]
-[ext_resource type="PackedScene" uid="uid://ckvgyvclnwggo" path="res://addons/dialogue_manager/dialogue_label.tscn" id="2_a8ve6"]
-[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="2_pfnde"]
-[ext_resource type="Script" uid="uid://bb52rsfwhkxbn" path="res://addons/dialogue_manager/dialogue_responses_menu.gd" id="3_72ixx"]
-[ext_resource type="Texture2D" uid="uid://ctvutcaoqvftf" path="res://assets/first_party/icons/right_arrow.png" id="4_qmeow"]
-[ext_resource type="AudioStream" uid="uid://cs1bx2odpj6vm" path="res://scenes/ui_elements/dialogue/components/sounds/pencil.ogg" id="5_dbsi0"]
+[ext_resource type="Script" uid="uid://n1guv6m28qbw" path="res://scenes/ui_elements/dialogue/components/balloon.gd" id="1_oh0dh"]
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="2_efi2m"]
+[ext_resource type="Texture2D" uid="uid://dh4tixu06hfwt" path="res://assets/third_party/tiny-swords/UI/Banners/Carved_9Slides.png" id="3_1s4ug"]
+[ext_resource type="PackedScene" uid="uid://ckvgyvclnwggo" path="res://addons/dialogue_manager/dialogue_label.tscn" id="4_3tiik"]
+[ext_resource type="Script" uid="uid://bb52rsfwhkxbn" path="res://addons/dialogue_manager/dialogue_responses_menu.gd" id="5_gjlrd"]
+[ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="6_y5co6"]
+[ext_resource type="Texture2D" uid="uid://c6fggds355rko" path="res://assets/third_party/inputs/atlas_kenney_input_prompts_1.4/keyboard/keyboard_space_outline.tres" id="7_qmj24"]
+[ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="8_saw5e"]
+[ext_resource type="Resource" uid="uid://c1beocky1qjxi" path="res://scenes/game_elements/props/hint/resources/devices.tres" id="9_j0m6q"]
+[ext_resource type="AudioStream" uid="uid://cs1bx2odpj6vm" path="res://scenes/ui_elements/dialogue/components/sounds/pencil.ogg" id="10_oyhl1"]
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_beq22"]
+content_margin_left = 16.0
+content_margin_top = 16.0
+content_margin_right = 16.0
+content_margin_bottom = 16.0
+texture = ExtResource("3_1s4ug")
+texture_margin_left = 64.0
+texture_margin_top = 64.0
+texture_margin_right = 64.0
+texture_margin_bottom = 64.0
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+modulate_color = Color(1.3807716, 1.3807716, 1.3807716, 0.83137256)
 
 [node name="DialogueBalloon" type="CanvasLayer" unique_id=308207015]
 layer = 100
-script = ExtResource("1_36de5")
+script = ExtResource("1_oh0dh")
 
 [node name="Balloon" type="Control" parent="." unique_id=2032365240]
 unique_name_in_owner = true
 layout_mode = 3
-anchors_preset = 0
-theme = ExtResource("2_pfnde")
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("2_efi2m")
 
-[node name="PanelContainer" type="PanelContainer" parent="Balloon" unique_id=58550594]
-layout_mode = 0
-offset_right = 480.0
-offset_bottom = 359.0
-
-[node name="VBoxContainer" type="VBoxContainer" parent="Balloon/PanelContainer" unique_id=412895659]
-custom_minimum_size = Vector2(352, 128)
-layout_mode = 2
-
-[node name="CharacterPanel" type="PanelContainer" parent="Balloon/PanelContainer/VBoxContainer" unique_id=383126775]
+[node name="BalloonContainer" type="VBoxContainer" parent="Balloon" unique_id=701404412]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(0, 64)
-layout_mode = 2
-size_flags_horizontal = 0
-theme_type_variation = &"NPCRibbon"
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -384.0
+offset_right = 384.0
+offset_bottom = 151.0
+grow_horizontal = 2
+pivot_offset_ratio = Vector2(0.5, 0.5)
+theme_override_constants/separation = -38
 
-[node name="CharacterLabel" type="Label" parent="Balloon/PanelContainer/VBoxContainer/CharacterPanel" unique_id=172265592]
+[node name="MarginContainer" type="MarginContainer" parent="Balloon/BalloonContainer" unique_id=1972618856]
+layout_mode = 2
+theme_override_constants/margin_left = 0
+theme_override_constants/margin_top = 0
+theme_override_constants/margin_bottom = 0
+
+[node name="PanelContainer" type="PanelContainer" parent="Balloon/BalloonContainer/MarginContainer" unique_id=58550594]
+layout_mode = 2
+mouse_filter = 1
+theme_override_styles/panel = SubResource("StyleBoxTexture_beq22")
+
+[node name="MarginContainer" type="MarginContainer" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer" unique_id=234873226]
+layout_mode = 2
+theme_override_constants/margin_left = 0
+theme_override_constants/margin_top = 0
+theme_override_constants/margin_right = 32
+theme_override_constants/margin_bottom = 0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer" unique_id=412895659]
+custom_minimum_size = Vector2(704, 0)
+layout_mode = 2
+size_flags_vertical = 8
+theme_override_constants/separation = 3
+
+[node name="CharacterLabel" type="RichTextLabel" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer" unique_id=109841824]
 unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 1
-text = "Musician"
-horizontal_alignment = 1
+bbcode_enabled = true
+text = "[u]Musician:"
+fit_content = true
 
-[node name="DialogueLabel" parent="Balloon/PanelContainer/VBoxContainer" unique_id=728821532 instance=ExtResource("2_a8ve6")]
+[node name="DialogueLabel" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer" unique_id=728821532 instance=ExtResource("4_3tiik")]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_vertical = 3
 text = "¡Ah! ¿Another wanderer? It’s been a while siñce aňyone çame löõkiŋ for  instead of «treaßure»."
 skip_action = &"dialogue_skip"
 
-[node name="NextButton" type="Button" parent="Balloon/PanelContainer/VBoxContainer" unique_id=110419078]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 8
-theme_type_variation = &"FlatNextButton"
-text = "next"
-icon = ExtResource("4_qmeow")
-icon_alignment = 2
-
-[node name="ResponsesMenu" type="VBoxContainer" parent="Balloon/PanelContainer/VBoxContainer" unique_id=938619174 node_paths=PackedStringArray("response_template")]
+[node name="ResponsesMenu" type="VBoxContainer" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer" unique_id=938619174 node_paths=PackedStringArray("response_template")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
+size_flags_horizontal = 4
 size_flags_vertical = 8
 theme_override_constants/separation = 2
-script = ExtResource("3_72ixx")
+script = ExtResource("5_gjlrd")
 response_template = NodePath("ResponseExample")
 
-[node name="ResponseExample" type="Button" parent="Balloon/PanelContainer/VBoxContainer/ResponsesMenu" unique_id=957333658]
+[node name="ResponseExample" type="Button" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ResponsesMenu" unique_id=957333658]
 layout_mode = 2
 theme_type_variation = &"FlatButton"
 text = "Response example"
 
+[node name="NextButton" type="Button" parent="Balloon/BalloonContainer" unique_id=1047703477]
+unique_name_in_owner = true
+z_index = 1
+custom_minimum_size = Vector2(64, 64)
+layout_mode = 2
+size_flags_horizontal = 8
+theme_type_variation = &"NextButton"
+
+[node name="InteractHint" type="TextureRect" parent="Balloon/BalloonContainer/NextButton" unique_id=661213085]
+material = ExtResource("6_y5co6")
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -32.0
+offset_top = -32.0
+offset_right = 32.0
+offset_bottom = 32.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 8
+size_flags_vertical = 8
+texture = ExtResource("7_qmj24")
+script = ExtResource("8_saw5e")
+action_name = &"interact"
+devices = ExtResource("9_j0m6q")
+
 [node name="TalkSoundPlayer" type="AudioStreamPlayer" parent="." unique_id=1778551533]
-stream = ExtResource("5_dbsi0")
+stream = ExtResource("10_oyhl1")
 volume_db = 2.0
 bus = &"SFX"
 parameters/looping = true
 
 [connection signal="gui_input" from="Balloon" to="." method="_on_balloon_gui_input"]
-[connection signal="response_selected" from="Balloon/PanelContainer/VBoxContainer/ResponsesMenu" to="." method="_on_responses_menu_response_selected"]
+[connection signal="response_selected" from="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ResponsesMenu" to="." method="_on_responses_menu_response_selected"]

--- a/scenes/ui_elements/dialogue/balloon.tscn
+++ b/scenes/ui_elements/dialogue/balloon.tscn
@@ -52,45 +52,62 @@ grow_horizontal = 2
 pivot_offset_ratio = Vector2(0.5, 0.5)
 theme_override_constants/separation = -38
 
-[node name="MarginContainer" type="MarginContainer" parent="Balloon/BalloonContainer" unique_id=1972618856]
+[node name="MarginContainer" type="MarginContainer" parent="Balloon/BalloonContainer" unique_id=344362871]
 layout_mode = 2
 theme_override_constants/margin_left = 0
-theme_override_constants/margin_top = 0
-theme_override_constants/margin_bottom = 0
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 0
+theme_override_constants/margin_bottom = 8
 
-[node name="PanelContainer" type="PanelContainer" parent="Balloon/BalloonContainer/MarginContainer" unique_id=58550594]
+[node name="CharacterPanel" type="PanelContainer" parent="Balloon/BalloonContainer/MarginContainer" unique_id=737681563]
+unique_name_in_owner = true
+z_index = 1
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
+theme_type_variation = &"NPCRibbon"
+
+[node name="CharacterLabel" type="Label" parent="Balloon/BalloonContainer/MarginContainer/CharacterPanel" unique_id=1133007357]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
+mouse_filter = 1
+text = "Musician"
+
+[node name="MarginContainer" type="MarginContainer" parent="Balloon/BalloonContainer/MarginContainer" unique_id=1972618856]
+custom_minimum_size = Vector2(0, 128)
+layout_mode = 2
+theme_override_constants/margin_left = 48
+theme_override_constants/margin_top = 27
+theme_override_constants/margin_right = 29
+theme_override_constants/margin_bottom = 29
+
+[node name="PanelContainer" type="PanelContainer" parent="Balloon/BalloonContainer/MarginContainer/MarginContainer" unique_id=58550594]
 layout_mode = 2
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxTexture_beq22")
 
-[node name="MarginContainer" type="MarginContainer" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer" unique_id=234873226]
+[node name="MarginContainer" type="MarginContainer" parent="Balloon/BalloonContainer/MarginContainer/MarginContainer/PanelContainer" unique_id=234873226]
 layout_mode = 2
 theme_override_constants/margin_left = 0
 theme_override_constants/margin_top = 0
 theme_override_constants/margin_right = 32
 theme_override_constants/margin_bottom = 0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer" unique_id=412895659]
+[node name="VBoxContainer" type="VBoxContainer" parent="Balloon/BalloonContainer/MarginContainer/MarginContainer/PanelContainer/MarginContainer" unique_id=412895659]
 custom_minimum_size = Vector2(704, 0)
 layout_mode = 2
-size_flags_vertical = 8
 theme_override_constants/separation = 3
 
-[node name="CharacterLabel" type="RichTextLabel" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer" unique_id=109841824]
+[node name="DialogueLabel" parent="Balloon/BalloonContainer/MarginContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer" unique_id=728821532 instance=ExtResource("4_3tiik")]
 unique_name_in_owner = true
 layout_mode = 2
-mouse_filter = 1
-bbcode_enabled = true
-text = "[u]Musician:"
-fit_content = true
-
-[node name="DialogueLabel" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer" unique_id=728821532 instance=ExtResource("4_3tiik")]
-unique_name_in_owner = true
-layout_mode = 2
+size_flags_vertical = 3
 text = "¡Ah! ¿Another wanderer? It’s been a while siñce aňyone çame löõkiŋ for  instead of «treaßure»."
+vertical_alignment = 1
 skip_action = &"dialogue_skip"
 
-[node name="ResponsesMenu" type="VBoxContainer" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer" unique_id=938619174 node_paths=PackedStringArray("response_template")]
+[node name="ResponsesMenu" type="VBoxContainer" parent="Balloon/BalloonContainer/MarginContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer" unique_id=938619174 node_paths=PackedStringArray("response_template")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -100,20 +117,21 @@ theme_override_constants/separation = 2
 script = ExtResource("5_gjlrd")
 response_template = NodePath("ResponseExample")
 
-[node name="ResponseExample" type="Button" parent="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ResponsesMenu" unique_id=957333658]
+[node name="ResponseExample" type="Button" parent="Balloon/BalloonContainer/MarginContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ResponsesMenu" unique_id=957333658]
 layout_mode = 2
 theme_type_variation = &"FlatButton"
 text = "Response example"
 
-[node name="NextButton" type="Button" parent="Balloon/BalloonContainer" unique_id=1047703477]
+[node name="NextButton" type="Button" parent="Balloon/BalloonContainer/MarginContainer" unique_id=1047703477]
 unique_name_in_owner = true
 z_index = 1
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 2
 size_flags_horizontal = 8
+size_flags_vertical = 8
 theme_type_variation = &"NextButton"
 
-[node name="InteractHint" type="TextureRect" parent="Balloon/BalloonContainer/NextButton" unique_id=661213085]
+[node name="InteractHint" type="TextureRect" parent="Balloon/BalloonContainer/MarginContainer/NextButton" unique_id=661213085]
 material = ExtResource("6_y5co6")
 layout_mode = 1
 anchors_preset = 8
@@ -141,4 +159,4 @@ bus = &"SFX"
 parameters/looping = true
 
 [connection signal="gui_input" from="Balloon" to="." method="_on_balloon_gui_input"]
-[connection signal="response_selected" from="Balloon/BalloonContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ResponsesMenu" to="." method="_on_responses_menu_response_selected"]
+[connection signal="response_selected" from="Balloon/BalloonContainer/MarginContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ResponsesMenu" to="." method="_on_responses_menu_response_selected"]

--- a/scenes/ui_elements/dialogue/components/balloon.gd
+++ b/scenes/ui_elements/dialogue/components/balloon.gd
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present Nathan Hoad and Dialogue Manager contributors.
 # SPDX-License-Identifier: MIT
+@tool
 extends CanvasLayer
 ## A basic dialogue balloon for use with Dialogue Manager.
 
@@ -11,6 +12,9 @@ const NPC_RIBBON_TYPE_VARIATION := &"NPCRibbon"
 
 ## The action to use to skip typing the dialogue
 @export var skip_action: StringName = &"dialogue_skip"
+
+@export_tool_button("Anchor to top") var to_top_editor_button: Callable = anchor_to_top
+@export_tool_button("Anchor to bottom") var to_bottom_editor_button: Callable = anchor_to_bottom
 
 ## The dialogue resource
 var resource: DialogueResource
@@ -75,6 +79,8 @@ var _player_name: String = ""
 
 
 func _ready() -> void:
+	if Engine.is_editor_hint():
+		return
 	balloon.hide()
 	Engine.get_singleton("DialogueManager").mutated.connect(_on_mutated)
 
@@ -104,6 +110,8 @@ func _notification(what: int) -> void:
 		self.dialogue_line = await resource.get_next_dialogue_line(dialogue_line.id)
 		if visible_ratio < 1:
 			dialogue_label.skip_typing()
+	elif what == NOTIFICATION_EDITOR_PRE_SAVE:
+		anchor_to_bottom()
 
 
 ## Start some dialogue
@@ -141,15 +149,9 @@ func apply_dialogue_line() -> void:
 
 	next_button.hide()
 
-	if _is_player_at_top():
-		# Anchor container to bottom:
-		balloon_container.anchor_top = 1
-		balloon_container.anchor_bottom = 1
-		balloon_container.offset_top = 4096
-		balloon_container.offset_bottom = 0
-		balloon_container.grow_vertical = Control.GROW_DIRECTION_BEGIN
-		# And change the order of the next button:
-		balloon_container.move_child(next_button, 0)
+	# Assumes that the balloon scene is anchored to the bottom by default:
+	if _is_player_at_bottom():
+		anchor_to_top()
 
 	# Show our balloon
 	balloon.show()
@@ -189,7 +191,8 @@ func apply_dialogue_line() -> void:
 		next_button.show()
 
 
-func _is_player_at_top() -> bool:
+## True if the player position is at the bottom vertical quarter of the screen.
+func _is_player_at_bottom() -> bool:
 	var player: Node2D = get_tree().get_first_node_in_group("player")
 	if not player:
 		return false
@@ -197,7 +200,25 @@ func _is_player_at_top() -> bool:
 	var viewport := player.get_viewport()
 	var screen_pos: Vector2 = viewport.get_canvas_transform() * player.global_position
 	var viewport_size: Vector2 = viewport.get_visible_rect().size
-	return screen_pos.y <= viewport_size.y / 2.0
+	return screen_pos.y > viewport_size.y * 3 / 4.0
+
+
+## Anchor container to top:
+func anchor_to_top() -> void:
+	balloon_container.anchor_top = 0
+	balloon_container.anchor_bottom = 0
+	balloon_container.offset_top = 0
+	balloon_container.offset_bottom = -4096
+	balloon_container.grow_vertical = Control.GROW_DIRECTION_END
+
+
+## Anchor container to bottom:
+func anchor_to_bottom() -> void:
+	balloon_container.anchor_top = 1
+	balloon_container.anchor_bottom = 1
+	balloon_container.offset_top = 4096
+	balloon_container.offset_bottom = 0
+	balloon_container.grow_vertical = Control.GROW_DIRECTION_BEGIN
 
 
 ## Go to the next line

--- a/scenes/ui_elements/dialogue/components/balloon.gd
+++ b/scenes/ui_elements/dialogue/components/balloon.gd
@@ -53,11 +53,11 @@ var _player_name: String = ""
 ## The base balloon anchor
 @onready var balloon: Control = %Balloon
 
-## The panel holding the label showing the name of the currently-speaking character
-@onready var character_panel: PanelContainer = %CharacterPanel
+## The balloon container to anchor it to the top or bottom
+@onready var balloon_container: VBoxContainer = %BalloonContainer
 
 ## The label showing the name of the currently speaking character
-@onready var character_label: Label = %CharacterLabel
+@onready var character_label: RichTextLabel = %CharacterLabel
 
 ## The label showing the currently spoken dialogue
 @onready var dialogue_label: DialogueLabel = %DialogueLabel
@@ -122,13 +122,8 @@ func apply_dialogue_line() -> void:
 	balloon.focus_mode = Control.FOCUS_ALL
 	balloon.grab_focus()
 
-	character_panel.visible = not dialogue_line.character.is_empty()
-	character_panel.theme_type_variation = (
-		PLAYER_RIBBON_TYPE_VARIATION
-		if _player_name == dialogue_line.character
-		else NPC_RIBBON_TYPE_VARIATION
-	)
-	character_label.text = tr(dialogue_line.character, "dialogue")
+	character_label.visible = not dialogue_line.character.is_empty()
+	character_label.text = "[u]" + tr(dialogue_line.character, "dialogue") + ":"
 
 	dialogue_label.hide()
 	dialogue_label.dialogue_line = dialogue_line
@@ -137,6 +132,16 @@ func apply_dialogue_line() -> void:
 	responses_menu.responses = dialogue_line.responses
 
 	next_button.hide()
+
+	if _is_player_at_top():
+		# Anchor container to bottom:
+		balloon_container.anchor_top = 1
+		balloon_container.anchor_bottom = 1
+		balloon_container.offset_top = 4096
+		balloon_container.offset_bottom = 0
+		balloon_container.grow_vertical = Control.GROW_DIRECTION_BEGIN
+		# And change the order of the next button:
+		balloon_container.move_child(next_button, 0)
 
 	# Show our balloon
 	balloon.show()
@@ -166,6 +171,17 @@ func apply_dialogue_line() -> void:
 		balloon.focus_mode = Control.FOCUS_ALL
 		balloon.grab_focus()
 		next_button.show()
+
+
+func _is_player_at_top() -> bool:
+	var player: Node2D = get_tree().get_first_node_in_group("player")
+	if not player:
+		return false
+
+	var viewport := player.get_viewport()
+	var screen_pos: Vector2 = viewport.get_canvas_transform() * player.global_position
+	var viewport_size: Vector2 = viewport.get_visible_rect().size
+	return screen_pos.y <= viewport_size.y / 2.0
 
 
 ## Go to the next line

--- a/scenes/ui_elements/dialogue/components/balloon.gd
+++ b/scenes/ui_elements/dialogue/components/balloon.gd
@@ -159,9 +159,8 @@ func apply_dialogue_line() -> void:
 
 	# Add a squash-stretch effect when the dialogue appears.
 	balloon_container.scale = Vector2(1.15, 0.7)
-	var tween := create_tween().set_parallel(true).set_trans(Tween.TRANS_BACK).set_ease(
-		Tween.EASE_OUT
-	)
+	var tween := create_tween().set_parallel(true)
+	tween.set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
 	tween.tween_property(balloon_container, "scale:x", 1.0, 0.25)
 	tween.tween_property(balloon_container, "scale:y", 1.0, 0.25)
 

--- a/scenes/ui_elements/dialogue/components/balloon.gd
+++ b/scenes/ui_elements/dialogue/components/balloon.gd
@@ -56,8 +56,11 @@ var _player_name: String = ""
 ## The balloon container to anchor it to the top or bottom
 @onready var balloon_container: VBoxContainer = %BalloonContainer
 
+## The panel holding the label showing the name of the currently-speaking character
+@onready var character_panel: PanelContainer = %CharacterPanel
+
 ## The label showing the name of the currently speaking character
-@onready var character_label: RichTextLabel = %CharacterLabel
+@onready var character_label: Label = %CharacterLabel
 
 ## The label showing the currently spoken dialogue
 @onready var dialogue_label: DialogueLabel = %DialogueLabel
@@ -122,8 +125,13 @@ func apply_dialogue_line() -> void:
 	balloon.focus_mode = Control.FOCUS_ALL
 	balloon.grab_focus()
 
-	character_label.visible = not dialogue_line.character.is_empty()
-	character_label.text = "[u]" + tr(dialogue_line.character, "dialogue") + ":"
+	character_panel.visible = not dialogue_line.character.is_empty()
+	character_panel.theme_type_variation = (
+		PLAYER_RIBBON_TYPE_VARIATION
+		if _player_name == dialogue_line.character
+		else NPC_RIBBON_TYPE_VARIATION
+	)
+	character_label.text = tr(dialogue_line.character, "dialogue")
 
 	dialogue_label.hide()
 	dialogue_label.dialogue_line = dialogue_line

--- a/scenes/ui_elements/dialogue/components/balloon.gd
+++ b/scenes/ui_elements/dialogue/components/balloon.gd
@@ -147,6 +147,14 @@ func apply_dialogue_line() -> void:
 	balloon.show()
 	will_hide_balloon = false
 
+	# Add a squash-stretch effect when the dialogue appears.
+	balloon_container.scale = Vector2(1.15, 0.7)
+	var tween := create_tween().set_parallel(true).set_trans(Tween.TRANS_BACK).set_ease(
+		Tween.EASE_OUT
+	)
+	tween.tween_property(balloon_container, "scale:x", 1.0, 0.25)
+	tween.tween_property(balloon_container, "scale:y", 1.0, 0.25)
+
 	dialogue_label.show()
 	if not dialogue_line.text.is_empty():
 		dialogue_label.type_out()

--- a/scenes/ui_elements/input_hints/components/input_hud.gd
+++ b/scenes/ui_elements/input_hints/components/input_hud.gd
@@ -9,6 +9,8 @@ var player_hook: PlayerHook
 
 var sokoban_ruleset: RuleEngine
 
+var displaying_dialogue: bool
+
 @onready var normal_controls := %NormalControls
 @onready var interact_input_hint: LabeledInputHint = %InteractInputHint
 @onready var aim_input_hint := %AimInputHint
@@ -21,6 +23,8 @@ var sokoban_ruleset: RuleEngine
 
 func _ready() -> void:
 	get_tree().scene_changed.connect(_on_scene_changed)
+	DialogueManager.dialogue_started.connect(_on_dialogue_started)
+	DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
 
 	Transitions.started.connect(_update_visibility)
 	Transitions.finished.connect(_update_visibility)
@@ -67,6 +71,7 @@ func _update_visibility() -> void:
 		Settings.show_input_hud
 		and not get_tree().paused
 		and not Transitions.is_running()
+		and not displaying_dialogue
 		and (player or sokoban_ruleset)
 	)
 
@@ -89,6 +94,16 @@ func _update_player_state() -> void:
 
 	throw_input_hint.visible = player_hook and player_hook.visible
 	aim_input_hint.visible = player_hook and player_hook.visible
+
+
+func _on_dialogue_started(_resource: DialogueResource) -> void:
+	displaying_dialogue = true
+	_update_visibility()
+
+
+func _on_dialogue_ended(_resource: DialogueResource) -> void:
+	displaying_dialogue = false
+	_update_visibility()
 
 
 func _display_skip() -> void:


### PR DESCRIPTION
The balloon is now anchored to the screen bottom-center by default. And is anchored
to the screen top-center through scripting if the player position in the
screen is below the 3/4 of the screen height.

The balloon size is now the double as before, with more room for words per line.

The "next" button now has a TextureRect inside with the interact_input.gd script
attached, so it will display the corresponding input to close the dialogue. For
theming the background it has its own theme type variation.

The "next" button is now outside the visible panel, stacked vertically with a
bit of negative margin to overlap it. The visible panel also has margin (through
MarginContainer nodes) to prevent the text to be below the "next" button, and to
make the "next" button appear outside horizontally.

The label for the talking character name with the ribbon is also outside the visible
panel and overlapping it.

For now, the panels of this dialogue use existing textures modulated to be:
lighter and a bit transparent for the main panel. And darker for the "next"
button background.

### Balloon: Add small squash-stretch effect when it appears

This is intended to grab the eye of the player to the dialogue when it appears.
Because now it can appear at the top or at the bottom, conditionally.

### Input HUD: Hide it when displaying dialogue

During dialogue, the input is grabbed by it and the player can't move, run or
trigger other actions. Also, now this HUD may appear below the dialogue when it
is displayed at the bottom.

### Powerup dialogue: Center text in dialogue

It looks better!

Resolve https://github.com/endlessm/threadbare/issues/2278
Fix https://github.com/endlessm/threadbare/issues/1846
