### PR TITLE
Pause Overlay: Don't handle next/previous_tab while unpaused

### DIFF
--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -22,16 +22,6 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed(&"pause"):
 		toggle_pause()
 		get_viewport().set_input_as_handled()
-	elif event.is_action_pressed("next_tab"):
-		tab_container.current_tab = wrapi(
-			tab_container.current_tab + 1, 0, tab_container.get_tab_count()
-		)
-		tab_container.accept_event()
-	elif event.is_action_pressed("previous_tab"):
-		tab_container.current_tab = wrapi(
-			tab_container.current_tab - 1, 0, tab_container.get_tab_count()
-		)
-		tab_container.accept_event()
 
 
 func toggle_pause() -> void:

--- a/scenes/globals/pause/pause_overlay.tscn
+++ b/scenes/globals/pause/pause_overlay.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://y88qplkioj1q" path="res://scenes/globals/pause/pause_overlay.gd" id="1_lf64b"]
 [ext_resource type="Resource" uid="uid://bm4xxsl17ho55" path="res://scenes/globals/pause/quest_abandoned.dialogue" id="2_xccck"]
+[ext_resource type="Script" uid="uid://5m2ugqcn640v" path="res://scenes/globals/pause/tab_container.gd" id="3_fh64e"]
 [ext_resource type="Script" uid="uid://i4urwefxrrdt" path="res://addons/threadbare_git_describe/version_label.gd" id="3_m62bn"]
 [ext_resource type="PackedScene" uid="uid://dkeb0yjgcfi86" path="res://scenes/menus/options/options.tscn" id="3_sd5t1"]
 [ext_resource type="Script" uid="uid://gntvq01vvati" path="res://scenes/globals/pause/report_bug_button.gd" id="4_mjd51"]
@@ -43,6 +44,7 @@ grow_horizontal = 2
 grow_vertical = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="." unique_id=746524343]
+process_mode = 2
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -60,6 +62,7 @@ size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxEmpty_1tcw0")
 tab_alignment = 1
 current_tab = 2
+script = ExtResource("3_fh64e")
 
 [node name="Inventory" parent="MarginContainer/VBoxContainer/TabContainer" unique_id=1910667653 instance=ExtResource("4_qydtk")]
 visible = false
@@ -67,7 +70,6 @@ layout_mode = 2
 
 [node name="Options" parent="MarginContainer/VBoxContainer/TabContainer" unique_id=2078715393 instance=ExtResource("3_sd5t1")]
 unique_name_in_owner = true
-process_mode = 2
 visible = false
 layout_mode = 2
 metadata/_tab_index = 1

--- a/scenes/globals/pause/tab_container.gd
+++ b/scenes/globals/pause/tab_container.gd
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends TabContainer
+
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("next_tab"):
+		current_tab = wrapi(current_tab + 1, 0, get_tab_count())
+		accept_event()
+	elif event.is_action_pressed("previous_tab"):
+		current_tab = wrapi(current_tab - 1, 0, get_tab_count())
+		accept_event()

--- a/scenes/globals/pause/tab_container.gd.uid
+++ b/scenes/globals/pause/tab_container.gd.uid
@@ -1,0 +1,1 @@
+uid://5m2ugqcn640v


### PR DESCRIPTION
Change the process mode for the whole Control hierarchy of the Pause
menu to "WHEN_PAUSED", which was previously set on what is now just one
page of it.

Move the handling of the next_tab and previous_tab events into _input()
in a script attached to the TabContainer, rather than in
_unhandled_input() on the PauseOverlay itself.

This fixes an issue I was seeing where pressing A/D/X/Z (the keys bound
to these two actions) in a menu I am making for the quest separator
would cause focus to be taken away from all visible controls.
