### PR TITLE
Powerup: Don't access GameState in editor or before _ready

### DIFF
--- a/scenes/game_elements/props/powerup/components/powerup.gd
+++ b/scenes/game_elements/props/powerup/components/powerup.gd
@@ -40,8 +40,9 @@ var _tween: Tween
 
 func _set_ability(new_ability: Enums.PlayerAbilities) -> void:
 	ability = new_ability
-	_update_ability_name()
-	interact_area.action = "Collect " + ability_name
+	if not Engine.is_editor_hint() and is_node_ready():
+		_update_ability_name()
+		interact_area.action = "Collect " + ability_name if ability_name else "Collect"
 
 
 func _set_sprite_frames(new_sprite_frames: SpriteFrames) -> void:


### PR DESCRIPTION
Previously, during export:

    SCRIPT ERROR: Invalid access to property or key 'quest' on a base object of type 'Node (game_state.gd)'.
              at: _update_ability_name (res://scenes/game_elements/props/powerup/components/powerup.gd:65)
              GDScript backtrace (most recent call first):
                  [0] _update_ability_name (res://scenes/game_elements/props/powerup/components/powerup.gd:65)
                  [1] _set_ability (res://scenes/game_elements/props/powerup/components/powerup.gd:43)
    SCRIPT ERROR: Invalid assignment of property or key 'action' with value of type 'String' on a base object of type 'Nil'.
              at: _set_ability (res://scenes/game_elements/props/powerup/components/powerup.gd:44)
              GDScript backtrace (most recent call first):
                  [0] _set_ability (res://scenes/game_elements/props/powerup/components/powerup.gd:44)

And when editing a scene that uses a powerup in the editor:

    ERROR: res://scenes/game_elements/props/powerup/components/powerup.gd:65 - Invalid access to property or key 'quest' on a base object of type 'Node (game_state.gd)'.
    ERROR: res://scenes/game_elements/props/powerup/components/powerup.gd:44 - Invalid assignment of property or key 'action' with value of type 'String' on a base object of type 'Nil'.
    ERROR: res://scenes/game_elements/props/powerup/components/powerup.gd:65 - Invalid access to property or key 'quest' on a base object of type 'Node (game_state.gd)'.


`powerup.gd` is a `@tool` script (so that its appearance
can be updated based on the sprite_frames property, I guess) but
`game_state.gd` is not. But the `Powerup.ability` setter would
previously try to use properties of GameState unconditionally.

In `_set_ability`, skip `_update_ability_name()` in two cases:

1. When running in the editor: GameState is not available here, and the
   `ability_name` property and the interact area's action description
   aren't used in the editor anyway.
2. When not _ready(): When playing a specific scene with `F6`, GameState
   will not be _ready() at the point where the scene containing the
   powerup is added to the tree. So `GameState.quest` will be null and
   the powerup will always be named after the default abilities:
   incorrect if the quest eventually turns out to have custom names.

`_set_ability` is called again from `_ready` (in our standard pattern)
so this should cause no behaviour change in-game.

Helps https://github.com/endlessm/threadbare/issues/2353
