### PR TITLE
Add health component

### DIFF
--- a/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
+++ b/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
@@ -30,10 +30,9 @@ func hit_by_droplet(droplet_label: String) -> void:
 		health_component.damage(1)
 
 
-func take_damage(_current_health: int, has_depleted_health: bool) -> void:
-	if not has_depleted_health:
-		crack_sound.play()
-		update_cracks()
+func take_damage() -> void:
+	crack_sound.play()
+	update_cracks()
 
 
 func update_cracks() -> void:

--- a/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
+++ b/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
@@ -42,7 +42,7 @@ func update_cracks() -> void:
 	crack_overlay_node.frame = frame_index
 
 
-func break_barrel() -> void:
+func _on_health_component_health_depleted() -> void:
 	crack_overlay_node.visible = false
 
 	shatter_sound.play()

--- a/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
+++ b/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
@@ -7,50 +7,39 @@ extends FillingBarrel
 ## Emitted when [member current_health] reaches 0.
 signal barrel_destroyed(barrel_instance: FragileBarrel)
 
-## Maximum hits the barrel can take before breaking.
-@export_range(1, 100) var max_health: int = 4
-
-var current_health: int
-
 @onready var crack_overlay_node: AnimatedSprite2D = %CrackOverlay
 @onready var crack_sound: AudioStreamPlayer2D = %CrackSound
 @onready var shatter_sound: AudioStreamPlayer2D = %ShatterSound
+@onready var health_component: HealthComponent = %HealthComponent
 
 
 func _ready() -> void:
 	super._ready()
-	current_health = max_health
 	crack_overlay_node.visible = false
 
 
 # Logic called by Projectile when it hits this object
 func hit_by_droplet(droplet_label: String) -> void:
 	# Ignore if already full or destroyed
-	if _amount >= needed_amount or current_health <= 0:
+	if _amount >= needed_amount or health_component.has_depleted_health:
 		return
 
 	if droplet_label == self.label:
 		increment()
 	else:
-		take_damage()
+		health_component.damage(1)
 
 
-func take_damage() -> void:
-	current_health -= 1
-
-	if current_health <= 0:
-		break_barrel()
-	else:
+func take_damage(_current_health: int, has_depleted_health: bool) -> void:
+	if not has_depleted_health:
 		crack_sound.play()
 		update_cracks()
 
 
 func update_cracks() -> void:
-	var damage_taken: int = max_health - current_health
-
 	# IMPROVEMENT: Calculate frame index proportionally based on damage percentage.
 	var total_frames: int = crack_overlay_node.sprite_frames.get_frame_count("default")
-	var frame_index: int = int(floor((float(damage_taken) / max_health) * total_frames))
+	var frame_index: int = int(floor((health_component.damage_taken_percentage) * total_frames))
 
 	# Clamp to ensure we don't exceed available frames (0-based index)
 	frame_index = clamp(frame_index, 0, total_frames - 1)

--- a/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
+++ b/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
@@ -33,7 +33,7 @@ func hit_by_droplet(droplet_label: String) -> void:
 func update_cracks() -> void:
 	# IMPROVEMENT: Calculate frame index proportionally based on damage percentage.
 	var total_frames: int = crack_overlay_node.sprite_frames.get_frame_count("default")
-	var frame_index: int = int(floor((health_component.damage_taken_percentage) * total_frames))
+	var frame_index: int = int(floor((health_component.damage_taken_ratio) * total_frames))
 
 	# Clamp to ensure we don't exceed available frames (0-based index)
 	frame_index = clamp(frame_index, 0, total_frames - 1)

--- a/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
+++ b/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
@@ -30,11 +30,6 @@ func hit_by_droplet(droplet_label: String) -> void:
 		health_component.damage(1)
 
 
-func take_damage() -> void:
-	crack_sound.play()
-	update_cracks()
-
-
 func update_cracks() -> void:
 	# IMPROVEMENT: Calculate frame index proportionally based on damage percentage.
 	var total_frames: int = crack_overlay_node.sprite_frames.get_frame_count("default")
@@ -57,3 +52,8 @@ func break_barrel() -> void:
 	await animated_sprite_2d.animation_finished
 
 	barrel_destroyed.emit(self)
+
+
+func _on_health_component_health_changed() -> void:
+	crack_sound.play()
+	update_cracks()

--- a/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
+++ b/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
@@ -4,7 +4,7 @@
 class_name FragileBarrel
 extends FillingBarrel
 
-## Emitted when [member current_health] reaches 0.
+## Emitted when barrel's health reaches 0.
 signal barrel_destroyed(barrel_instance: FragileBarrel)
 
 @onready var crack_overlay_node: AnimatedSprite2D = %CrackOverlay

--- a/scenes/game_elements/props/filling_barrel/fragile_barrel.tscn
+++ b/scenes/game_elements/props/filling_barrel/fragile_barrel.tscn
@@ -32,4 +32,4 @@ script = ExtResource("6_v7k7g")
 metadata/_custom_type_script = "uid://b0qrfv6upnqtu"
 
 [connection signal="health_changed" from="HealthComponent" to="." method="_on_health_component_health_changed" unbinds=1]
-[connection signal="health_depleted" from="HealthComponent" to="." method="break_barrel"]
+[connection signal="health_depleted" from="HealthComponent" to="." method="_on_health_component_health_depleted"]

--- a/scenes/game_elements/props/filling_barrel/fragile_barrel.tscn
+++ b/scenes/game_elements/props/filling_barrel/fragile_barrel.tscn
@@ -5,10 +5,10 @@
 [ext_resource type="Script" uid="uid://d05hp7ascndlr" path="res://scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd" id="2_wal8y"]
 [ext_resource type="AudioStream" uid="uid://bknpb07lvbded" path="res://scenes/game_elements/props/filling_barrel/components/sfx_barrel_crack.tres" id="4_sdj6j"]
 [ext_resource type="AudioStream" uid="uid://c3iuv5ax8i78v" path="res://scenes/game_elements/props/filling_barrel/components/sfx_barrel_breaking.tres" id="5_v7k7g"]
+[ext_resource type="Script" uid="uid://b0qrfv6upnqtu" path="res://scenes/game_logic/health_component.gd" id="6_v7k7g"]
 
 [node name="FragileBarrel" unique_id=2064522120 instance=ExtResource("1_ab25j")]
 script = ExtResource("2_wal8y")
-max_health = 4
 
 [node name="CrackOverlay" type="AnimatedSprite2D" parent="." index="1" unique_id=473951260]
 unique_name_in_owner = true
@@ -25,3 +25,11 @@ bus = &"SFX"
 unique_name_in_owner = true
 stream = ExtResource("5_v7k7g")
 bus = &"SFX"
+
+[node name="HealthComponent" type="Node2D" parent="." index="10" unique_id=1654759649]
+unique_name_in_owner = true
+script = ExtResource("6_v7k7g")
+metadata/_custom_type_script = "uid://b0qrfv6upnqtu"
+
+[connection signal="health_changed" from="HealthComponent" to="." method="take_damage"]
+[connection signal="health_depleted" from="HealthComponent" to="." method="break_barrel"]

--- a/scenes/game_elements/props/filling_barrel/fragile_barrel.tscn
+++ b/scenes/game_elements/props/filling_barrel/fragile_barrel.tscn
@@ -31,5 +31,5 @@ unique_name_in_owner = true
 script = ExtResource("6_v7k7g")
 metadata/_custom_type_script = "uid://b0qrfv6upnqtu"
 
-[connection signal="health_changed" from="HealthComponent" to="." method="take_damage"]
+[connection signal="health_changed" from="HealthComponent" to="." method="take_damage" unbinds=1]
 [connection signal="health_depleted" from="HealthComponent" to="." method="break_barrel"]

--- a/scenes/game_elements/props/filling_barrel/fragile_barrel.tscn
+++ b/scenes/game_elements/props/filling_barrel/fragile_barrel.tscn
@@ -26,7 +26,7 @@ unique_name_in_owner = true
 stream = ExtResource("5_v7k7g")
 bus = &"SFX"
 
-[node name="HealthComponent" type="Node2D" parent="." index="10" unique_id=1654759649]
+[node name="HealthComponent" type="Node" parent="." index="10" unique_id=707508929]
 unique_name_in_owner = true
 script = ExtResource("6_v7k7g")
 metadata/_custom_type_script = "uid://b0qrfv6upnqtu"

--- a/scenes/game_elements/props/filling_barrel/fragile_barrel.tscn
+++ b/scenes/game_elements/props/filling_barrel/fragile_barrel.tscn
@@ -31,5 +31,5 @@ unique_name_in_owner = true
 script = ExtResource("6_v7k7g")
 metadata/_custom_type_script = "uid://b0qrfv6upnqtu"
 
-[connection signal="health_changed" from="HealthComponent" to="." method="take_damage" unbinds=1]
+[connection signal="health_changed" from="HealthComponent" to="." method="_on_health_component_health_changed" unbinds=1]
 [connection signal="health_depleted" from="HealthComponent" to="." method="break_barrel"]

--- a/scenes/game_logic/health_component.gd
+++ b/scenes/game_logic/health_component.gd
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 class_name HealthComponent
-extends Node2D
+extends Node
 
 ## Emitted when [member current_health] reaches zero.
 signal health_depleted

--- a/scenes/game_logic/health_component.gd
+++ b/scenes/game_logic/health_component.gd
@@ -11,9 +11,9 @@ signal health_changed(current_health: int)
 var current_health: int = max_health:
 	set(value):
 		if value == current_health:
-			pass
+			return
 
-		current_health = value
+		current_health = clamp(value, 0, max_health)
 		if current_health <= 0:
 			health_depleted.emit()
 		else:

--- a/scenes/game_logic/health_component.gd
+++ b/scenes/game_logic/health_component.gd
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name HealthComponent
+extends Node2D
+
+signal health_depleted
+signal health_changed(current_health: int, has_depleted_health: bool)
+
+@export_range(1, 100) var max_health: int = 4
+
+var current_health: int = max_health:
+	set(value):
+		var old_health: int = current_health
+		current_health = value
+		if value <= 0:
+			health_depleted.emit()
+		elif value != old_health:
+			health_changed.emit(value, has_depleted_health)
+
+var damage_taken: int:
+	get:
+		return max_health - current_health
+
+var damage_taken_percentage: float:
+	get:
+		return float(damage_taken) / max_health
+
+var has_depleted_health: bool:
+	get:
+		return current_health <= 0
+
+
+func damage(amount: int) -> void:
+	current_health -= amount
+
+
+func heal(amount: int) -> void:
+	current_health += amount

--- a/scenes/game_logic/health_component.gd
+++ b/scenes/game_logic/health_component.gd
@@ -4,18 +4,20 @@ class_name HealthComponent
 extends Node2D
 
 signal health_depleted
-signal health_changed(current_health: int, has_depleted_health: bool)
+signal health_changed(current_health: int)
 
 @export_range(1, 100) var max_health: int = 4
 
 var current_health: int = max_health:
 	set(value):
-		var old_health: int = current_health
+		if value == current_health:
+			pass
+
 		current_health = value
-		if value <= 0:
+		if current_health <= 0:
 			health_depleted.emit()
-		elif value != old_health:
-			health_changed.emit(value, has_depleted_health)
+		else:
+			health_changed.emit(current_health)
 
 var damage_taken: int:
 	get:

--- a/scenes/game_logic/health_component.gd
+++ b/scenes/game_logic/health_component.gd
@@ -23,7 +23,7 @@ var damage_taken: int:
 	get:
 		return max_health - current_health
 
-var damage_taken_percentage: float:
+var damage_taken_ratio: float:
 	get:
 		return float(damage_taken) / max_health
 

--- a/scenes/game_logic/health_component.gd
+++ b/scenes/game_logic/health_component.gd
@@ -3,11 +3,17 @@
 class_name HealthComponent
 extends Node2D
 
+## Emitted when [member current_health] reaches zero.
 signal health_depleted
+
+## Emitted when [member current_health] changes.[br]
+## Is not emitted when the health reaches zero, [signal health_depleted] is emitted instead.
 signal health_changed(current_health: int)
 
 @export_range(1, 100) var max_health: int = 4
 
+## Represents the current health.[br]
+## The value will always be in the following range [code]0 <= current_health <= max_health[/code].
 var current_health: int = max_health:
 	set(value):
 		if value == current_health:

--- a/scenes/game_logic/health_component.gd.uid
+++ b/scenes/game_logic/health_component.gd.uid
@@ -1,0 +1,1 @@
+uid://b0qrfv6upnqtu


### PR DESCRIPTION
Added a generic health component that can be reused in different scenes.
It exports a max health property and provides various properties regarding health status.
It also provides two signals
- `health_depleted` emitted when a change to the current health pushes it to zero or below
- `health_changed` emitted when the health is changed and the change does not cause the health to deplete; emits the current health as an argument

Refactored the fragile barrel to use the new health component

Resolves https://github.com/endlessm/threadbare/issues/1747