### PR TITLE
Player: Stop player particle system running on player defeat

### DIFF
--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -71,6 +71,7 @@ var _system_controllers: Array[Node] = []
 @onready var player_hook: PlayerHook = %PlayerHook
 @onready var player_sprite: AnimatedSprite2D = %PlayerSprite
 @onready var _walk_sound: AudioStreamPlayer2D = %WalkSound
+@onready var player_dust_particles: GPUParticles2D = %PlayerDustParticles
 
 
 func _set_mode(new_mode: Mode) -> void:
@@ -207,6 +208,8 @@ func defeat(falling: bool = false) -> void:
 
 	# Stop moving the player.
 	velocity = Vector2.ZERO
+
+	player_dust_particles.emitting = false
 
 	GameState.player.decrement_lives()
 

--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -70,8 +70,8 @@ var _system_controllers: Array[Node] = []
 @onready var player_repel: Node2D = %PlayerRepel
 @onready var player_hook: PlayerHook = %PlayerHook
 @onready var player_sprite: AnimatedSprite2D = %PlayerSprite
-@onready var _walk_sound: AudioStreamPlayer2D = %WalkSound
 @onready var player_dust_particles: GPUParticles2D = %PlayerDustParticles
+@onready var _walk_sound: AudioStreamPlayer2D = %WalkSound
 
 
 func _set_mode(new_mode: Mode) -> void:


### PR DESCRIPTION
The player's particle system now stops emitting when the player is defeated.

Resolves https://github.com/endlessm/threadbare/issues/2260