### PR TITLE
TalkBehavior: Remove before_dialogue hook

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -36,7 +36,10 @@ func _ready() -> void:
 	if self not in eternal_loom.elders:
 		eternal_loom.elders.append(self)
 
-	talk_behavior.before_dialogue = _before_dialogue
+	GameState.global.item_collected.connect(_update_dialogue_title)
+	GameState.global.item_consumed.connect(_update_dialogue_title)
+	_update_dialogue_title()
+
 	interact_area.interaction_ended.connect(_on_interaction_ended)
 	animated_sprite_2d.connect("frame_changed", _on_frame_changed)
 
@@ -82,7 +85,7 @@ func congratulate_player() -> void:
 	await DialogueManager.dialogue_ended
 
 
-func _before_dialogue() -> void:
+func _update_dialogue_title(_item: InventoryItem = null) -> void:
 	if eternal_loom and eternal_loom.is_item_offering_possible():
 		talk_behavior.title = "go_to_loom"
 	elif not _storybook or not _storybook.has_quests():

--- a/scenes/game_logic/talk_behavior.gd
+++ b/scenes/game_logic/talk_behavior.gd
@@ -12,10 +12,6 @@ extends Node
 ## InteractArea.end_interaction].
 ## If the parent is an NPC, it sets the [member InteractArea.action] to "Talk to NAME",
 ## where NAME is the [member NPC.npc_name].[br][br]
-## Optionally, an awaitable function can be passed to [member before_dialogue] if
-## something needs to happen before the [member dialogue] is displayed. This can be used,
-## for example, to dynamically set the [member title] of the dialogue considering the
-## game state at the moment the interaction happens.
 
 @export var dialogue: DialogueResource = preload("uid://cc3paugq4mma4")
 @export var title: String = ""
@@ -27,8 +23,6 @@ extends Node
 ## Each node in this list can be accessed by its [member Node.name].
 ## Having multiple nodes in this list with the same name is not advised.
 @export var extra_context: Array[Node]
-
-var before_dialogue: Callable
 
 
 func _set_interact_area(new_interact_area: InteractArea) -> void:
@@ -54,8 +48,6 @@ func _ready() -> void:
 
 
 func _on_interaction_started(player: Player, _from_right: bool) -> void:
-	if before_dialogue:
-		await before_dialogue.call()
 	var extra: Dictionary[String, Node]
 	for node: Node in extra_context:
 		extra[node.name] = node


### PR DESCRIPTION
TalkBehavior: Remove before_dialogue hook

This was only used by the elder to vary the dialogue based on the game
state. I think it is cleaner to do that directly in response to game
state signals.
