### PR TITLE
Loom: Save after end-of-quest interaction

### DIFF
--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
@@ -7,20 +7,11 @@ signal retelling_started
 signal retelling_finished
 signal give_retelling_upgrade(type: InventoryItem.ItemType)
 
-const ETERNAL_LOOM_INTERACTION: DialogueResource = preload("uid://yafw7bf362gh")
-
 var elders: Array[Elder]
-
-var _have_threads := is_item_offering_possible()
 
 @onready var interact_area: InteractArea = %InteractArea
 @onready var talk_behavior: TalkBehavior = %TalkBehavior
 @onready var loom_offering_animation_player: AnimationPlayer = %LoomOfferingAnimationPlayer
-
-
-func _ready() -> void:
-	talk_behavior.dialogue = ETERNAL_LOOM_INTERACTION
-	talk_behavior.title = "have_threads" if _have_threads else "no_threads"
 
 
 func _find_elder(quest: Quest) -> Elder:
@@ -109,6 +100,7 @@ func on_offering_succeeded() -> void:
 		push_warning("Could not find elder for %s" % [GameState.quest.quest.resource_path])
 
 	GameState.mark_quest_completed()
+	GameState.save()
 
 
 func has_retelling() -> bool:

--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom_interaction.dialogue
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom_interaction.dialogue
@@ -2,15 +2,13 @@
 # SPDX-License-Identifier: MPL-2.0
 ~ welcome
 The Eternal Loom welcomes you, StoryWeaver. Threads you collect help to repair the fabric of our world.
-=> END
-
-~ no_threads
-=>< welcome
-It seems you are lacking the threads of Memory, Imagination, and Spirit... try coming back later.
-=> END
+if is_item_offering_possible():
+	=> have_threads
+else:
+	It seems you are lacking the threads of Memory, Imagination, and Spirit... try coming back later.
+	=> END
 
 ~ have_threads
-=>< welcome
 The Memory, Imagination, and Spirit threads are ready to be incorporated into the loom!
 if has_retelling():
 	do start_retelling()

--- a/scenes/game_elements/props/eternal_loom/eternal_loom.tscn
+++ b/scenes/game_elements/props/eternal_loom/eternal_loom.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://5wscjc8yqqts" path="res://assets/first_party/collectibles/world_memory.png" id="4_12bvc"]
 [ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="4_eq7jh"]
 [ext_resource type="Texture2D" uid="uid://6bf8rum68wq3" path="res://assets/first_party/collectibles/world_imagination.png" id="5_eq7jh"]
+[ext_resource type="Resource" uid="uid://yafw7bf362gh" path="res://scenes/game_elements/props/eternal_loom/components/eternal_loom_interaction.dialogue" id="5_k2bt4"]
 [ext_resource type="Texture2D" uid="uid://cepg1o3ihp055" path="res://assets/first_party/collectibles/world_spirit.png" id="6_hfqem"]
 [ext_resource type="AudioStream" uid="uid://bg8u4en3hlo6w" path="res://assets/third_party/sounds/eternal_loom/EternalLoomShort.ogg" id="7_12bvc"]
 [ext_resource type="Texture2D" uid="uid://b5ooaiyxdrp6a" path="res://scenes/game_elements/components/light_texture_256x256.tres" id="9_mjlja"]
@@ -563,6 +564,7 @@ position = Vector2(0, -152)
 [node name="TalkBehavior" type="Node" parent="." unique_id=562216088 node_paths=PackedStringArray("interact_area")]
 unique_name_in_owner = true
 script = ExtResource("4_eq7jh")
+dialogue = ExtResource("5_k2bt4")
 interact_area = NodePath("../InteractArea")
 metadata/_custom_type_script = "uid://edcifob4jc4s"
 


### PR DESCRIPTION
Previously the Eternal Loom implicitly saved the game state at the end
of the end-of-quest interaction, originally because GameState always
saved itself, and then, after the recent refactor, because it switched
to a Sokoban scene immediately which triggers a save.

Now we need to explicitly save the game state at the end of the
interaction, once the quest has been marked as complete.

In addition, the loom would check when instantiated whether the
end-of-quest interaction is possible, but it cached the result for the
lifetime of the instance. With the removal of the Sokoban transition
this no longer works. We can call is_item_offering_possible() directly
in the dialogue, and eliminate this code to change the dialogue title at
startup. While we're there, set the dialogue resource in the scene not
the script.

