### PR TITLE
Elders: Hide balloon from dialogue

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -72,13 +72,6 @@ func show_storybook() -> void:
 	var storybook := STORYBOOK_SCENE.instantiate()
 	storybook.quests = _quests
 
-	# GDM will hide the balloon after a short pause if the awaitable hasn't resolved, but we want it
-	# to be replaced with the storybook immediately.
-	if talk_behavior.dialogue_balloon:
-		# Confusingly the DialogueBalloon node (root of our balloon.tscn) has a balloon property;
-		# it is the latter which gets hidden and shown.
-		talk_behavior.dialogue_balloon.balloon.hide()
-
 	_storybook_layer.add_child(storybook)
 	chosen_quest = await storybook.selected
 	_storybook_layer.remove_child(storybook)

--- a/scenes/game_elements/characters/npcs/elder/components/story_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/elder/components/story_quest_starter.dialogue
@@ -3,6 +3,7 @@
 ~ start
 StoryQuest Elder: [[Hi|Hello|Greetings]], StoryWeaver. We've been waiting for you. Our world is unraveling!
 StoryQuest Elder: We need you to recover the Sacred Elements: the threads of Memory, Imagination, and Spirit! Will you help us?
+do balloon.hide()
 do show_storybook()
 if chosen_quest == null:
 	% StoryQuest Elder: Please stay. Our world will perish without your help!

--- a/scenes/game_elements/characters/npcs/elder/components/template_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/elder/components/template_quest_starter.dialogue
@@ -3,6 +3,7 @@
 ~ start
 Template Elder: [[Hi|Hello|Greetings]], StoryWeaver. We've been waiting for you. Our world is unraveling!
 Template Elder: We need you to recover the Sacred Elements: the threads of Memory, Imagination, and Spirit! Will you help us?
+do balloon.hide()
 do show_storybook()
 if chosen_quest == null:
 	% Template Elder: Please stay. Our world will perish without your help!

--- a/scenes/game_logic/talk_behavior.gd
+++ b/scenes/game_logic/talk_behavior.gd
@@ -24,9 +24,6 @@ extends Node
 ## Having multiple nodes in this list with the same name is not advised.
 @export var extra_context: Array[Node]
 
-## While showing dialogue, the dialogue balloon node.
-var dialogue_balloon: Node
-
 
 func _set_interact_area(new_interact_area: InteractArea) -> void:
 	interact_area = new_interact_area
@@ -54,9 +51,6 @@ func _on_interaction_started(player: Player, _from_right: bool) -> void:
 	var extra: Dictionary[String, Node]
 	for node: Node in extra_context:
 		extra[node.name] = node
-	dialogue_balloon = DialogueManager.show_dialogue_balloon(
-		dialogue, title, [get_parent(), player, extra]
-	)
+	DialogueManager.show_dialogue_balloon(dialogue, title, [get_parent(), player, extra])
 	await DialogueManager.dialogue_ended
-	dialogue_balloon = null  # The balloon queue_free()s itself
 	interact_area.end_interaction()


### PR DESCRIPTION
Elders: Hide balloon from dialogue

I have just noticed that the balloon script adds itself to the context
that is available to dialogue. This means there is a cleaner way to hide
the dialogue balloon before showing the storybook than what I
implemented in commit dfa9e69bc3011695f41967fd95532a9fb67bbae4: call
`balloon.hide()` directly from the dialogue, right before calling
`show_storybook()` on the Elder (which talk_behavior.gd passes as
context).

Implement this. Remove the plumbing that I added to make the balloon
node accessible from the elder script.
