### PR TITLE
Phantom Camera: Filter exported files

### DIFF
--- a/addons/phantom_camera/export_plugin.gd
+++ b/addons/phantom_camera/export_plugin.gd
@@ -1,0 +1,26 @@
+extends EditorExportPlugin
+## Excludes Phantom Camera files that are not needed in exported game
+##
+## Annoyingly EditorExportPlugin._export_file() is not called for .gd files, so
+## (for example) example scripts are included in the export.
+
+const IGNORED_PATHS := [
+	"/assets",
+	"/examples",
+	"/fonts",
+	"/inspector",
+	"/panel",
+	"/scripts/panel",
+	"/themes",
+]
+
+
+func _get_name() -> String:
+	return "Phantom Camera Export Plugin"
+
+
+func _export_file(path: String, type: String, features: PackedStringArray) -> void:
+	var plugin_path: String = self.get_script().resource_path.get_base_dir()
+	for ignored_path: String in IGNORED_PATHS:
+		if path.begins_with(plugin_path + ignored_path):
+			skip()

--- a/addons/phantom_camera/export_plugin.gd.uid
+++ b/addons/phantom_camera/export_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://be54drdkmjbwu

--- a/addons/phantom_camera/plugin.gd
+++ b/addons/phantom_camera/plugin.gd
@@ -37,6 +37,7 @@ var pcam_3d_noise_emitter_gizmo_plugin: EditorNode3DGizmoPlugin = PCam3DNoiseEmi
 var editor_panel_instance: Control
 var panel_button: Button
 #var viewfinder_panel_instance
+var export_plugin: EditorExportPlugin
 
 #endregion
 
@@ -122,8 +123,16 @@ func _enter_tree() -> void:
 	scene_changed.connect(editor_panel_instance.viewfinder.scene_changed)
 	scene_changed.connect(_scene_changed)
 
+	if Engine.is_editor_hint():
+		export_plugin = preload("./export_plugin.gd").new()
+		add_export_plugin(export_plugin)
+
 
 func _exit_tree() -> void:
+	if Engine.is_editor_hint():
+		remove_export_plugin(export_plugin)
+		export_plugin = null
+
 	panel_button.toggled.disconnect(_btn_toggled)
 	scene_changed.disconnect(editor_panel_instance.viewfinder.scene_changed)
 	scene_changed.disconnect(_scene_changed)


### PR DESCRIPTION
Phantom Camera: Filter exported files

Most of this plugin is not needed in exported builds. In particular, it
includes some example scenes that trigger warnings during export, so
excluding these feeds two birds with one scone: reduced export warnings
& smaller .pck.

Annoyingly I have learnt that EditorExportPlugin doesn't get the chance
to exclude .gd files, so scripts from the example scenes are included.
At least the .gdc files are relatively small.

The alternatives are:

1. Filter out unwanted files in each export preset. I don't like this
   because you have to configure this for each export preset separately.
   I think it is error-prone.
2. Delete the files from the source tree. This would allow us to fully
   exclude the examples, including scripts, but would mean taking
   special care when we update the plugin, and also doesn't let us
   filter out unwanted scenes.

Helps https://github.com/endlessm/threadbare/issues/2353
