### PR TITLE
Show dialogue after abandoning a Quest

### DIFF
--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -4,6 +4,7 @@ extends CanvasLayer
 
 @export_file("*.tscn") var title_scene: String
 @export_file("*.tscn") var frays_end: String
+@export var abandon_dialogue: DialogueResource
 
 @onready var pause_menu: Control = %PauseMenu
 @onready var resume_button: Button = %ResumeButton
@@ -46,6 +47,7 @@ func toggle_pause() -> void:
 func _on_abandon_quest_pressed() -> void:
 	toggle_pause()
 
+	var quest := GameState.quest.quest
 	var abandon_scene := GameState.quest.abandon_scene_path
 	var abandon_spawn_point: NodePath
 	if abandon_scene:
@@ -57,6 +59,12 @@ func _on_abandon_quest_pressed() -> void:
 	SceneSwitcher.change_to_file_with_transition(
 		abandon_scene, abandon_spawn_point, Transition.Effect.FADE, Transition.Effect.FADE
 	)
+	await Transitions.finished
+
+	var player: Node2D = get_tree().get_first_node_in_group("player")
+	var replaying := quest in GameState.global.completed_quests
+	var title := "abandoned_replay" if replaying else "abandoned"
+	DialogueManager.show_dialogue_balloon(abandon_dialogue, title, [player])
 
 
 func _on_skip_tutorial_pressed() -> void:

--- a/scenes/globals/pause/pause_overlay.tscn
+++ b/scenes/globals/pause/pause_overlay.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://y88qplkioj1q" path="res://scenes/globals/pause/pause_overlay.gd" id="1_lf64b"]
 [ext_resource type="Texture2D" uid="uid://lg5dl13njsg3" path="res://assets/first_party/tiles/Grass_And_Sand_Tiles.png" id="2_1tcw0"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="2_sd5t1"]
+[ext_resource type="Resource" uid="uid://bm4xxsl17ho55" path="res://scenes/globals/pause/quest_abandoned.dialogue" id="2_xccck"]
 [ext_resource type="Script" uid="uid://i4urwefxrrdt" path="res://addons/threadbare_git_describe/version_label.gd" id="3_m62bn"]
 [ext_resource type="PackedScene" uid="uid://dkeb0yjgcfi86" path="res://scenes/menus/options/options.tscn" id="3_sd5t1"]
 [ext_resource type="Script" uid="uid://gntvq01vvati" path="res://scenes/globals/pause/report_bug_button.gd" id="4_mjd51"]
@@ -16,6 +17,7 @@ layer = 2
 script = ExtResource("1_lf64b")
 title_scene = "uid://stdqc6ttomff"
 frays_end = "uid://cufkthb25mpxy"
+abandon_dialogue = ExtResource("2_xccck")
 
 [node name="FabricBackground" type="NinePatchRect" parent="." unique_id=37882440]
 modulate = Color(1, 1, 1, 0.498039)

--- a/scenes/globals/pause/quest_abandoned.dialogue
+++ b/scenes/globals/pause/quest_abandoned.dialogue
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+~ abandoned
+% StoryWeaver: Maybe I'll try that again another time.
+% StoryWeaver: That was a bit much for me right now.
+=> END
+
+~ abandoned_replay
+StoryWeaver: I've heard that one before, anyway.
+=> END

--- a/scenes/globals/pause/quest_abandoned.dialogue.import
+++ b/scenes/globals/pause/quest_abandoned.dialogue.import
@@ -1,0 +1,16 @@
+[remap]
+
+importer="dialogue_manager"
+importer_version=15
+type="Resource"
+uid="uid://bm4xxsl17ho55"
+path="res://.godot/imported/quest_abandoned.dialogue-bdfe93551f9eede68bc00c843e30c79a.tres"
+
+[deps]
+
+source_file="res://scenes/globals/pause/quest_abandoned.dialogue"
+dest_files=["res://.godot/imported/quest_abandoned.dialogue-bdfe93551f9eede68bc00c843e30c79a.tres"]
+
+[params]
+
+defaults=true


### PR DESCRIPTION
We need to pass some temporary state between the point where the quest
is abandoned, and the point where the player has spawned back in the
world. Rather than adding more explicit state to the game, play this
dialogue directly from the pause menu, which is what drives abandoning
quests anyway.

Vary the dialogue based on whether the quest was being played for the
first time, or is being replayed. We could in future vary it based on
whether the quest was a LoreQuest or StoryQuest too.

Resolves https://github.com/endlessm/threadbare/issues/2299

