### PR TITLE
Keep list of quests in the Elder scene

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -7,7 +7,10 @@ extends CharacterBody2D
 const STORYBOOK_SCENE := preload("uid://bhm7fdjvppt8b")
 
 ## Directory of quests that this Elder offers to the player during interactions.
-@export_dir var quest_directory: String
+## This directory should have 1 or more subdirectories, each of which
+## have a [code]quest.tres[/code] file within.
+@export_dir var quest_directory: String:
+	set = _set_quest_directory
 
 ## A reference to the loom, so that this Elder can determine whether you have
 ## the items you need to operate it.
@@ -20,7 +23,7 @@ const STORYBOOK_SCENE := preload("uid://bhm7fdjvppt8b")
 var chosen_quest: Quest
 
 var _dialogue_balloon: CanvasLayer
-var _storybook: Storybook
+var _quests: Array[Quest]
 
 @onready var animated_sprite_2d: AnimatedSprite2D = %AnimatedSprite2D
 @onready var interact_area: InteractArea = %InteractArea
@@ -39,12 +42,16 @@ func _ready() -> void:
 	interact_area.interaction_ended.connect(_on_interaction_ended)
 	animated_sprite_2d.connect("frame_changed", _on_frame_changed)
 
-	if quest_directory:
-		_storybook = STORYBOOK_SCENE.instantiate()
-		_storybook.quest_directory = quest_directory
-
 	GameState.global.item_collected.connect(_update_dialogue_title)
 	GameState.global.item_consumed.connect(_update_dialogue_title)
+	_update_dialogue_title()
+
+
+func _set_quest_directory(new_value: String) -> void:
+	quest_directory = new_value
+	if Engine.is_editor_hint():
+		return
+	_quests = Quest.enumerate(quest_directory)
 	_update_dialogue_title()
 
 
@@ -60,24 +67,20 @@ func _get_configuration_warnings() -> PackedStringArray:
 	return warnings
 
 
-func has_quests() -> bool:
-	return _storybook and _storybook.has_quests()
-
-
 ## Show a storybook to the player, and wait for them to select a story or close the book.
 func show_storybook() -> void:
-	if not _storybook:
-		return
+	var storybook := STORYBOOK_SCENE.instantiate()
+	storybook.quests = _quests
 
 	# GDM will hide the balloon after a short pause if the awaitable hasn't resolved, but we want it
 	# to be replaced with the storybook immediately.
 	if _dialogue_balloon:
 		_dialogue_balloon.balloon.hide()
 
-	_storybook_layer.add_child(_storybook)
-	_storybook.reset_focus()
-	chosen_quest = await _storybook.selected
-	_storybook_layer.remove_child(_storybook)
+	_storybook_layer.add_child(storybook)
+	chosen_quest = await storybook.selected
+	_storybook_layer.remove_child(storybook)
+	storybook.queue_free()
 
 
 func congratulate_player() -> void:
@@ -88,7 +91,7 @@ func congratulate_player() -> void:
 func _update_dialogue_title(_item: InventoryItem = null) -> void:
 	if eternal_loom and eternal_loom.is_item_offering_possible():
 		talk_behavior.title = "go_to_loom"
-	elif not _storybook or not _storybook.has_quests():
+	elif not _quests:
 		talk_behavior.title = "no_quests"
 	else:
 		talk_behavior.title = ""

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -22,12 +22,9 @@ const TEMPLATE_ANIMATION_NAME: StringName = &"idle"
 
 const QUEST_RESOURCE_NAME := "quest.tres"
 
-## Directory to scan for quests. This directory should have 1 or more subdirectories, each of which
-## have a [code]quest.tres[/code] file within.
-@export_dir var quest_directory: String:
-	set = _set_quest_directory
+## Quests to show in the storybook.
+@export var quests: Array[Quest]
 
-var _quests: Array[Quest] = []
 var _current_spread_index: int = -1
 var _navigation_locked: bool = false
 
@@ -41,26 +38,14 @@ var _navigation_locked: bool = false
 @onready var right_button: Button = %Right_Button
 
 
-func _enumerate_quests() -> Array[Quest]:
-	var quests: Array[Quest] = Quest.enumerate(quest_directory)
-	var template_index := quests.find(STORY_QUEST_TEMPLATE)
-	if template_index != -1:
-		quests[template_index] = TEMPLATE_QUEST_METADATA
-
-	return quests
-
-
-func _set_quest_directory(new_value: String) -> void:
-	quest_directory = new_value
-	_quests = _enumerate_quests()
-
-
 func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
 
 	var previous_button: Button = null
-	for i in _quests.size():
-		var quest: Quest = _quests[i]
+	for i in quests.size():
+		var quest: Quest = quests[i]
+		if quest == STORY_QUEST_TEMPLATE:
+			quest = TEMPLATE_QUEST_METADATA
 		var button := Button.new()
 		button.text = quest.get_title()
 		button.theme_type_variation = "FlatButton"
@@ -89,7 +74,7 @@ func _ready() -> void:
 ## Show/hide index or detail pages
 func _update_page_visibility() -> void:
 	left_button.visible = _current_spread_index > 0
-	right_button.visible = _current_spread_index < _quests.size()
+	right_button.visible = _current_spread_index < quests.size()
 
 	if _current_spread_index == 0:
 		quest_container.visible = true
@@ -104,8 +89,11 @@ func _update_page_visibility() -> void:
 		storybook_page.visible = true
 
 		var quest_index: int = _current_spread_index - 1
-		if quest_index >= 0 and quest_index < _quests.size():
-			storybook_page.quest = _quests[quest_index]
+		if quest_index >= 0 and quest_index < quests.size():
+			var quest: Quest = quests[quest_index]
+			if quest == STORY_QUEST_TEMPLATE:
+				quest = TEMPLATE_QUEST_METADATA
+			storybook_page.quest = quest
 
 			if storybook_page.play_button and is_instance_valid(storybook_page.play_button):
 				if not storybook_page.play_button.has_focus():
@@ -120,7 +108,7 @@ func _switch_to_page(spread_index: int) -> void:
 	if _navigation_locked:
 		return
 
-	var total_spreads: int = _quests.size() + 1
+	var total_spreads: int = quests.size() + 1
 	if total_spreads <= 1:
 		return
 
@@ -193,7 +181,3 @@ func _on_back_button_pressed() -> void:
 
 func reset_focus() -> void:
 	_switch_to_page(0)
-
-
-func has_quests() -> bool:
-	return not _quests.is_empty()

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -2,10 +2,14 @@
 
 [ext_resource type="Script" uid="uid://5bt5um5g1g3p" path="res://scenes/menus/storybook/components/storybook.gd" id="1_gw8hn"]
 [ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_m2ghf"]
+[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="3_21r2o"]
 [ext_resource type="PackedScene" uid="uid://cgtonist08yxn" path="res://scenes/menus/storybook/components/storybook_page.tscn" id="3_n2i2u"]
 [ext_resource type="SpriteFrames" uid="uid://dne3cxrhbjuno" path="res://scenes/menus/storybook/components/storybook_animation.tres" id="3_y0b3i"]
+[ext_resource type="Resource" uid="uid://2bvdlmiega0r" path="res://scenes/quests/story_quests/stella/quest.tres" id="4_ywp77"]
 [ext_resource type="Texture2D" uid="uid://bqe8u2t2tsoma" path="res://assets/third_party/tiny-swords/UI/Buttons/Button_Disable_3Slides.png" id="5_jl72s"]
 [ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="5_m2ghf"]
+[ext_resource type="Resource" uid="uid://tphgv15oanfs" path="res://scenes/quests/story_quests/el_ojo_revelador/quest.tres" id="5_x5pjn"]
+[ext_resource type="Resource" uid="uid://ddxn14xw66ud8" path="res://scenes/quests/template_quests/NO_EDIT/quest.tres" id="5_ywp77"]
 [ext_resource type="Texture2D" uid="uid://bxk0fu4vv6wt2" path="res://assets/third_party/tiny-swords/UI/Buttons/Button_Hover_3Slides.png" id="6_b2xx3"]
 [ext_resource type="Texture2D" uid="uid://dv7kcbngjjwq7" path="res://assets/third_party/tiny-swords/UI/Buttons/Button_Blue_3Slides.png" id="7_21r2o"]
 [ext_resource type="Texture2D" uid="uid://dcum6i8n2paam" path="res://assets/third_party/tiny-swords/UI/Buttons/Button_Blue_3Slides_Pressed.png" id="8_ywp77"]
@@ -268,7 +272,7 @@ grow_vertical = 2
 size_flags_horizontal = 4
 theme = ExtResource("1_m2ghf")
 script = ExtResource("1_gw8hn")
-quest_directory = "res://scenes/quests/story_quests/"
+quests = Array[ExtResource("3_21r2o")]([ExtResource("4_ywp77"), ExtResource("5_ywp77"), ExtResource("5_x5pjn")])
 
 [node name="Panel" type="PanelContainer" parent="." unique_id=802233687]
 layout_mode = 1


### PR DESCRIPTION
Keep list of quests in the Elder scene

Previously, the quest folder path was a property of the elder which
would pass it through to the storybook scene, and rely on the storybook
to see if there are any quests inside.

Instead, give the storybook scene an Array[Quest] property. Set it in
the .tscn to two semi-randomly-selected quests to ease testing.

Then have the elder list the contents of the quest directory and pass
the list of quests into the storybook. Construct the storybook on demand.
