### PR TITLE
Quest Separator: Add Play & Back buttons

### DIFF
--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -47,6 +47,13 @@ func toggle_pause() -> void:
 
 func _on_abandon_quest_pressed() -> void:
 	toggle_pause()
+	abandon_quest()
+
+
+func abandon_quest() -> void:
+	if not GameState.quest:
+		push_warning("No quest to abandon")
+		return
 
 	var quest := GameState.quest.quest
 	var abandon_scene := GameState.quest.abandon_scene_path

--- a/scenes/menus/quest_separator/components/quest_separator.gd
+++ b/scenes/menus/quest_separator/components/quest_separator.gd
@@ -5,6 +5,10 @@ extends Control
 @onready var title: Label = %Title
 @onready var animated_texture_rect: AnimatedTextureRect = %AnimatedTextureRect
 @onready var rich_text_label: RichTextLabel = %RichTextLabel
+@onready var back_button: Button = %BackButton
+@onready var play_button: Button = %PlayButton
+@onready var auto_play_progress_bar: ProgressBar = %AutoPlayProgressBar
+@onready var auto_play_timer: Timer = %AutoPlayTimer
 
 
 func _ready() -> void:
@@ -15,14 +19,29 @@ func _ready() -> void:
 	animated_texture_rect.animation_name = quest.animation_name
 	rich_text_label.text = quest.description
 
-	await get_tree().create_timer(3).timeout
+	play_button.grab_focus()
+	play_button.focus_exited.connect(stop_timer, CONNECT_ONE_SHOT)
+	play_button.pressed.connect(play)
 
-	(
-		SceneSwitcher
-		. change_to_file_with_transition(
-			quest.first_scene,
-			^"",
-			Transition.Effect.RADIAL,
-			Transition.Effect.FADE,
-		)
+	back_button.pressed.connect(back)
+
+	auto_play_timer.timeout.connect(play)
+
+
+func stop_timer() -> void:
+	auto_play_timer.stop()
+
+
+func back() -> void:
+	stop_timer()
+	# TODO: it is weird to call into the pause overlay from here.
+	# Perhaps this separator should itself be part of the "pause" menu hierarchy?
+	PauseOverlay.abandon_quest()
+
+
+func play() -> void:
+	stop_timer()
+	var quest := GameState.quest.quest
+	SceneSwitcher.change_to_file_with_transition(
+		quest.first_scene, ^"", Transition.Effect.RADIAL, Transition.Effect.FADE
 	)

--- a/scenes/menus/quest_separator/components/timer_progress_bar.gd
+++ b/scenes/menus/quest_separator/components/timer_progress_bar.gd
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends ProgressBar
+## Visualises the progress of a Timer.
+##
+## Removes itself from the tree when the timer expires or is stopped.
+
+@export var timer: Timer
+
+
+func _ready() -> void:
+	max_value = timer.wait_time
+
+
+func _process(_delta: float) -> void:
+	if timer.paused or timer.is_stopped():
+		queue_free()
+	else:
+		value = timer.wait_time - timer.time_left

--- a/scenes/menus/quest_separator/components/timer_progress_bar.gd.uid
+++ b/scenes/menus/quest_separator/components/timer_progress_bar.gd.uid
@@ -1,0 +1,1 @@
+uid://b78blxbleps14

--- a/scenes/menus/quest_separator/quest_separator.tscn
+++ b/scenes/menus/quest_separator/quest_separator.tscn
@@ -4,6 +4,8 @@
 [ext_resource type="Script" uid="uid://dccjkvox5cjsy" path="res://scenes/menus/quest_separator/components/quest_separator.gd" id="2_ayaqs"]
 [ext_resource type="Texture2D" uid="uid://csbhg24hsxecd" path="res://scenes/quests/lore_quests/quest_002/Void.png" id="4_fqr5p"]
 [ext_resource type="Script" uid="uid://dfx8s2ybd11mt" path="res://scenes/menus/storybook/components/animated_texture_rect.gd" id="4_olqir"]
+[ext_resource type="Shortcut" uid="uid://c5pwgp1w8p3y1" path="res://scenes/ui_elements/shortcuts/back_shortcut.tres" id="5_wq0a1"]
+[ext_resource type="Script" uid="uid://b78blxbleps14" path="res://scenes/menus/quest_separator/components/timer_progress_bar.gd" id="6_amr4g"]
 [ext_resource type="Texture2D" uid="uid://dcwmaoqgu5t84" path="res://scenes/globals/scene_switcher/transitions/Radial.png" id="6_wq0a1"]
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_l1xe8"]
@@ -16,6 +18,8 @@ animations = [{
 "name": &"default",
 "speed": 5.0
 }]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_amr4g"]
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_wq0a1"]
 blend_mode = 2
@@ -48,6 +52,10 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/margin_left = 192
+theme_override_constants/margin_top = 64
+theme_override_constants/margin_right = 192
+theme_override_constants/margin_bottom = 64
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1354617346]
 layout_mode = 2
@@ -82,6 +90,44 @@ layout_mode = 2
 text = "StoryWeaver runs away from a growing emptiness that spreads across the land, smothering and swallowing everything it covers."
 fit_content = true
 
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer" unique_id=175954450]
+layout_mode = 2
+alignment = 2
+
+[node name="BackButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer" unique_id=1588571350]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 0
+theme_type_variation = &"FlatButton"
+shortcut = ExtResource("5_wq0a1")
+text = "Back"
+flat = true
+
+[node name="PlayButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer" unique_id=327046167]
+unique_name_in_owner = true
+layout_mode = 2
+theme_type_variation = &"FlatButton"
+text = "Play"
+flat = true
+
+[node name="AutoPlayProgressBar" type="ProgressBar" parent="MarginContainer/VBoxContainer/HBoxContainer/PlayButton" unique_id=1528838248 node_paths=PackedStringArray("timer")]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 20)
+layout_mode = 1
+anchors_preset = 14
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_top = -2.0
+offset_bottom = 2.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/background = SubResource("StyleBoxEmpty_amr4g")
+value = 50.0
+show_percentage = false
+script = ExtResource("6_amr4g")
+timer = NodePath("../../../../../AutoPlayTimer")
+
 [node name="TextureRect" type="TextureRect" parent="." unique_id=279230856]
 material = SubResource("CanvasItemMaterial_wq0a1")
 layout_mode = 1
@@ -90,4 +136,11 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 texture = ExtResource("6_wq0a1")
+
+[node name="AutoPlayTimer" type="Timer" parent="." unique_id=229639968]
+unique_name_in_owner = true
+wait_time = 5.0
+one_shot = true
+autostart = true


### PR DESCRIPTION
This screen previously automatically advanced to the first scene of the
quest after a few seconds, unconditionally.

Increase that timeout slightly. Add a “Play” button. Show a progress bar
over the top of it that follows the timer. Stop the timer on any input
event except a mouse movement.

Add a “Back” button which abandons the quest before it has even started.

Add some margins to the scene as a whole.

Ignore mouse input in the TextureRect which covers the whole scene, so
that the buttons can be clicked.

https://github.com/endlessm/threadbare/issues/2281#issuecomment-4692428165

