### PR TITLE
quest_teleporter: Add abandon_point setter

### DIFF
--- a/scenes/game_elements/props/teleporter/quest_teleporter.gd
+++ b/scenes/game_elements/props/teleporter/quest_teleporter.gd
@@ -11,7 +11,8 @@ extends Area2D
 
 ## Spawn point in the current scene to place the player at if they abandon the
 ## quest. Should be outside this area.
-@export var abandon_point: SpawnPoint
+@export var abandon_point: SpawnPoint:
+	set = set_abandon_point
 
 ## Transition to use at the start of the switch to [member quest].
 @export var enter_transition: Transition.Effect:


### PR DESCRIPTION
quest_teleporter: Add abandon_point setter

I defined set_abandon_point but did not make it the setter for the
abandon_point property.
