### PR TITLE
Do not assume class of first node in group player

### DIFF
--- a/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
+++ b/scenes/game_elements/characters/enemies/throwing_enemy/components/throwing_enemy.gd
@@ -129,6 +129,7 @@ var allowed_labels: Array[String] = ["???"]
 ## color-matching game.
 var color_per_label: Dictionary[String, Color]
 
+var _player: Node2D
 var _initial_position: Vector2
 var _target_position: Vector2
 var _is_attacking: bool
@@ -171,10 +172,10 @@ func _ready() -> void:
 	_set_sprite_frames(sprite_frames)
 	if Engine.is_editor_hint():
 		return
-	var player: Player = get_tree().get_first_node_in_group("player")
-	if is_instance_valid(player):
+	_player = get_tree().get_first_node_in_group("player") as Node2D
+	if is_instance_valid(_player):
 		var direction: Vector2 = projectile_marker.global_position.direction_to(
-			player.global_position
+			_player.global_position
 		)
 		scale.x = 1 if direction.x < 0 else -1
 	if autostart:
@@ -261,8 +262,7 @@ func _set_target_position() -> void:
 
 
 func _on_timeout() -> void:
-	var player: Player = get_tree().get_first_node_in_group("player")
-	if not is_instance_valid(player):
+	if not is_instance_valid(_player):
 		return
 	_is_attacking = true
 	animation_player.play(&"attack")
@@ -270,12 +270,11 @@ func _on_timeout() -> void:
 
 
 func shoot_projectile() -> void:
-	var player: Player = get_tree().get_first_node_in_group("player")
 	if not allowed_labels:
 		_is_attacking = false
 		return
 
-	if shoot_projectile_at(player):
+	if shoot_projectile_at(_player):
 		_set_target_position()
 		_is_attacking = false
 

--- a/scenes/game_elements/props/player_follower/player_follower.gd
+++ b/scenes/game_elements/props/player_follower/player_follower.gd
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 extends PathFollow2D
 
-@onready var player: Player = get_tree().get_first_node_in_group("player")
+@onready var player := get_tree().get_first_node_in_group("player") as Node2D
 
 
 func _process(_delta: float) -> void:

--- a/scenes/game_elements/props/spawn_point/components/spawn_point.gd
+++ b/scenes/game_elements/props/spawn_point/components/spawn_point.gd
@@ -26,7 +26,7 @@ func _ready() -> void:
 
 
 func move_player_to_self_position(smooth_camera: bool = false) -> void:
-	var player: Node2D = get_tree().get_first_node_in_group("player")
+	var player := get_tree().get_first_node_in_group("player") as Node2D
 
 	if is_instance_valid(player):
 		player.teleport_to(self.global_position, smooth_camera, look_at_side_on_spawn)

--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -72,7 +72,7 @@ func _on_abandon_quest_pressed() -> void:
 	)
 	await Transitions.finished
 
-	var player: Node2D = get_tree().get_first_node_in_group("player")
+	var player := get_tree().get_first_node_in_group("player") as Node2D
 	var replaying := quest in GameState.global.completed_quests
 	var title := "abandoned_replay" if replaying else "abandoned"
 	DialogueManager.show_dialogue_balloon(abandon_dialogue, title, [player])

--- a/scenes/quests/story_quests/champ/0_intro/champ_intro.tscn
+++ b/scenes/quests/story_quests/champ/0_intro/champ_intro.tscn
@@ -218,7 +218,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=1029059295]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1995106097]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1995106097 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_ufx21")
 animation = &"idle"

--- a/scenes/quests/story_quests/champ/4_outro/champ_outro.tscn
+++ b/scenes/quests/story_quests/champ/4_outro/champ_outro.tscn
@@ -52,7 +52,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=484328888]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=34892077]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=34892077 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_276wt")
 animation = &"idle"

--- a/scenes/quests/story_quests/el_abrigo/0_el_abrigo_intro/el_abrigo_intro.tscn
+++ b/scenes/quests/story_quests/el_abrigo/0_el_abrigo_intro/el_abrigo_intro.tscn
@@ -178,7 +178,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=117602598]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=577377136]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=577377136 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_p845x")
 animation = &"idle"

--- a/scenes/quests/story_quests/el_abrigo/4_el_abrigo_outro/el_abrigo_outro.tscn
+++ b/scenes/quests/story_quests/el_abrigo/4_el_abrigo_outro/el_abrigo_outro.tscn
@@ -88,7 +88,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=120484108]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=735842756]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=735842756 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_7j76p")
 animation = &"idle"

--- a/scenes/quests/story_quests/el_juguete_perdido/0_intro/intro.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/0_intro/intro.tscn
@@ -182,7 +182,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=101635259]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=190991224]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=190991224 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("10_nf7lg")
 animation = &"idle"

--- a/scenes/quests/story_quests/el_juguete_perdido/4_outro/outro.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/4_outro/outro.tscn
@@ -130,7 +130,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=1697789778]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1591226122]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1591226122 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("12_ij0xq")
 animation = &"idle"

--- a/scenes/quests/story_quests/el_ojo_revelador/0_intro/el_ojo_revelador_intro.tscn
+++ b/scenes/quests/story_quests/el_ojo_revelador/0_intro/el_ojo_revelador_intro.tscn
@@ -342,7 +342,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=1522597320]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1611473687]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1611473687 groups=["player"]]
 position = Vector2(400, 349)
 scale = Vector2(1.3, 1.3)
 sprite_frames = SubResource("SpriteFrames_jdw12")

--- a/scenes/quests/story_quests/el_ojo_revelador/4_outro/el_ojo_revelador_outro.tscn
+++ b/scenes/quests/story_quests/el_ojo_revelador/4_outro/el_ojo_revelador_outro.tscn
@@ -49,7 +49,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=756268099]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1808734603]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1808734603 groups=["player"]]
 position = Vector2(410, 349)
 scale = Vector2(1.4, 1.4)
 sprite_frames = ExtResource("5_vf5av")

--- a/scenes/quests/story_quests/eldrune/0_intro/eldrune_intro.tscn
+++ b/scenes/quests/story_quests/eldrune/0_intro/eldrune_intro.tscn
@@ -175,7 +175,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=1558146302]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=356003840]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=356003840 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_6qcmh")
 animation = &"idle"

--- a/scenes/quests/story_quests/eldrune/4_outro/eldrune_outro.tscn
+++ b/scenes/quests/story_quests/eldrune/4_outro/eldrune_outro.tscn
@@ -33,7 +33,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=721146208]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1617927815]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1617927815 groups=["player"]]
 position = Vector2(556, 473)
 sprite_frames = ExtResource("3_th1v8")
 animation = &"idle"

--- a/scenes/quests/story_quests/renya_beyond_sorrow/0_intro/renya_intro.tscn
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/0_intro/renya_intro.tscn
@@ -165,7 +165,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=7227233]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1004525138]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1004525138 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_6nf35")
 animation = &"idle"

--- a/scenes/quests/story_quests/renya_beyond_sorrow/4_outro/renya_beyond_sorrow_outro.tscn
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/4_outro/renya_beyond_sorrow_outro.tscn
@@ -99,7 +99,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=769881264]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=576736229]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=576736229 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_2lbeu")
 animation = &"idle"

--- a/scenes/quests/story_quests/shjourney/2_shjourney_intro/template_intro.tscn
+++ b/scenes/quests/story_quests/shjourney/2_shjourney_intro/template_intro.tscn
@@ -346,7 +346,7 @@ tile_set = ExtResource("2_u7gwd")
 [node name="OnTheGround" type="Node2D" parent="." unique_id=1045393253]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1377581853]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1377581853 groups=["player"]]
 position = Vector2(506, -132.86)
 scale = Vector2(1.32, 1.32)
 sprite_frames = ExtResource("8_aeas8")

--- a/scenes/quests/story_quests/shjourney/6_Espada/Espada.tscn
+++ b/scenes/quests/story_quests/shjourney/6_Espada/Espada.tscn
@@ -2559,7 +2559,7 @@ animation_player = NodePath("../AnimationPlayer")
 next_scene = "uid://detarlsgchyx3"
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
-[node name="Character" type="AnimatedSprite2D" parent="." unique_id=2000745803]
+[node name="Character" type="AnimatedSprite2D" parent="." unique_id=2000745803 groups=["player"]]
 z_index = 1
 position = Vector2(48, 232)
 scale = Vector2(1.7, 1.7)

--- a/scenes/quests/story_quests/shjourney/9_shjourney_outro_2/Outro2.tscn
+++ b/scenes/quests/story_quests/shjourney/9_shjourney_outro_2/Outro2.tscn
@@ -445,7 +445,7 @@ script = ExtResource("3_w2ehx")
 root_node = NodePath("../..")
 libraries/ = SubResource("AnimationLibrary_45rex")
 
-[node name="Character" type="AnimatedSprite2D" parent="Node2D/AnimationPlayer" unique_id=394681596]
+[node name="Character" type="AnimatedSprite2D" parent="Node2D/AnimationPlayer" unique_id=394681596 groups=["player"]]
 z_index = -1
 position = Vector2(1662, 1243)
 scale = Vector2(1.7, 1.7)

--- a/scenes/quests/story_quests/stella/0_stella_intro/stella_intro.tscn
+++ b/scenes/quests/story_quests/stella/0_stella_intro/stella_intro.tscn
@@ -137,7 +137,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=769653899]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1644183695]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1644183695 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_vak0f")
 animation = &"idle"

--- a/scenes/quests/story_quests/stella/4_stella_outro/stella_outro.tscn
+++ b/scenes/quests/story_quests/stella/4_stella_outro/stella_outro.tscn
@@ -50,7 +50,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=1559146347]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1248735459]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1248735459 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_veri0")
 animation = &"idle"

--- a/scenes/quests/story_quests/verso/0_verso_intro/verso_intro.tscn
+++ b/scenes/quests/story_quests/verso/0_verso_intro/verso_intro.tscn
@@ -248,7 +248,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=608732327]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1683150534]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1683150534 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_h1xjl")
 animation = &"idle"

--- a/scenes/quests/story_quests/verso/4_verso_outro/verso_outro.tscn
+++ b/scenes/quests/story_quests/verso/4_verso_outro/verso_outro.tscn
@@ -99,7 +99,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=946772914]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=900465229]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=900465229 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_vpp8x")
 animation = &"idle"

--- a/scenes/quests/template_quests/NO_EDIT/0_NO_EDIT_intro/NO_EDIT_intro.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/0_NO_EDIT_intro/NO_EDIT_intro.tscn
@@ -128,7 +128,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=836096441]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=169229228]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=169229228 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("3_bol4n")
 animation = &"idle"

--- a/scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro.tscn
@@ -40,7 +40,7 @@ editor_draw_limits = true
 [node name="OnTheGround" type="Node2D" parent="." unique_id=2094226334]
 y_sort_enabled = true
 
-[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1142153150]
+[node name="Character" type="AnimatedSprite2D" parent="OnTheGround" unique_id=1142153150 groups=["player"]]
 position = Vector2(400, 349)
 sprite_frames = ExtResource("2_ka28e")
 animation = &"idle"

--- a/scenes/ui_elements/dialogue/components/balloon.gd
+++ b/scenes/ui_elements/dialogue/components/balloon.gd
@@ -192,7 +192,7 @@ func apply_dialogue_line() -> void:
 
 ## True if the player position is at the bottom vertical quarter of the screen.
 func _is_player_at_bottom() -> bool:
-	var player: Node2D = get_tree().get_first_node_in_group("player")
+	var player := get_tree().get_first_node_in_group("player") as Node2D
 	if not player:
 		return false
 

--- a/scenes/ui_elements/input_hints/components/input_hud.gd
+++ b/scenes/ui_elements/input_hints/components/input_hud.gd
@@ -39,7 +39,7 @@ func _ready() -> void:
 
 
 func _on_scene_changed() -> void:
-	player = get_tree().get_first_node_in_group("player")
+	player = get_tree().get_first_node_in_group("player") as CharacterBody2D
 	sokoban_ruleset = get_tree().get_first_node_in_group("sokoban_ruleset")
 
 	_update_visibility()

--- a/scenes/world_map/components/retelling_townie.gd
+++ b/scenes/world_map/components/retelling_townie.gd
@@ -74,7 +74,7 @@ func become_helper(type: InventoryItem.ItemType) -> void:
 	closer_path.global_position = enter_path.global_position
 	var curve := Curve2D.new()
 	curve.add_point(Vector2.ZERO)
-	var player: Node2D = get_tree().get_first_node_in_group("player")
+	var player := get_tree().get_first_node_in_group("player") as Node2D
 	_closer_to_player_position = townie.global_position.direction_to(player.global_position) * 100.0
 	curve.add_point(_closer_to_player_position)
 	closer_path.curve = curve


### PR DESCRIPTION
So cinematics can assign "player" group to the mock player sprite.

This makes the dialogue balloon to appear at the top of the screen when the
sprite is at the bottom.

### Do not assume class of first node in group player

Certain scripts could treat player as a CharacterBody2D for physics,
as a Node2D for its position, or as a CanvasItem for visual stuff, etc.

Input HUD: It considers the player a CharacterBody2D and checks for its
components using `Object.get(COMPONENT_NAME) as COMPONENT_CLASS`. Previously it
was assuming that the output of `get_first_node_in_group()` was a
CharacterBody2D. The assignment would fail if the first node in group "player"
is of another type. This doesn't allow mock players, for example an
AnimatedSprite2D in a cinematic.

Throwing enemy: All this enemy needs is the global_position of player for
throwing. This makes it closer to the ThrowProjectileBehavior which has `@export
var target: Node2D`. Also get the player node from group "player" only once.

player_follower.gd: All this script needs is the global_position of player
for calculating the offset.

----

Fix https://github.com/endlessm/threadbare/issues/2306
