### PR TITLE
Add title screen when entering a LoreQuest

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -22,7 +22,6 @@ const STORYBOOK_SCENE := preload("uid://bhm7fdjvppt8b")
 ## The quest chosen by the player from the storybook
 var chosen_quest: Quest
 
-var _dialogue_balloon: CanvasLayer
 var _quests: Array[Quest]
 
 @onready var animated_sprite_2d: AnimatedSprite2D = %AnimatedSprite2D
@@ -75,8 +74,10 @@ func show_storybook() -> void:
 
 	# GDM will hide the balloon after a short pause if the awaitable hasn't resolved, but we want it
 	# to be replaced with the storybook immediately.
-	if _dialogue_balloon:
-		_dialogue_balloon.balloon.hide()
+	if talk_behavior.dialogue_balloon:
+		# Confusingly the DialogueBalloon node (root of our balloon.tscn) has a balloon property;
+		# it is the latter which gets hidden and shown.
+		talk_behavior.dialogue_balloon.balloon.hide()
 
 	_storybook_layer.add_child(storybook)
 	chosen_quest = await storybook.selected

--- a/scenes/game_elements/props/teleporter/quest_teleporter.gd
+++ b/scenes/game_elements/props/teleporter/quest_teleporter.gd
@@ -18,10 +18,6 @@ extends Area2D
 @export var enter_transition: Transition.Effect:
 	set = set_enter_transition
 
-## Transition to use at the end of the switch to [member quest].
-@export var exit_transition: Transition.Effect:
-	set = set_exit_transition
-
 @onready var scene_link: SceneLink = %SceneLink
 
 
@@ -29,7 +25,6 @@ extends Area2D
 func _ready() -> void:
 	set_quest(quest)
 	set_enter_transition(enter_transition)
-	set_exit_transition(exit_transition)
 
 	if not Engine.is_editor_hint():
 		body_entered.connect(_on_body_entered)
@@ -50,8 +45,6 @@ func _get_configuration_warnings() -> PackedStringArray:
 #region Setters
 func set_quest(new_value: LoreQuest) -> void:
 	quest = new_value
-	if scene_link:
-		scene_link.next_scene = quest.first_scene if quest else ""
 	update_configuration_warnings()
 
 
@@ -64,12 +57,6 @@ func set_enter_transition(new_value: Transition.Effect) -> void:
 	enter_transition = new_value
 	if scene_link:
 		scene_link.enter_transition = new_value
-
-
-func set_exit_transition(new_value: Transition.Effect) -> void:
-	exit_transition = new_value
-	if scene_link:
-		scene_link.exit_transition = new_value
 
 
 #endregion

--- a/scenes/game_elements/props/teleporter/quest_teleporter.tscn
+++ b/scenes/game_elements/props/teleporter/quest_teleporter.tscn
@@ -10,4 +10,5 @@ script = ExtResource("1_b63j3")
 [node name="SceneLink" type="Node2D" parent="." unique_id=926828314]
 unique_name_in_owner = true
 script = ExtResource("3_5i7c3")
+next_scene = "uid://c0fdh0ttv7brl"
 metadata/_custom_type_script = "uid://d2vp62mjrf6gn"

--- a/scenes/game_logic/talk_behavior.gd
+++ b/scenes/game_logic/talk_behavior.gd
@@ -24,6 +24,9 @@ extends Node
 ## Having multiple nodes in this list with the same name is not advised.
 @export var extra_context: Array[Node]
 
+## While showing dialogue, the dialogue balloon node.
+var dialogue_balloon: Node
+
 
 func _set_interact_area(new_interact_area: InteractArea) -> void:
 	interact_area = new_interact_area
@@ -51,6 +54,9 @@ func _on_interaction_started(player: Player, _from_right: bool) -> void:
 	var extra: Dictionary[String, Node]
 	for node: Node in extra_context:
 		extra[node.name] = node
-	DialogueManager.show_dialogue_balloon(dialogue, title, [get_parent(), player, extra])
+	dialogue_balloon = DialogueManager.show_dialogue_balloon(
+		dialogue, title, [get_parent(), player, extra]
+	)
 	await DialogueManager.dialogue_ended
+	dialogue_balloon = null  # The balloon queue_free()s itself
 	interact_area.end_interaction()

--- a/scenes/menus/quest_separator/components/quest_separator.gd
+++ b/scenes/menus/quest_separator/components/quest_separator.gd
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Control
+
+@onready var title: Label = %Title
+@onready var animated_texture_rect: AnimatedTextureRect = %AnimatedTextureRect
+@onready var rich_text_label: RichTextLabel = %RichTextLabel
+
+
+func _ready() -> void:
+	var quest := GameState.quest.quest
+
+	title.text = quest.title
+	animated_texture_rect.sprite_frames = quest.sprite_frames
+	rich_text_label.text = quest.description
+
+	await get_tree().create_timer(3).timeout
+
+	(
+		SceneSwitcher
+		. change_to_file_with_transition(
+			quest.first_scene,
+			^"",
+			Transition.Effect.RADIAL,
+			Transition.Effect.FADE,
+		)
+	)

--- a/scenes/menus/quest_separator/components/quest_separator.gd.uid
+++ b/scenes/menus/quest_separator/components/quest_separator.gd.uid
@@ -1,0 +1,1 @@
+uid://dccjkvox5cjsy

--- a/scenes/menus/quest_separator/quest_separator.tscn
+++ b/scenes/menus/quest_separator/quest_separator.tscn
@@ -1,0 +1,113 @@
+[gd_scene format=3 uid="uid://c0fdh0ttv7brl"]
+
+[ext_resource type="Theme" uid="uid://cvitou84ni7qe" path="res://scenes/ui_elements/components/theme.tres" id="1_7uacu"]
+[ext_resource type="Texture2D" uid="uid://lg5dl13njsg3" path="res://assets/first_party/tiles/Grass_And_Sand_Tiles.png" id="1_m3hp4"]
+[ext_resource type="Script" uid="uid://dccjkvox5cjsy" path="res://scenes/menus/quest_separator/components/quest_separator.gd" id="2_ayaqs"]
+[ext_resource type="Texture2D" uid="uid://csbhg24hsxecd" path="res://scenes/quests/lore_quests/quest_002/Void.png" id="4_fqr5p"]
+[ext_resource type="Script" uid="uid://dfx8s2ybd11mt" path="res://scenes/menus/storybook/components/animated_texture_rect.gd" id="4_olqir"]
+[ext_resource type="Texture2D" uid="uid://dcwmaoqgu5t84" path="res://scenes/globals/scene_switcher/transitions/Radial.png" id="6_wq0a1"]
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_l1xe8"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": ExtResource("4_fqr5p")
+}],
+"loop": true,
+"name": &"default",
+"speed": 5.0
+}]
+
+[sub_resource type="Shader" id="Shader_wq0a1"]
+code = "shader_type canvas_item;
+render_mode blend_sub;
+
+void vertex() {
+	// Called for every vertex the material is visible on.
+}
+
+void fragment() {
+	// Called for every pixel the material is visible on.
+}
+
+//void light() {
+//	// Called for every pixel for every light affecting the CanvasItem.
+//	// Uncomment to replace the default light processing function with this one.
+//}
+"
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_amr4g"]
+shader = SubResource("Shader_wq0a1")
+
+[node name="QuestSeparator" type="Control" unique_id=277155232]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_7uacu")
+script = ExtResource("2_ayaqs")
+
+[node name="FabricBackground" type="NinePatchRect" parent="." unique_id=321321864]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("1_m3hp4")
+region_rect = Rect2(384, 64, 64, 64)
+axis_stretch_horizontal = 1
+axis_stretch_vertical = 1
+
+[node name="MarginContainer" type="MarginContainer" parent="." unique_id=1658580560]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1354617346]
+layout_mode = 2
+
+[node name="TitleBox" type="PanelContainer" parent="MarginContainer/VBoxContainer" unique_id=495174348]
+custom_minimum_size = Vector2(370, 64)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_type_variation = &"PlayerRibbon"
+
+[node name="Title" type="Label" parent="MarginContainer/VBoxContainer/TitleBox" unique_id=3731616]
+unique_name_in_owner = true
+layout_mode = 2
+text = "The Void"
+horizontal_alignment = 1
+
+[node name="AnimatedTextureRect" type="TextureRect" parent="MarginContainer/VBoxContainer" unique_id=2119895536]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+expand_mode = 1
+stretch_mode = 5
+script = ExtResource("4_olqir")
+sprite_frames = SubResource("SpriteFrames_l1xe8")
+animation_name = &"default"
+metadata/_custom_type_script = "uid://dfx8s2ybd11mt"
+
+[node name="RichTextLabel" type="RichTextLabel" parent="MarginContainer/VBoxContainer" unique_id=822544477]
+unique_name_in_owner = true
+layout_mode = 2
+text = "StoryWeaver runs away from a growing emptiness that spreads across the land, smothering and swallowing everything it covers."
+fit_content = true
+
+[node name="TextureRect" type="TextureRect" parent="." unique_id=279230856]
+material = SubResource("ShaderMaterial_amr4g")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("6_wq0a1")

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -1430,7 +1430,6 @@ position = Vector2(5, 7)
 quest = ExtResource("59_t7c6s")
 abandon_point = NodePath("../SpawnPoint")
 enter_transition = 4
-exit_transition = 1
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/SouthPath/QuestTeleporter" unique_id=2120778996]
 shape = SubResource("RectangleShape2D_uxfrp")

--- a/scenes/world_map/linenville_path.tscn
+++ b/scenes/world_map/linenville_path.tscn
@@ -732,7 +732,6 @@ position = Vector2(3041, 1310)
 quest = ExtResource("30_hq8vv")
 abandon_point = NodePath("SpawnPoint")
 enter_transition = 1
-exit_transition = 1
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Links/VoidQuest/VoidQuestTeleporter" unique_id=2073303635]
 shape = SubResource("RectangleShape2D_6r5d6")

--- a/scenes/world_map/song_sanctuary_path.tscn
+++ b/scenes/world_map/song_sanctuary_path.tscn
@@ -1122,7 +1122,6 @@ position = Vector2(571, 56)
 quest = ExtResource("24_jhhto")
 abandon_point = NodePath("SpawnPoint")
 enter_transition = 5
-exit_transition = 5
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="MusicianQuestTeleporter" unique_id=1318641544]
 shape = SubResource("RectangleShape2D_4mhqc")
@@ -1135,7 +1134,6 @@ position = Vector2(1563, 638)
 quest = ExtResource("37_bt13d")
 abandon_point = NodePath("SpawnPoint")
 enter_transition = 5
-exit_transition = 5
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PlaceholderQuestTeleporter" unique_id=441493068]
 shape = SubResource("RectangleShape2D_b6uih")


### PR DESCRIPTION
Add title screen when entering a LoreQuest

The player no longer chooses LoreQuests from a book, so there is no
longer any clear demarcation that a quest has begun.

Add a quest title screen, which displays the the title, description, and
art from the current Quest resource, then switches to the first scene
after a short delay. Update QuestTeleporter to switch to this scene
rather than to the first scene of the quest. Remove the exit_transition
property from QuestTeleporter: the title card removes the spatial
relationship between the hub and the starting scene of the quest.

Resolves https://github.com/endlessm/threadbare/issues/2298

Co-authored-by: Will Thompson <wjt@endlessaccess.org>
