### PR TITLE
Don't infer PhantomCamera-based variable types

### DIFF
--- a/scenes/globals/camera_utilities/camera_utilities.gd
+++ b/scenes/globals/camera_utilities/camera_utilities.gd
@@ -5,7 +5,7 @@ class_name CameraUtilities
 
 ## Return the absolute path to the limit target of the current active camera, if it has one.
 static func _get_phantom_camera_limit_target() -> NodePath:
-	var phantom_camera_hosts := PhantomCameraManager.phantom_camera_hosts
+	var phantom_camera_hosts: Array[PhantomCameraHost] = PhantomCameraManager.phantom_camera_hosts
 	if not phantom_camera_hosts:
 		return ""
 	var active_pcam := phantom_camera_hosts[0].get_active_pcam() as PhantomCamera2D

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/grappling_hook_powerup.gd
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/grappling_hook_powerup.gd
@@ -19,6 +19,6 @@ func _on_abilities_changed() -> void:
 	if zoom_tween:
 		zoom_tween.kill()
 	zoom_tween = create_tween()
-	var cameras := PhantomCameraManager.get_phantom_camera_2ds()
+	var cameras: Array[PhantomCamera2D] = PhantomCameraManager.get_phantom_camera_2ds()
 	for cam: PhantomCamera2D in cameras:
 		zoom_tween.tween_property(cam, "zoom", camera_zoom, 1.0)

--- a/scenes/quests/lore_quests/quest_002/3_void_grappling/components/void_grapping_round_2.gd
+++ b/scenes/quests/lore_quests/quest_002/3_void_grappling/components/void_grapping_round_2.gd
@@ -25,7 +25,7 @@ func _on_abilities_changed() -> void:
 	if zoom_tween:
 		zoom_tween.kill()
 	zoom_tween = create_tween()
-	var cameras := PhantomCameraManager.get_phantom_camera_2ds()
+	var cameras: Array[PhantomCamera2D] = PhantomCameraManager.get_phantom_camera_2ds()
 	for cam: PhantomCamera2D in cameras:
 		zoom_tween.tween_property(cam, "zoom", camera_zoom, 1.0)
 


### PR DESCRIPTION
Don't infer PhantomCamera-based variable types

On initial import, these lines caused the following errors (and
cascading script compilation errors):

> ERROR: res://scenes/globals/camera_utilities/camera_utilities.gd:8 -
> Parse Error: Cannot infer the type of "phantom_camera_hosts" variable because the value doesn't have a set type.

> ERROR: res://scenes/quests/lore_quests/quest_002/2_grappling_hook/components/grappling_hook_powerup.gd:22 -
> Parse Error: Cannot infer the type of "cameras" variable because the value doesn't have a set type.

> ERROR: res://scenes/quests/lore_quests/quest_002/3_void_grappling/components/void_grapping_round_2.gd:28 -
> Parse Error: Cannot infer the type of "cameras" variable because the value doesn't have a set type.

This is because during first import the custom types defined by the
addon are not known to the engine.

Specifying the variable types directly rather than using `:=` fixes
this.

Resolves https://github.com/endlessm/threadbare/issues/2288
