### PR TITLE
PlayerMode: Don't access GameState before _ready()

### DIFF
--- a/scenes/game_logic/player_mode.gd
+++ b/scenes/game_logic/player_mode.gd
@@ -25,6 +25,8 @@ enum Mode {
 
 func set_mode(new_mode: Mode) -> void:
 	mode = new_mode
+	if not is_node_ready():
+		return
 	match mode:
 		Mode.FIGHTING:
 			GameState.player.abilities = Enums.PlayerAbilities.ABILITY_A


### PR DESCRIPTION
When playing a scene directly (with F6) which uses PlayerMode with a
non-default mode, the scene would crash as follows:

    SCRIPT ERROR: Invalid access to property or key 'player' on a base object of type 'Nil'.
        at: @player_getter (res://scenes/globals/game_state/game_state.gd:57)
        GDScript backtrace (most recent call first):
            [0] @player_getter (res://scenes/globals/game_state/game_state.gd:57)
            [1] set_mode (res://scenes/game_logic/player_mode.gd:30)

The offending line of code is:

    return quest.player if quest else global.player

The issue is that `GameState.global` is `null` until `GameState` becomes
ready. And the scene tree is set up before sending the ready
notification. This is a regression from commit
515115d8d76d8c9d9f5687b142e0c846684cf6f5 refactoring the game state.

In `PlayerMode.set_mode()`, don't access `GameState` if the `PlayerMode`
is not ready. `GameState` will become ready first, and
`PlayerMode._ready` calls `set_mode()` again.
