### PR TITLE
Elder: Don't crash when setting quest_directory before ready

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -52,7 +52,8 @@ func _set_quest_directory(new_value: String) -> void:
 	if Engine.is_editor_hint():
 		return
 	_quests = Quest.enumerate(quest_directory)
-	_update_dialogue_title()
+	if is_node_ready():
+		_update_dialogue_title()
 
 
 func _get_configuration_warnings() -> PackedStringArray:


### PR DESCRIPTION
`_update_dialogue_title` requires `talk_behavior` to have been initialised,
which happens via `@onready`. But `quest_directory` is set prior to the
scene becoming ready.
