### PR TITLE
Elder: Hide dialogue balloon immediately when showing storybook

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -22,7 +22,6 @@ const STORYBOOK_SCENE := preload("uid://bhm7fdjvppt8b")
 ## The quest chosen by the player from the storybook
 var chosen_quest: Quest
 
-var _dialogue_balloon: CanvasLayer
 var _quests: Array[Quest]
 
 @onready var animated_sprite_2d: AnimatedSprite2D = %AnimatedSprite2D
@@ -75,8 +74,10 @@ func show_storybook() -> void:
 
 	# GDM will hide the balloon after a short pause if the awaitable hasn't resolved, but we want it
 	# to be replaced with the storybook immediately.
-	if _dialogue_balloon:
-		_dialogue_balloon.balloon.hide()
+	if talk_behavior.dialogue_balloon:
+		# Confusingly the DialogueBalloon node (root of our balloon.tscn) has a balloon property;
+		# it is the latter which gets hidden and shown.
+		talk_behavior.dialogue_balloon.balloon.hide()
 
 	_storybook_layer.add_child(storybook)
 	chosen_quest = await storybook.selected

--- a/scenes/game_logic/talk_behavior.gd
+++ b/scenes/game_logic/talk_behavior.gd
@@ -24,6 +24,9 @@ extends Node
 ## Having multiple nodes in this list with the same name is not advised.
 @export var extra_context: Array[Node]
 
+## While showing dialogue, the dialogue balloon node.
+var dialogue_balloon: Node
+
 
 func _set_interact_area(new_interact_area: InteractArea) -> void:
 	interact_area = new_interact_area
@@ -51,6 +54,9 @@ func _on_interaction_started(player: Player, _from_right: bool) -> void:
 	var extra: Dictionary[String, Node]
 	for node: Node in extra_context:
 		extra[node.name] = node
-	DialogueManager.show_dialogue_balloon(dialogue, title, [get_parent(), player, extra])
+	dialogue_balloon = DialogueManager.show_dialogue_balloon(
+		dialogue, title, [get_parent(), player, extra]
+	)
 	await DialogueManager.dialogue_ended
+	dialogue_balloon = null  # The balloon queue_free()s itself
 	interact_area.end_interaction()


### PR DESCRIPTION
This regressed when the elder was switched to use TalkBehavior.

