### PR TITLE
Options menu: Split in multiple setting pages

### DIFF
--- a/scenes/globals/pause/pause_overlay.tscn
+++ b/scenes/globals/pause/pause_overlay.tscn
@@ -7,7 +7,6 @@
 [ext_resource type="Script" uid="uid://i4urwefxrrdt" path="res://addons/threadbare_git_describe/version_label.gd" id="3_m62bn"]
 [ext_resource type="PackedScene" uid="uid://dkeb0yjgcfi86" path="res://scenes/menus/options/options.tscn" id="3_sd5t1"]
 [ext_resource type="Script" uid="uid://gntvq01vvati" path="res://scenes/globals/pause/report_bug_button.gd" id="4_mjd51"]
-[ext_resource type="PackedScene" uid="uid://56ja3m4283wa" path="res://scenes/menus/debug/debug_settings.tscn" id="5_ai8ue"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_1tcw0"]
 
@@ -110,13 +109,6 @@ size_flags_horizontal = 4
 theme_type_variation = &"FlatButton"
 text = "Options"
 
-[node name="DebugButton" type="Button" parent="TabContainer/PauseMenu/VBoxContainer" unique_id=75453807]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-theme_type_variation = &"FlatButton"
-text = "Debug Settings"
-
 [node name="ReportBugButton" type="Button" parent="TabContainer/PauseMenu/VBoxContainer" unique_id=1750937607]
 unique_name_in_owner = true
 layout_mode = 2
@@ -137,17 +129,11 @@ unique_name_in_owner = true
 process_mode = 2
 visible = false
 layout_mode = 2
-
-[node name="DebugSettings" parent="TabContainer" unique_id=1197092088 instance=ExtResource("5_ai8ue")]
-visible = false
-layout_mode = 2
-metadata/_tab_index = 2
+metadata/_tab_index = 1
 
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/ResumeButton" to="." method="_on_resume_button_pressed"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/AbandonQuestButton" to="." method="_on_abandon_quest_pressed"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/SkipTutorialButton" to="." method="_on_skip_tutorial_pressed"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/OptionsButton" to="." method="_on_options_button_pressed"]
-[connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/DebugButton" to="TabContainer/DebugSettings" method="show"]
 [connection signal="pressed" from="TabContainer/PauseMenu/VBoxContainer/TitleScreenButton" to="." method="_on_title_screen_button_pressed"]
 [connection signal="back" from="TabContainer/Options" to="." method="_on_options_back"]
-[connection signal="back" from="TabContainer/DebugSettings" to="." method="_on_options_back"]

--- a/scenes/globals/pause/pause_overlay.tscn
+++ b/scenes/globals/pause/pause_overlay.tscn
@@ -70,6 +70,7 @@ theme = ExtResource("2_sd5t1")
 metadata/_tab_index = 0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/PauseMenu" unique_id=113544093]
+custom_minimum_size = Vector2(640, 0)
 layout_mode = 2
 
 [node name="PanelContainer" type="PanelContainer" parent="TabContainer/PauseMenu/VBoxContainer" unique_id=1739655898]

--- a/scenes/menus/debug/components/debug_completed_quests.tscn
+++ b/scenes/menus/debug/components/debug_completed_quests.tscn
@@ -1,0 +1,59 @@
+[gd_scene format=3 uid="uid://bdbgcqsts7sk2"]
+
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_theme"]
+[ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="2_back"]
+[ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="3_arrow"]
+[ext_resource type="PackedScene" uid="uid://cie2w455avmwm" path="res://scenes/menus/debug/debug_completed_quest_list.tscn" id="4_list"]
+
+[node name="DebugCompletedQuests" type="PanelContainer" unique_id=1100020001 node_paths=PackedStringArray("back_button")]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -320.0
+offset_top = -300.0
+offset_right = 320.0
+offset_bottom = 300.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+script = ExtResource("2_back")
+back_button = NodePath("VBoxContainer/BackButton")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1100020002]
+custom_minimum_size = Vector2(640, 0)
+layout_mode = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer" unique_id=1100020003]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"PlayerRibbon"
+
+[node name="Label" type="Label" parent="VBoxContainer/PanelContainer" unique_id=1100020004]
+layout_mode = 2
+text = "Completed Quests"
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer" unique_id=1100020005]
+custom_minimum_size = Vector2(0, 400)
+layout_mode = 2
+size_flags_vertical = 3
+follow_focus = true
+horizontal_scroll_mode = 0
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/ScrollContainer" unique_id=1100020006]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="DebugCompletedQuestList" parent="VBoxContainer/ScrollContainer/MarginContainer" unique_id=1100020007 instance=ExtResource("4_list")]
+layout_mode = 2
+
+[node name="BackButton" type="Button" parent="VBoxContainer" unique_id=1100020008]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Back"
+icon = ExtResource("3_arrow")
+flat = true

--- a/scenes/menus/debug/components/debug_player_abilities.tscn
+++ b/scenes/menus/debug/components/debug_player_abilities.tscn
@@ -1,0 +1,59 @@
+[gd_scene format=3 uid="uid://bdbgpa6vsm70w"]
+
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_theme"]
+[ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="2_back"]
+[ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="3_arrow"]
+[ext_resource type="PackedScene" uid="uid://dap7xk2m1yfhs" path="res://scenes/menus/debug/debug_player_abilities_list.tscn" id="4_list"]
+
+[node name="DebugPlayerAbilities" type="PanelContainer" unique_id=1100030001 node_paths=PackedStringArray("back_button")]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -320.0
+offset_top = -300.0
+offset_right = 320.0
+offset_bottom = 300.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+script = ExtResource("2_back")
+back_button = NodePath("VBoxContainer/BackButton")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1100030002]
+custom_minimum_size = Vector2(640, 0)
+layout_mode = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer" unique_id=1100030003]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"PlayerRibbon"
+
+[node name="Label" type="Label" parent="VBoxContainer/PanelContainer" unique_id=1100030004]
+layout_mode = 2
+text = "Player Abilities"
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer" unique_id=1100030005]
+custom_minimum_size = Vector2(0, 400)
+layout_mode = 2
+size_flags_vertical = 3
+follow_focus = true
+horizontal_scroll_mode = 0
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/ScrollContainer" unique_id=1100030006]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="DebugPlayerAbilitiesList" parent="VBoxContainer/ScrollContainer/MarginContainer" unique_id=1100030007 instance=ExtResource("4_list")]
+layout_mode = 2
+
+[node name="BackButton" type="Button" parent="VBoxContainer" unique_id=1100030008]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Back"
+icon = ExtResource("3_arrow")
+flat = true

--- a/scenes/menus/debug/debug_completed_quest_list.gd
+++ b/scenes/menus/debug/debug_completed_quest_list.gd
@@ -30,6 +30,8 @@ func rebuild() -> void:
 			bits.append(quest.resource_path.get_base_dir().substr(QUEST_ROOT.length() + 1))
 			var button := CheckButton.new()
 			button.text = " · ".join(bits)
+			button.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+			button.clip_text = true
 			button.button_pressed = completed_quests.has(quest)
 			button.toggled.connect(_on_button_toggled.bind(quest))
 			add_child(button)

--- a/scenes/menus/debug/debug_completed_quest_list.tscn
+++ b/scenes/menus/debug/debug_completed_quest_list.tscn
@@ -4,6 +4,10 @@
 [ext_resource type="Script" uid="uid://d3s58aw5loxqd" path="res://scenes/menus/debug/debug_completed_quest_list.gd" id="1_68hah"]
 
 [node name="DebugCompletedQuestList" type="VBoxContainer" unique_id=1279772854]
+anchors_preset = 10
+anchor_right = 1.0
+offset_bottom = 192.0
+grow_horizontal = 2
 theme = ExtResource("1_1g3i8")
 theme_override_constants/separation = 0
 script = ExtResource("1_68hah")
@@ -12,13 +16,19 @@ script = ExtResource("1_68hah")
 editor_description = "These sample nodes are deleted at runtime; they are only here to help edit this scene, and scenes that use it."
 layout_mode = 2
 text = "The Musician's Quest · lore_quests/quest_001"
+text_overrun_behavior = 3
+clip_text = true
 
 [node name="Sample2" type="CheckButton" parent="." unique_id=1811931812]
 editor_description = "These sample nodes are deleted at runtime; they are only here to help edit this scene, and scenes that use it."
 layout_mode = 2
 text = "After The Tremor · story_quests/after_the_tremor"
+text_overrun_behavior = 3
+clip_text = true
 
 [node name="Sample3" type="CheckButton" parent="." unique_id=1488387126]
 editor_description = "These sample nodes are deleted at runtime; they are only here to help edit this scene, and scenes that use it."
 layout_mode = 2
 text = "template_quests/NO_EDIT"
+text_overrun_behavior = 3
+clip_text = true

--- a/scenes/menus/debug/debug_player_abilities_list.gd
+++ b/scenes/menus/debug/debug_player_abilities_list.gd
@@ -27,6 +27,8 @@ func rebuild() -> void:
 		var ability: Enums.PlayerAbilities = Enums.PlayerAbilities[ability_string]
 		var button := CheckButton.new()
 		button.text = abilities_names.get(ability, ability_string)
+		button.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+		button.clip_text = true
 		button.button_pressed = GameState.player.has_ability(ability)
 		button.toggled.connect(_on_button_toggled.bind(ability))
 		add_child(button)

--- a/scenes/menus/debug/debug_player_abilities_list.tscn
+++ b/scenes/menus/debug/debug_player_abilities_list.tscn
@@ -1,19 +1,27 @@
 [gd_scene format=3 uid="uid://dap7xk2m1yfhs"]
 
+[ext_resource type="Script" uid="uid://chcw7ewwtftgl" path="res://scenes/menus/debug/debug_player_abilities_list.gd" id="1_script"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_theme"]
-[ext_resource type="Script" path="res://scenes/menus/debug/debug_player_abilities_list.gd" id="1_script"]
 
-[node name="DebugPlayerAbilitiesList" type="VBoxContainer"]
+[node name="DebugPlayerAbilitiesList" type="VBoxContainer" unique_id=491953567]
+anchors_preset = 10
+anchor_right = 1.0
+offset_bottom = 128.0
+grow_horizontal = 2
 theme = ExtResource("1_theme")
 theme_override_constants/separation = 0
 script = ExtResource("1_script")
 
-[node name="Sample1" type="CheckButton" parent="."]
+[node name="Sample1" type="CheckButton" parent="." unique_id=2050727879]
 editor_description = "These sample nodes are deleted at runtime; they are only here to help edit this scene, and scenes that use it."
 layout_mode = 2
 text = "ABILITY_A"
+text_overrun_behavior = 3
+clip_text = true
 
-[node name="Sample2" type="CheckButton" parent="."]
+[node name="Sample2" type="CheckButton" parent="." unique_id=1934970896]
 editor_description = "These sample nodes are deleted at runtime; they are only here to help edit this scene, and scenes that use it."
 layout_mode = 2
 text = "ABILITY_B"
+text_overrun_behavior = 3
+clip_text = true

--- a/scenes/menus/debug/debug_settings.tscn
+++ b/scenes/menus/debug/debug_settings.tscn
@@ -18,6 +18,15 @@ back_button = NodePath("VBoxContainer/BackButton")
 custom_minimum_size = Vector2(640, 0)
 layout_mode = 2
 
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer" unique_id=2028086682]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"PlayerRibbon"
+
+[node name="Label" type="Label" parent="VBoxContainer/PanelContainer" unique_id=1494650387]
+layout_mode = 2
+text = "Debug Settings"
+
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer" unique_id=57528092]
 layout_mode = 2
 size_flags_vertical = 3

--- a/scenes/menus/debug/debug_settings.tscn
+++ b/scenes/menus/debug/debug_settings.tscn
@@ -15,6 +15,7 @@ script = ExtResource("2_46px3")
 back_button = NodePath("VBoxContainer/BackButton")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1670771472]
+custom_minimum_size = Vector2(640, 0)
 layout_mode = 2
 
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer" unique_id=57528092]

--- a/scenes/menus/debug/debug_settings.tscn
+++ b/scenes/menus/debug/debug_settings.tscn
@@ -1,75 +1,88 @@
 [gd_scene format=3 uid="uid://56ja3m4283wa"]
 
-[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_w7kol"]
-[ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="2_46px3"]
-[ext_resource type="PackedScene" uid="uid://cie2w455avmwm" path="res://scenes/menus/debug/debug_completed_quest_list.tscn" id="2_k06h7"]
-[ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="3_46px3"]
-[ext_resource type="PackedScene" uid="uid://dap7xk2m1yfhs" path="res://scenes/menus/debug/debug_player_abilities_list.tscn" id="4_abilities"]
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_theme"]
+[ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="2_back"]
+[ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="3_arrow"]
+[ext_resource type="PackedScene" uid="uid://bdbgcqsts7sk2" path="res://scenes/menus/debug/components/debug_completed_quests.tscn" id="4_cq"]
+[ext_resource type="PackedScene" uid="uid://bdbgpa6vsm70w" path="res://scenes/menus/debug/components/debug_player_abilities.tscn" id="5_pa"]
 
-[node name="DebugSettings" type="PanelContainer" unique_id=35497477 node_paths=PackedStringArray("back_button")]
-custom_minimum_size = Vector2(800, 600)
-offset_right = 675.0
-offset_bottom = 255.0
-theme = ExtResource("1_w7kol")
-script = ExtResource("2_46px3")
-back_button = NodePath("VBoxContainer/BackButton")
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_panel"]
 
-[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1670771472]
+[node name="DebugSettings" type="CenterContainer" unique_id=35497477 node_paths=PackedStringArray("back_button", "default_page")]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -221.0
+offset_top = -225.0
+offset_right = 221.0
+offset_bottom = 225.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+script = ExtResource("2_back")
+back_button = NodePath("TabContainer/DebugMenu/VBoxContainer/BackButton")
+default_page = NodePath("TabContainer/DebugMenu")
+
+[node name="TabContainer" type="TabContainer" parent="." unique_id=1100040001]
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxEmpty_panel")
+current_tab = 0
+tabs_visible = false
+
+[node name="DebugMenu" type="PanelContainer" parent="TabContainer" unique_id=1100040002]
+unique_name_in_owner = true
+layout_mode = 2
+metadata/_tab_index = 0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/DebugMenu" unique_id=1100040003]
 custom_minimum_size = Vector2(640, 0)
 layout_mode = 2
 
-[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer" unique_id=2028086682]
+[node name="PanelContainer" type="PanelContainer" parent="TabContainer/DebugMenu/VBoxContainer" unique_id=1100040004]
 layout_mode = 2
 size_flags_horizontal = 4
 theme_type_variation = &"PlayerRibbon"
 
-[node name="Label" type="Label" parent="VBoxContainer/PanelContainer" unique_id=1494650387]
+[node name="Label" type="Label" parent="TabContainer/DebugMenu/VBoxContainer/PanelContainer" unique_id=1100040005]
 layout_mode = 2
 text = "Debug Settings"
 
-[node name="TabContainer" type="TabContainer" parent="VBoxContainer" unique_id=57528092]
+[node name="CompletedQuestsButton" type="Button" parent="TabContainer/DebugMenu/VBoxContainer" unique_id=1100040006]
 layout_mode = 2
-size_flags_vertical = 3
-tab_alignment = 1
-current_tab = 0
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Completed Quests"
 
-[node name="Completed Quests" type="ScrollContainer" parent="VBoxContainer/TabContainer" unique_id=2057728842]
+[node name="PlayerAbilitiesButton" type="Button" parent="TabContainer/DebugMenu/VBoxContainer" unique_id=1100040007]
 layout_mode = 2
-follow_focus = true
-horizontal_scroll_mode = 0
-metadata/_tab_index = 0
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Player Abilities"
 
-[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TabContainer/Completed Quests" unique_id=802864242]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="DebugCompletedQuestList" parent="VBoxContainer/TabContainer/Completed Quests/MarginContainer" unique_id=1279772854 instance=ExtResource("2_k06h7")]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="Player Abilities" type="ScrollContainer" parent="VBoxContainer/TabContainer" unique_id=1413429209]
-visible = false
-layout_mode = 2
-follow_focus = true
-horizontal_scroll_mode = 0
-metadata/_tab_index = 1
-
-[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TabContainer/Player Abilities" unique_id=1320054365]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="DebugPlayerAbilitiesList" parent="VBoxContainer/TabContainer/Player Abilities/MarginContainer" unique_id=1996259651 instance=ExtResource("4_abilities")]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="BackButton" type="Button" parent="VBoxContainer" unique_id=751568689]
+[node name="BackButton" type="Button" parent="TabContainer/DebugMenu/VBoxContainer" unique_id=1100040008]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 theme_type_variation = &"FlatButton"
 text = "Back"
-icon = ExtResource("3_46px3")
+icon = ExtResource("3_arrow")
 flat = true
+
+[node name="CompletedQuests" parent="TabContainer" unique_id=1100040010 instance=ExtResource("4_cq")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 1
+
+[node name="PlayerAbilities" parent="TabContainer" unique_id=1100040011 instance=ExtResource("5_pa")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 2
+
+[connection signal="pressed" from="TabContainer/DebugMenu/VBoxContainer/CompletedQuestsButton" to="TabContainer/CompletedQuests" method="show"]
+[connection signal="pressed" from="TabContainer/DebugMenu/VBoxContainer/PlayerAbilitiesButton" to="TabContainer/PlayerAbilities" method="show"]
+[connection signal="back" from="TabContainer/CompletedQuests" to="TabContainer/DebugMenu" method="show"]
+[connection signal="back" from="TabContainer/CompletedQuests" to="TabContainer/DebugMenu/VBoxContainer/BackButton" method="grab_focus"]
+[connection signal="back" from="TabContainer/PlayerAbilities" to="TabContainer/DebugMenu" method="show"]
+[connection signal="back" from="TabContainer/PlayerAbilities" to="TabContainer/DebugMenu/VBoxContainer/BackButton" method="grab_focus"]

--- a/scenes/menus/options/components/language_settings.tscn
+++ b/scenes/menus/options/components/language_settings.tscn
@@ -2,28 +2,43 @@
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_abc"]
 [ext_resource type="Script" uid="uid://dk2wa6nonu0jc" path="res://scenes/menus/options/components/language_option.gd" id="2_abc"]
+[ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="3_back"]
+[ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="4_arrow"]
 
-[node name="LanguageSettings" type="VBoxContainer" unique_id=85827291]
-offset_left = 96.0
-offset_top = 64.0
-offset_right = 544.0
-offset_bottom = 254.0
+[node name="LanguageSettings" type="PanelContainer" unique_id=1534586532 node_paths=PackedStringArray("back_button")]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -266.5
+offset_top = -153.0
+offset_right = 266.5
+offset_bottom = 153.0
+grow_horizontal = 2
+grow_vertical = 2
 theme = ExtResource("1_abc")
+script = ExtResource("3_back")
+back_button = NodePath("VBoxContainer/BackButton")
 
-[node name="PanelContainer" type="PanelContainer" parent="." unique_id=1311807474]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=85827291]
+custom_minimum_size = Vector2(640, 0)
 layout_mode = 2
-size_flags_horizontal = 0
+
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer" unique_id=1311807474]
+layout_mode = 2
+size_flags_horizontal = 4
 theme_type_variation = &"PlayerRibbon"
 
-[node name="Label" type="Label" parent="PanelContainer" unique_id=1487597883]
+[node name="Label" type="Label" parent="VBoxContainer/PanelContainer" unique_id=1487597883]
 layout_mode = 2
 text = "Language Settings"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="." unique_id=1302951996]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer" unique_id=1302951996]
 layout_mode = 2
 script = ExtResource("2_abc")
 
-[node name="EnglishButton" type="Button" parent="HBoxContainer" unique_id=993974861]
+[node name="EnglishButton" type="Button" parent="VBoxContainer/HBoxContainer" unique_id=993974861]
 unique_name_in_owner = true
 auto_translate_mode = 2
 layout_mode = 2
@@ -32,7 +47,7 @@ theme_type_variation = &"FlatButton"
 toggle_mode = true
 text = "English"
 
-[node name="SpanishButton" type="Button" parent="HBoxContainer" unique_id=355814411]
+[node name="SpanishButton" type="Button" parent="VBoxContainer/HBoxContainer" unique_id=355814411]
 unique_name_in_owner = true
 auto_translate_mode = 2
 layout_mode = 2
@@ -41,5 +56,14 @@ theme_type_variation = &"FlatButton"
 toggle_mode = true
 text = "Español"
 
-[connection signal="pressed" from="HBoxContainer/EnglishButton" to="HBoxContainer" method="_on_button_pressed" binds= ["en"]]
-[connection signal="pressed" from="HBoxContainer/SpanishButton" to="HBoxContainer" method="_on_button_pressed" binds= ["es"]]
+[node name="BackButton" type="Button" parent="VBoxContainer" unique_id=1300000003]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Back"
+icon = ExtResource("4_arrow")
+flat = true
+
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/EnglishButton" to="VBoxContainer/HBoxContainer" method="_on_button_pressed" binds= ["en"]]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/SpanishButton" to="VBoxContainer/HBoxContainer" method="_on_button_pressed" binds= ["es"]]

--- a/scenes/menus/options/components/options.gd
+++ b/scenes/menus/options/components/options.gd
@@ -2,9 +2,15 @@
 # SPDX-License-Identifier: MPL-2.0
 extends Control
 
+## Emitted when this menu goes back to the previous (if any)
+## through the [member back_button].
 signal back
 
+## The button to go back to the previous menu, if any.
 @export var back_button: Button
+
+## The default control to show when this menu becomes visible.
+@export var default_page: Control
 
 
 func _ready() -> void:
@@ -15,8 +21,11 @@ func _ready() -> void:
 
 
 func _on_visibility_changed() -> void:
-	if visible and back_button:
-		back_button.grab_focus()
+	if visible:
+		if back_button:
+			back_button.grab_focus()
+		if default_page:
+			default_page.show()
 
 
 func _on_back_button_pressed() -> void:

--- a/scenes/menus/options/components/sound_settings.tscn
+++ b/scenes/menus/options/components/sound_settings.tscn
@@ -2,42 +2,66 @@
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_g0mqx"]
 [ext_resource type="PackedScene" uid="uid://dvlpr4m0dt5rw" path="res://scenes/menus/options/components/volume_slider.tscn" id="3_ntmw0"]
+[ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="4_back"]
+[ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="5_arrow"]
 
-[node name="SoundSettings" type="VBoxContainer" unique_id=707663916]
-offset_left = 96.0
-offset_top = 64.0
-offset_right = 544.0
-offset_bottom = 254.0
+[node name="SoundSettings" type="PanelContainer" unique_id=1536122933 node_paths=PackedStringArray("back_button")]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -224.0
+offset_top = -109.0
+offset_right = 224.0
+offset_bottom = 109.0
+grow_horizontal = 2
+grow_vertical = 2
 theme = ExtResource("1_g0mqx")
+script = ExtResource("4_back")
+back_button = NodePath("VBoxContainer/BackButton")
 
-[node name="PanelContainer" type="PanelContainer" parent="." unique_id=2027742998]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=707663916]
+custom_minimum_size = Vector2(640, 0)
 layout_mode = 2
-size_flags_horizontal = 0
+
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer" unique_id=2027742998]
+layout_mode = 2
+size_flags_horizontal = 4
 theme_type_variation = &"PlayerRibbon"
 
-[node name="Label" type="Label" parent="PanelContainer" unique_id=305661971]
+[node name="Label" type="Label" parent="VBoxContainer/PanelContainer" unique_id=305661971]
 layout_mode = 2
 text = "Sound Settings"
 
-[node name="GridContainer" type="GridContainer" parent="." unique_id=198803873]
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer" unique_id=198803873]
 layout_mode = 2
 columns = 2
 
-[node name="MusicLabel" type="Label" parent="GridContainer" unique_id=1017472749]
+[node name="MusicLabel" type="Label" parent="VBoxContainer/GridContainer" unique_id=1017472749]
 layout_mode = 2
 text = "Music"
 horizontal_alignment = 2
 
-[node name="MusicSlider" parent="GridContainer" unique_id=72306828 instance=ExtResource("3_ntmw0")]
+[node name="MusicSlider" parent="VBoxContainer/GridContainer" unique_id=72306828 instance=ExtResource("3_ntmw0")]
 unique_name_in_owner = true
 layout_mode = 2
 bus_name = "Music"
 
-[node name="SFXLabel" type="Label" parent="GridContainer" unique_id=1732124740]
+[node name="SFXLabel" type="Label" parent="VBoxContainer/GridContainer" unique_id=1732124740]
 layout_mode = 2
 text = "Sound Effects"
 horizontal_alignment = 2
 
-[node name="SFXSlider" parent="GridContainer" unique_id=1153945983 instance=ExtResource("3_ntmw0")]
+[node name="SFXSlider" parent="VBoxContainer/GridContainer" unique_id=1153945983 instance=ExtResource("3_ntmw0")]
 layout_mode = 2
 bus_name = "SFX"
+
+[node name="BackButton" type="Button" parent="VBoxContainer" unique_id=1300000001]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Back"
+icon = ExtResource("5_arrow")
+flat = true

--- a/scenes/menus/options/components/video_settings.tscn
+++ b/scenes/menus/options/components/video_settings.tscn
@@ -2,36 +2,61 @@
 
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_qb52c"]
 [ext_resource type="Script" uid="uid://c63sfg6wgj2uy" path="res://scenes/menus/options/components/settings_toggle.gd" id="2_qb52c"]
+[ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="3_back"]
+[ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="4_arrow"]
 
-[node name="VideoSettings" type="VBoxContainer" unique_id=1199621136]
-offset_left = 96.0
-offset_top = 64.0
-offset_right = 544.0
-offset_bottom = 254.0
+[node name="VideoSettings" type="PanelContainer" unique_id=150368892 node_paths=PackedStringArray("back_button")]
+custom_minimum_size = Vector2(640, 0)
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -224.0
+offset_top = -191.5
+offset_right = 224.0
+offset_bottom = 191.5
+grow_horizontal = 2
+grow_vertical = 2
 theme = ExtResource("1_qb52c")
+script = ExtResource("3_back")
+back_button = NodePath("VBoxContainer/BackButton")
 
-[node name="PanelContainer" type="PanelContainer" parent="." unique_id=2038282423]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1199621136]
+custom_minimum_size = Vector2(640, 0)
 layout_mode = 2
-size_flags_horizontal = 0
+
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer" unique_id=2038282423]
+layout_mode = 2
+size_flags_horizontal = 4
 theme_type_variation = &"PlayerRibbon"
 
-[node name="Label" type="Label" parent="PanelContainer" unique_id=1282877578]
+[node name="Label" type="Label" parent="VBoxContainer/PanelContainer" unique_id=1282877578]
 layout_mode = 2
 text = "Video Settings"
 
-[node name="GridContainer" type="GridContainer" parent="." unique_id=277212195]
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer" unique_id=277212195]
 layout_mode = 2
 theme_override_constants/v_separation = 0
 
-[node name="ShowControlsButton" type="CheckButton" parent="GridContainer" unique_id=153771304]
+[node name="ShowControlsButton" type="CheckButton" parent="VBoxContainer/GridContainer" unique_id=153771304]
 layout_mode = 2
 text = "Show Controls"
 script = ExtResource("2_qb52c")
 setting = &"show_input_hud"
 
-[node name="FullscreenButton" type="CheckButton" parent="GridContainer" unique_id=409098937]
+[node name="FullscreenButton" type="CheckButton" parent="VBoxContainer/GridContainer" unique_id=409098937]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Fullscreen"
 script = ExtResource("2_qb52c")
 setting = &"fullscreen"
+
+[node name="BackButton" type="Button" parent="VBoxContainer" unique_id=1300000002]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Back"
+icon = ExtResource("4_arrow")
+flat = true

--- a/scenes/menus/options/options.tscn
+++ b/scenes/menus/options/options.tscn
@@ -1,40 +1,73 @@
 [gd_scene format=3 uid="uid://dkeb0yjgcfi86"]
 
-[ext_resource type="PackedScene" uid="uid://de6s2quemrmkf" path="res://scenes/menus/options/components/sound_settings.tscn" id="1_7hrlm"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_ptihp"]
 [ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="2_cw13b"]
-[ext_resource type="PackedScene" uid="uid://tahf2q1d3e74" path="res://scenes/menus/options/components/video_settings.tscn" id="4_cw13b"]
+[ext_resource type="PackedScene" uid="uid://de6s2quemrmkf" path="res://scenes/menus/options/components/sound_settings.tscn" id="3_sound"]
+[ext_resource type="PackedScene" uid="uid://tahf2q1d3e74" path="res://scenes/menus/options/components/video_settings.tscn" id="4_video"]
 [ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="5_qdq3g"]
 [ext_resource type="PackedScene" uid="uid://w0uscqwgsi4w" path="res://scenes/menus/options/components/language_settings.tscn" id="6_lang"]
 
-[node name="Options" type="CenterContainer" unique_id=2066163370 node_paths=PackedStringArray("back_button")]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_panel"]
+
+[node name="Options" type="CenterContainer" unique_id=810691496 node_paths=PackedStringArray("back_button")]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -221.0
+offset_top = -225.0
+offset_right = 221.0
+offset_bottom = 225.0
 grow_horizontal = 2
 grow_vertical = 2
 theme = ExtResource("1_ptihp")
 script = ExtResource("2_cw13b")
-back_button = NodePath("PanelContainer/VBoxContainer/BackButton")
-metadata/_tab_index = 1
+back_button = NodePath("TabContainer/OptionsMenu/VBoxContainer/BackButton")
 
-[node name="PanelContainer" type="PanelContainer" parent="." unique_id=280848008]
+[node name="TabContainer" type="TabContainer" parent="." unique_id=2066163370]
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxEmpty_panel")
+current_tab = 0
+tabs_visible = false
+
+[node name="OptionsMenu" type="PanelContainer" parent="TabContainer" unique_id=1100000001]
+unique_name_in_owner = true
+layout_mode = 2
+metadata/_tab_index = 0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/OptionsMenu" unique_id=1100000002]
 custom_minimum_size = Vector2(640, 0)
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer" unique_id=924753986]
+[node name="PanelContainer" type="PanelContainer" parent="TabContainer/OptionsMenu/VBoxContainer" unique_id=1100000003]
 layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"PlayerRibbon"
 
-[node name="SoundSettingsPanel" parent="PanelContainer/VBoxContainer" unique_id=527494601 instance=ExtResource("1_7hrlm")]
+[node name="Label" type="Label" parent="TabContainer/OptionsMenu/VBoxContainer/PanelContainer" unique_id=1100000004]
 layout_mode = 2
+text = "Options"
 
-[node name="VideoSettings" parent="PanelContainer/VBoxContainer" unique_id=201104966 instance=ExtResource("4_cw13b")]
+[node name="SoundSettingsButton" type="Button" parent="TabContainer/OptionsMenu/VBoxContainer" unique_id=1100000005]
 layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Sound Settings"
 
-[node name="LanguageSettings" parent="PanelContainer/VBoxContainer" unique_id=1730937504 instance=ExtResource("6_lang")]
+[node name="VideoSettingsButton" type="Button" parent="TabContainer/OptionsMenu/VBoxContainer" unique_id=1100000006]
 layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Video Settings"
 
-[node name="BackButton" type="Button" parent="PanelContainer/VBoxContainer" unique_id=200110196]
+[node name="LanguageSettingsButton" type="Button" parent="TabContainer/OptionsMenu/VBoxContainer" unique_id=1100000007]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Language Settings"
+
+[node name="BackButton" type="Button" parent="TabContainer/OptionsMenu/VBoxContainer" unique_id=200110196]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -42,3 +75,28 @@ theme_type_variation = &"FlatButton"
 text = "Back"
 icon = ExtResource("5_qdq3g")
 flat = true
+
+[node name="SoundSettings" parent="TabContainer" unique_id=1100000010 instance=ExtResource("3_sound")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 1
+
+[node name="VideoSettings" parent="TabContainer" unique_id=1100000011 instance=ExtResource("4_video")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 2
+
+[node name="LanguageSettings" parent="TabContainer" unique_id=1100000012 instance=ExtResource("6_lang")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 3
+
+[connection signal="pressed" from="TabContainer/OptionsMenu/VBoxContainer/SoundSettingsButton" to="TabContainer/SoundSettings" method="show"]
+[connection signal="pressed" from="TabContainer/OptionsMenu/VBoxContainer/VideoSettingsButton" to="TabContainer/VideoSettings" method="show"]
+[connection signal="pressed" from="TabContainer/OptionsMenu/VBoxContainer/LanguageSettingsButton" to="TabContainer/LanguageSettings" method="show"]
+[connection signal="back" from="TabContainer/SoundSettings" to="TabContainer/OptionsMenu" method="show"]
+[connection signal="back" from="TabContainer/SoundSettings" to="TabContainer/OptionsMenu/VBoxContainer/BackButton" method="grab_focus"]
+[connection signal="back" from="TabContainer/VideoSettings" to="TabContainer/OptionsMenu" method="show"]
+[connection signal="back" from="TabContainer/VideoSettings" to="TabContainer/OptionsMenu/VBoxContainer/BackButton" method="grab_focus"]
+[connection signal="back" from="TabContainer/LanguageSettings" to="TabContainer/OptionsMenu" method="show"]
+[connection signal="back" from="TabContainer/LanguageSettings" to="TabContainer/OptionsMenu/VBoxContainer/BackButton" method="grab_focus"]

--- a/scenes/menus/options/options.tscn
+++ b/scenes/menus/options/options.tscn
@@ -10,7 +10,7 @@
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_panel"]
 
-[node name="Options" type="CenterContainer" unique_id=810691496 node_paths=PackedStringArray("back_button")]
+[node name="Options" type="CenterContainer" unique_id=810691496 node_paths=PackedStringArray("back_button", "default_page")]
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
@@ -25,6 +25,7 @@ grow_vertical = 2
 theme = ExtResource("1_ptihp")
 script = ExtResource("2_cw13b")
 back_button = NodePath("TabContainer/OptionsMenu/VBoxContainer/BackButton")
+default_page = NodePath("TabContainer/OptionsMenu")
 
 [node name="TabContainer" type="TabContainer" parent="." unique_id=2066163370]
 layout_mode = 2

--- a/scenes/menus/options/options.tscn
+++ b/scenes/menus/options/options.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://tahf2q1d3e74" path="res://scenes/menus/options/components/video_settings.tscn" id="4_video"]
 [ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="5_qdq3g"]
 [ext_resource type="PackedScene" uid="uid://w0uscqwgsi4w" path="res://scenes/menus/options/components/language_settings.tscn" id="6_lang"]
+[ext_resource type="PackedScene" uid="uid://56ja3m4283wa" path="res://scenes/menus/debug/debug_settings.tscn" id="7_s7dil"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_panel"]
 
@@ -67,6 +68,12 @@ size_flags_horizontal = 4
 theme_type_variation = &"FlatButton"
 text = "Language Settings"
 
+[node name="DebugSettingsButton" type="Button" parent="TabContainer/OptionsMenu/VBoxContainer" unique_id=1520031485]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+text = "Debug Settings"
+
 [node name="BackButton" type="Button" parent="TabContainer/OptionsMenu/VBoxContainer" unique_id=200110196]
 unique_name_in_owner = true
 layout_mode = 2
@@ -91,12 +98,20 @@ visible = false
 layout_mode = 2
 metadata/_tab_index = 3
 
+[node name="DebugSettings" parent="TabContainer" unique_id=35497477 instance=ExtResource("7_s7dil")]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 4
+
 [connection signal="pressed" from="TabContainer/OptionsMenu/VBoxContainer/SoundSettingsButton" to="TabContainer/SoundSettings" method="show"]
 [connection signal="pressed" from="TabContainer/OptionsMenu/VBoxContainer/VideoSettingsButton" to="TabContainer/VideoSettings" method="show"]
 [connection signal="pressed" from="TabContainer/OptionsMenu/VBoxContainer/LanguageSettingsButton" to="TabContainer/LanguageSettings" method="show"]
+[connection signal="pressed" from="TabContainer/OptionsMenu/VBoxContainer/DebugSettingsButton" to="TabContainer/DebugSettings" method="show"]
 [connection signal="back" from="TabContainer/SoundSettings" to="TabContainer/OptionsMenu" method="show"]
 [connection signal="back" from="TabContainer/SoundSettings" to="TabContainer/OptionsMenu/VBoxContainer/BackButton" method="grab_focus"]
 [connection signal="back" from="TabContainer/VideoSettings" to="TabContainer/OptionsMenu" method="show"]
 [connection signal="back" from="TabContainer/VideoSettings" to="TabContainer/OptionsMenu/VBoxContainer/BackButton" method="grab_focus"]
 [connection signal="back" from="TabContainer/LanguageSettings" to="TabContainer/OptionsMenu" method="show"]
 [connection signal="back" from="TabContainer/LanguageSettings" to="TabContainer/OptionsMenu/VBoxContainer/BackButton" method="grab_focus"]
+[connection signal="back" from="TabContainer/DebugSettings" to="TabContainer/OptionsMenu" method="show"]
+[connection signal="back" from="TabContainer/DebugSettings" to="TabContainer/OptionsMenu/VBoxContainer/BackButton" method="grab_focus"]


### PR DESCRIPTION
Make the Video, Sound and Language settings have each their own page. This adds
space for expanding these settings.

### Pause overlay: Move Debug Settings inside Options menu

### Debug Settings: Add title and prevent horizontal overflow

Add ellipsis to quest names and ability names, in case they are too long, so
they don't resize the settings panel.

### Options: Add default page to show

Usually this would be the first element of the TabContainer. We now have
submenus in the pause overlay, so if eg. Video Settings was being displayed and
the player resumes the game, then pauses the game and selects Options, it should
not go to Video Settings (the last one shown) directly.

### Debug Settings: Split in submenus

With submenus introduced, it makes more sense to have the existing 2 debug
setting in their own page, for easier navigation.

Helps https://github.com/endlessm/threadbare/issues/2280