### PR TITLE
void: Add checkpoints to void runner levels

### DIFF
--- a/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
@@ -49,6 +49,7 @@
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="29_gbo6l"]
 [ext_resource type="Resource" uid="uid://cki0neredlfou" path="res://scenes/quests/lore_quests/quest_002/1_void_runner/components/runner_lore_helper.dialogue" id="29_tsnue"]
 [ext_resource type="PackedScene" uid="uid://cf3cbl12wt6vr" path="res://scenes/game_elements/props/buildings/temple/temple.tscn" id="37_kgem8"]
+[ext_resource type="PackedScene" uid="uid://dua6mynlw2ptw" path="res://scenes/game_elements/props/checkpoint/checkpoint.tscn" id="48_auh5r"]
 
 [sub_resource type="NavigationPolygon" id="NavigationPolygon_05yrb"]
 vertices = PackedVector2Array(2927.9531, 1448.9609, 2920.039, 3273.8203, -1078, 3206.1563, -1078, 1433.0313)
@@ -80,6 +81,9 @@ size = Vector2(52, 61)
 script = ExtResource("23_amu0w")
 name = "Memory"
 metadata/_custom_type_script = "uid://bgmwplmj3bfls"
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_amu0w"]
+size = Vector2(64, 64)
 
 [node name="VoidRunner" type="Node2D" unique_id=506997450 node_paths=PackedStringArray("whole_scene_camera", "void_layer", "collectible_thread", "enemy")]
 script = ExtResource("1_r04sh")
@@ -1245,6 +1249,13 @@ sprite_frames = ExtResource("23_wtoj6")
 
 [node name="Rock" parent="OnTheGround/UnreachableIsland1" unique_id=82472428 instance=ExtResource("16_kfcfu")]
 position = Vector2(3079, 2415)
+
+[node name="Checkpoint" parent="OnTheGround" unique_id=1789892556 instance=ExtResource("48_auh5r")]
+position = Vector2(891, 2845)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Checkpoint" unique_id=181527241]
+position = Vector2(-25, 5)
+shape = SubResource("RectangleShape2D_amu0w")
 
 [node name="InTheWater" type="Node2D" parent="." unique_id=1796092885]
 z_index = -1

--- a/scenes/quests/lore_quests/quest_002/3_void_grappling/void_grappling_round_2.tscn
+++ b/scenes/quests/lore_quests/quest_002/3_void_grappling/void_grappling_round_2.tscn
@@ -32,6 +32,7 @@
 [ext_resource type="SpriteFrames" uid="uid://ckf0ncgsrnhek" path="res://scenes/game_elements/props/decoration/bush/components/bush_spriteframes_purple_large.tres" id="27_jr6vd"]
 [ext_resource type="SpriteFrames" uid="uid://k4jucjwkxxhc" path="res://scenes/game_elements/props/decoration/bush/components/bush_spriteframes_purple_small.tres" id="28_hxopk"]
 [ext_resource type="PackedScene" uid="uid://0ull24fvmhwk" path="res://scenes/game_elements/props/teleporter/teleporter.tscn" id="30_jr6vd"]
+[ext_resource type="PackedScene" uid="uid://dua6mynlw2ptw" path="res://scenes/game_elements/props/checkpoint/checkpoint.tscn" id="31_7xn87"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_grfk2"]
 size = Vector2(246, 549)
@@ -78,6 +79,12 @@ _data = {
 "points": PackedVector2Array(0, 0, 30, -30, 0, 0, -30, -30, 30, 30, 128, 0, 30, -30, -30, 30, 128, 128, 30, 30, -30, -30, 0, 128, -30, 30, 0, 0, 0, 0)
 }
 point_count = 5
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_jsqns"]
+size = Vector2(20, 320)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_7xn87"]
+size = Vector2(128, 128)
 
 [sub_resource type="NavigationPolygon" id="NavigationPolygon_c2723"]
 vertices = PackedVector2Array(2921.961, 2408.0469, 2928.9375, 3614.9766, -1572.9609, 3609.0078, -1559.0313, 112, 3734.039, 116.99219, 3742.961, 2105.039)
@@ -646,6 +653,19 @@ sprite_frames = ExtResource("27_jr6vd")
 [node name="Bush12" parent="OnTheGround/Props" unique_id=1771825618 instance=ExtResource("24_wrwcr")]
 position = Vector2(3234, 347)
 sprite_frames = ExtResource("28_hxopk")
+
+[node name="Checkpoint" parent="OnTheGround" unique_id=1789892556 instance=ExtResource("31_7xn87")]
+position = Vector2(374, 411)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Checkpoint" unique_id=2027973572]
+shape = SubResource("RectangleShape2D_jsqns")
+
+[node name="Checkpoint2" parent="OnTheGround" unique_id=1081431851 instance=ExtResource("31_7xn87")]
+position = Vector2(1673, 195)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Checkpoint2" unique_id=376778593]
+position = Vector2(-26, 0)
+shape = SubResource("RectangleShape2D_7xn87")
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="." unique_id=1623064448]
 


### PR DESCRIPTION
In the Loom Lounge yesterday, Stephen noticed that when I was caught in
void_runner, there was no Knitwitch when I respawned.

I don't think we strictly need to have Knitwitches at the start of every
level where you might be defeated. If you are caught by the very first
guard in the musician quest stealth level, you just respawn at the start
of the level, no witch.

However, perhaps it's reassuring to have one at the start of
void_runner. Having done that, maybe we can also put one after the
tricky three-needle crossing in void_grappling_round_2, and then also at
the start of that scene for good measure.

There is no good place (other than the very start) to put one in
void_grappling round 1.
