### PR TITLE
Refactor abilities names

### DIFF
--- a/addons/storyquest_bootstrap/copier.gd
+++ b/addons/storyquest_bootstrap/copier.gd
@@ -119,7 +119,7 @@ func copy_packed_scene(packed_scene: PackedScene, copy_path: String) -> Resource
 	return copied
 
 
-func copy_quest(quest: Quest, copy_path: String) -> Quest:
+func copy_quest(quest: StoryQuest, copy_path: String) -> StoryQuest:
 	var copied := quest.duplicate()
 	copied.title = _title
 	copied.description = _description
@@ -210,7 +210,7 @@ func copy(uid: String, resource: Resource) -> Resource:
 	var copied: Resource
 	if resource is PackedScene:
 		copied = await copy_packed_scene(resource, copy_path)
-	elif resource is Quest:
+	elif resource is StoryQuest:
 		copied = await copy_quest(resource, copy_path)
 	elif resource is CompressedTexture2D or resource is DialogueResource:
 		copied = await copy_as_file(resource, copy_path)
@@ -262,6 +262,6 @@ func copy_tilesets() -> void:
 func create_storyquest() -> void:
 	copy_tilesets()
 
-	var quest: Quest = load(TEMPLATE_PATH.path_join(QUEST_FILENAME))
+	var quest: StoryQuest = load(TEMPLATE_PATH.path_join(QUEST_FILENAME))
 	await copy_resource(quest)
 	EditorInterface.save_all_scenes()

--- a/scenes/game_elements/characters/player/components/unify_abilities_test.tscn
+++ b/scenes/game_elements/characters/player/components/unify_abilities_test.tscn
@@ -99,8 +99,6 @@ highlight_color = Color(0, 0.4392157, 1, 1)
 [node name="GrapplePowerup" parent="OnTheGround" unique_id=1564118198 instance=ExtResource("17_w66m4")]
 position = Vector2(-307, 1770)
 ability = 16
-ability_name = "Grapple"
-interact_action = "Collect Grapple"
 sprite_frames = ExtResource("18_mecxj")
 highlight_color = Color(0.8910073, 0.7227245, 0, 1)
 

--- a/scenes/game_elements/props/powerup/components/powerup.gd
+++ b/scenes/game_elements/props/powerup/components/powerup.gd
@@ -11,14 +11,8 @@ extends CharacterBody2D
 signal collected
 
 ## The player ability to enable.
-@export var ability: Enums.PlayerAbilities = Enums.PlayerAbilities.ABILITY_A
-
-## Name for the ability to display if using the default dialogue.
-@export var ability_name: String
-
-## Text to display in the label when the player gets close to interact with this powerup.
-@export var interact_action: String:
-	set = _set_interact_action
+@export var ability: Enums.PlayerAbilities = Enums.PlayerAbilities.ABILITY_A:
+	set = _set_ability
 
 ## Asset of this powerup.
 @export var sprite_frames: SpriteFrames = preload("uid://cualgrcaaggcm"):
@@ -31,6 +25,9 @@ signal collected
 ## Dialogue to display when collecting the powerup.
 @export var dialogue: DialogueResource = preload("uid://cj0i5jwlv8idi")
 
+## Name for the ability to display if using the default dialogue.
+var ability_name: String
+
 var _tween: Tween
 
 @onready var interact_area: InteractArea = %InteractArea
@@ -41,10 +38,10 @@ var _tween: Tween
 @onready var hookable_collision: CollisionShape2D = %HookableCollision
 
 
-func _set_interact_action(new_interact_action: String) -> void:
-	interact_action = new_interact_action
-	if is_node_ready():
-		interact_area.action = interact_action
+func _set_ability(new_ability: Enums.PlayerAbilities) -> void:
+	ability = new_ability
+	_update_ability_name()
+	interact_area.action = "Collect " + ability_name
 
 
 func _set_sprite_frames(new_sprite_frames: SpriteFrames) -> void:
@@ -60,8 +57,19 @@ func _set_highlight_color(new_highlight_color: Color) -> void:
 		highlight_effect.modulate = highlight_color
 
 
+func _update_ability_name() -> void:
+	if not ability:
+		ability_name = ""
+		return
+	var abilities_names: Dictionary[Enums.PlayerAbilities, String] = LoreInfo.ABILITIES_NAMES
+	if GameState.quest and GameState.quest.quest is StoryQuest:
+		var sq := GameState.quest.quest as StoryQuest
+		abilities_names = sq.abilities_names
+	ability_name = abilities_names.get(ability)
+
+
 func _ready() -> void:
-	_set_interact_action(interact_action)
+	_set_ability(ability)
 	_set_sprite_frames(sprite_frames)
 	_set_highlight_color(highlight_color)
 	if Engine.is_editor_hint():

--- a/scenes/game_elements/props/powerup/powerup.tscn
+++ b/scenes/game_elements/props/powerup/powerup.tscn
@@ -113,7 +113,6 @@ unique_name_in_owner = true
 position = Vector2(0, -34)
 sprite_frames = ExtResource("6_ljncq")
 autoplay = "default"
-frame_progress = 0.90992624
 
 [node name="HookableArea" type="Area2D" parent="." unique_id=1984587489 node_paths=PackedStringArray("controlled_entity", "anchor_point")]
 collision_layer = 4096

--- a/scenes/game_elements/props/powerup/powerup.tscn
+++ b/scenes/game_elements/props/powerup/powerup.tscn
@@ -71,7 +71,6 @@ size = Vector2(90, 90)
 collision_layer = 512
 collision_mask = 0
 script = ExtResource("1_5vrqc")
-ability_name = "Repel"
 interact_action = "Collect Repel"
 
 [node name="GroundCollision" type="CollisionShape2D" parent="." unique_id=1403567890]
@@ -114,6 +113,7 @@ unique_name_in_owner = true
 position = Vector2(0, -34)
 sprite_frames = ExtResource("6_ljncq")
 autoplay = "default"
+frame_progress = 0.90992624
 
 [node name="HookableArea" type="Area2D" parent="." unique_id=1984587489 node_paths=PackedStringArray("controlled_entity", "anchor_point")]
 collision_layer = 4096

--- a/scenes/globals/lore_info/lore_info.gd
+++ b/scenes/globals/lore_info/lore_info.gd
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name LoreInfo
+
+## The abilities names or verbs as they appear in game labels. For example: "You got a new
+## ability! Repel".
+const ABILITIES_NAMES: Dictionary[Enums.PlayerAbilities, String] = {
+	Enums.PlayerAbilities.ABILITY_A: "Repel",
+	Enums.PlayerAbilities.ABILITY_B: "Grapple",
+	Enums.PlayerAbilities.ABILITY_B_MODIFIER_1: "Longer Thread",
+}

--- a/scenes/globals/lore_info/lore_info.gd.uid
+++ b/scenes/globals/lore_info/lore_info.gd.uid
@@ -1,0 +1,1 @@
+uid://mn1iy20p5xuc

--- a/scenes/menus/debug/debug_player_abilities_list.gd
+++ b/scenes/menus/debug/debug_player_abilities_list.gd
@@ -18,10 +18,15 @@ func rebuild() -> void:
 		remove_child(child)
 		child.queue_free()
 
-	for ability_name: String in Enums.PlayerAbilities.keys():
-		var ability: Enums.PlayerAbilities = Enums.PlayerAbilities[ability_name]
+	var abilities_names: Dictionary[Enums.PlayerAbilities, String] = LoreInfo.ABILITIES_NAMES
+	if GameState.quest and GameState.quest.quest is StoryQuest:
+		var sq := GameState.quest.quest as StoryQuest
+		abilities_names = sq.abilities_names
+
+	for ability_string: String in Enums.PlayerAbilities.keys():
+		var ability: Enums.PlayerAbilities = Enums.PlayerAbilities[ability_string]
 		var button := CheckButton.new()
-		button.text = ability_name
+		button.text = abilities_names.get(ability, ability_string)
 		button.button_pressed = GameState.player.has_ability(ability)
 		button.toggled.connect(_on_button_toggled.bind(ability))
 		add_child(button)

--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -87,8 +87,8 @@ func _validate_property(property: Dictionary) -> void:
 
 
 func _to_string() -> String:
-	# TODO: subclass name
-	return '<Quest %s: "%s">' % [resource_path, title]
+	var subclass_name: StringName = (get_script() as Script).get_global_name()
+	return '<%s %s: "%s">' % [subclass_name, resource_path, title]
 
 
 ## Returns [member title] if set, or a placeholder identifying the quest otherwise.

--- a/scenes/menus/storybook/components/story_quest.gd
+++ b/scenes/menus/storybook/components/story_quest.gd
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name StoryQuest
+extends Quest
+## A self-contained story that lives alongside Threadbare's main narrative.
+
+## The abilities names or verbs as they appear in game labels. For example: "You got a new
+## ability! Repel".
+@export var abilities_names: Dictionary[Enums.PlayerAbilities, String] = {
+	Enums.PlayerAbilities.ABILITY_A: "Repel",
+	Enums.PlayerAbilities.ABILITY_B: "Grapple",
+	Enums.PlayerAbilities.ABILITY_B_MODIFIER_1: "Longer Thread",
+}

--- a/scenes/menus/storybook/components/story_quest.gd.uid
+++ b/scenes/menus/storybook/components/story_quest.gd.uid
@@ -1,0 +1,1 @@
+uid://dnso5a8iq3s1w

--- a/scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn
+++ b/scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn
@@ -250,8 +250,6 @@ position = Vector2(928, 58)
 [node name="GrapplePowerup" parent="OnTheGround" unique_id=297202740 instance=ExtResource("16_tjibw")]
 position = Vector2(157, 440)
 ability = 16
-ability_name = "Grapple"
-interact_action = "Collect Grapple"
 sprite_frames = ExtResource("17_k7scg")
 highlight_color = Color(0.8910073, 0.7227245, 0, 1)
 

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_powerup.tscn
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_powerup.tscn
@@ -248,8 +248,6 @@ text = "Go!"
 [node name="LongerThreadPowerup" parent="OnTheGround" unique_id=1795462717 instance=ExtResource("17_a36ca")]
 position = Vector2(-549, 689)
 ability = 32
-ability_name = "Longer Thread"
-interact_action = "Collect Longer Thread"
 sprite_frames = ExtResource("18_a36ca")
 highlight_color = Color(0.8910073, 0.7227245, 0, 1)
 

--- a/scenes/quests/lore_quests/quest_002/3_void_grappling/void_grappling_round_2.tscn
+++ b/scenes/quests/lore_quests/quest_002/3_void_grappling/void_grappling_round_2.tscn
@@ -237,8 +237,6 @@ metadata/_edit_group_ = true
 [node name="LongerThreadPowerup" parent="OnTheGround" unique_id=297202740 instance=ExtResource("16_bkul7")]
 position = Vector2(2048, 576)
 ability = 32
-ability_name = "Longer Thread"
-interact_action = "Collect Longer Thread"
 sprite_frames = ExtResource("17_jr6vd")
 highlight_color = Color(0.8910073, 0.7227245, 0, 1)
 

--- a/scenes/quests/story_quests/after_the_tremor/quest.tres
+++ b/scenes/quests/story_quests/after_the_tremor/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://dpenta10ob4us"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://dpenta10ob4us"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_dx67k"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_dx67k"]
 [ext_resource type="SpriteFrames" uid="uid://nfm4t7txex23" path="res://scenes/quests/story_quests/after_the_tremor/player_components/personajes/ente.tres" id="2_ds7b5"]
 
 [resource]

--- a/scenes/quests/story_quests/champ/quest.tres
+++ b/scenes/quests/story_quests/champ/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://cwlb5iclvp44u"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://cwlb5iclvp44u"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_qxsdu"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_qxsdu"]
 
 [resource]
 script = ExtResource("1_qxsdu")

--- a/scenes/quests/story_quests/el_abrigo/quest.tres
+++ b/scenes/quests/story_quests/el_abrigo/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://cx0ivl1xfh5qf"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://cx0ivl1xfh5qf"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_4uyxg"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_4uyxg"]
 
 [resource]
 script = ExtResource("1_4uyxg")

--- a/scenes/quests/story_quests/el_juguete_perdido/quest.tres
+++ b/scenes/quests/story_quests/el_juguete_perdido/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://bq51m1s0elu5s"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://bq51m1s0elu5s"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_bk13m"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_bk13m"]
 [ext_resource type="SpriteFrames" uid="uid://d0ci8wkfqhcai" path="res://scenes/quests/story_quests/el_juguete_perdido/player_components/apolo_components/apolo_player.tres" id="2_1uhqh"]
 
 [resource]

--- a/scenes/quests/story_quests/el_ojo_revelador/quest.tres
+++ b/scenes/quests/story_quests/el_ojo_revelador/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://tphgv15oanfs"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://tphgv15oanfs"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_nmqt7"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_nmqt7"]
 [ext_resource type="SpriteFrames" uid="uid://bhegk5e0gh8n4" path="res://scenes/quests/story_quests/el_ojo_revelador/player_components/el_ojo_revelador_player.tres" id="2_fkj7a"]
 
 [resource]

--- a/scenes/quests/story_quests/eldrune/quest.tres
+++ b/scenes/quests/story_quests/eldrune/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://onwaocv0de6e"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://onwaocv0de6e"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_ukbr7"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_ukbr7"]
 [ext_resource type="SpriteFrames" uid="uid://b1sol6f5xak4b" path="res://scenes/quests/story_quests/eldrune/player_components/eldrune_player.tres" id="2_8cyu4"]
 
 [resource]

--- a/scenes/quests/story_quests/renya_beyond_sorrow/quest.tres
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://bgt34kneuody0"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://bgt34kneuody0"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_kgprh"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_kgprh"]
 [ext_resource type="SpriteFrames" uid="uid://oggfoxxcn6ft" path="res://scenes/quests/story_quests/renya_beyond_sorrow/player_components/renya_player_combat.tres" id="2_e4jtr"]
 
 [resource]

--- a/scenes/quests/story_quests/shjourney/quest.tres
+++ b/scenes/quests/story_quests/shjourney/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://dl2tif60wcb87"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://dl2tif60wcb87"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_ssubp"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_ssubp"]
 [ext_resource type="SpriteFrames" uid="uid://vrthlt7kah8w" path="res://scenes/quests/story_quests/shjourney/Otros_componentes/tim_sprite_frames.tres" id="2_g2xd1"]
 
 [resource]

--- a/scenes/quests/story_quests/stella/quest.tres
+++ b/scenes/quests/story_quests/stella/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://2bvdlmiega0r"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://2bvdlmiega0r"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_sc4n7"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_sc4n7"]
 
 [resource]
 script = ExtResource("1_sc4n7")

--- a/scenes/quests/story_quests/verso/quest.tres
+++ b/scenes/quests/story_quests/verso/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://bossq58g0pu4k"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://bossq58g0pu4k"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_4xhj0"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_4xhj0"]
 
 [resource]
 script = ExtResource("1_4xhj0")

--- a/scenes/quests/template_quests/NO_EDIT/quest.tres
+++ b/scenes/quests/template_quests/NO_EDIT/quest.tres
@@ -1,6 +1,6 @@
-[gd_resource type="Resource" script_class="Quest" format=3 uid="uid://ddxn14xw66ud8"]
+[gd_resource type="Resource" script_class="StoryQuest" format=3 uid="uid://ddxn14xw66ud8"]
 
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_y02x1"]
+[ext_resource type="Script" uid="uid://dnso5a8iq3s1w" path="res://scenes/menus/storybook/components/story_quest.gd" id="1_y02x1"]
 
 [resource]
 script = ExtResource("1_y02x1")


### PR DESCRIPTION
### Add default ability names into a new LoreInfo class

They were set in powerup instances and passed to the dialogue from them. But
these names or verbs will appear in the inventory soon. Also, StoryQuest
creators may want to rename them or modify them.

Also format the "Collect [ability name]" through scripting.

### Add StoryQuest resource with custom ability names

Because StoryQuest creators may want to change these names, or use their own custom abilities.

Update StoryQuest bootstrap automation.

Quest: Use subclass when converting to string for log purposes.

Helps https://github.com/endlessm/threadbare/issues/2280