### PR TITLE
TimeAndWeather: Reduce night 2 hours

### DIFF
--- a/scenes/game_elements/fx/time_and_weather/components/clouds_shadows_schedule.tres
+++ b/scenes/game_elements/fx/time_and_weather/components/clouds_shadows_schedule.tres
@@ -4,5 +4,5 @@
 
 [resource]
 script = ExtResource("1_mnedg")
-start_time = 6.0
+start_time = 7.0
 stop_time = 17.0

--- a/scenes/game_elements/fx/time_and_weather/components/clouds_shadows_schedule.tres
+++ b/scenes/game_elements/fx/time_and_weather/components/clouds_shadows_schedule.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="EffectSchedule" format=3 uid="uid://jytd1cp6ogb3"]
+
+[ext_resource type="Script" uid="uid://djxha2otlvvea" path="res://scenes/game_elements/fx/time_and_weather/components/effect_schedule.gd" id="1_mnedg"]
+
+[resource]
+script = ExtResource("1_mnedg")
+start_time = 6.0
+stop_time = 17.0

--- a/scenes/game_elements/fx/time_and_weather/components/debug_label.gd
+++ b/scenes/game_elements/fx/time_and_weather/components/debug_label.gd
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 extends Label
 
-@onready var animation_player: AnimationPlayer = $"../../AnimationPlayer"
+@onready var animation_player: AnimationPlayer = %AnimationPlayer
 
 
 func _process(_delta: float) -> void:

--- a/scenes/game_elements/fx/time_and_weather/components/effect_schedule.gd
+++ b/scenes/game_elements/fx/time_and_weather/components/effect_schedule.gd
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+class_name EffectSchedule
+extends Resource
+## @experimental
+##
+## Schedule times for effects in [TimeAndWeather].
+
+## The effect start time in the 24-hour clock. For 4 PM set it to 16.
+@export_range(0.0, 24.0, 0.1, "suffix:h") var start_time: float
+
+## The effect stop time in the 24-hour clock. For 4 PM set it to 16.
+@export_range(0.0, 24.0, 0.1, "suffix:h") var stop_time: float

--- a/scenes/game_elements/fx/time_and_weather/components/effect_schedule.gd.uid
+++ b/scenes/game_elements/fx/time_and_weather/components/effect_schedule.gd.uid
@@ -1,0 +1,1 @@
+uid://djxha2otlvvea

--- a/scenes/game_elements/fx/time_and_weather/components/fog_schedule.tres
+++ b/scenes/game_elements/fx/time_and_weather/components/fog_schedule.tres
@@ -4,5 +4,5 @@
 
 [resource]
 script = ExtResource("1_gaagd")
-start_time = 22.0
-stop_time = 5.0
+start_time = 23.0
+stop_time = 4.0

--- a/scenes/game_elements/fx/time_and_weather/components/fog_schedule.tres
+++ b/scenes/game_elements/fx/time_and_weather/components/fog_schedule.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="EffectSchedule" format=3 uid="uid://bcoehk7j53s33"]
+
+[ext_resource type="Script" uid="uid://djxha2otlvvea" path="res://scenes/game_elements/fx/time_and_weather/components/effect_schedule.gd" id="1_gaagd"]
+
+[resource]
+script = ExtResource("1_gaagd")
+start_time = 22.0
+stop_time = 5.0

--- a/scenes/game_elements/fx/time_and_weather/components/lights_schedule.tres
+++ b/scenes/game_elements/fx/time_and_weather/components/lights_schedule.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="EffectSchedule" format=3 uid="uid://cb514qccge0gq"]
+
+[ext_resource type="Script" uid="uid://djxha2otlvvea" path="res://scenes/game_elements/fx/time_and_weather/components/effect_schedule.gd" id="1_7gm1k"]
+
+[resource]
+script = ExtResource("1_7gm1k")
+start_time = 19.0
+stop_time = 5.0

--- a/scenes/game_elements/fx/time_and_weather/components/lights_schedule.tres
+++ b/scenes/game_elements/fx/time_and_weather/components/lights_schedule.tres
@@ -4,5 +4,5 @@
 
 [resource]
 script = ExtResource("1_7gm1k")
-start_time = 19.0
-stop_time = 5.0
+start_time = 20.0
+stop_time = 4.0

--- a/scenes/game_elements/fx/time_and_weather/components/time_and_weather.gd
+++ b/scenes/game_elements/fx/time_and_weather/components/time_and_weather.gd
@@ -42,6 +42,17 @@ const SECONDS_PER_DAY: float = 24 * 60 * 60
 @export_range(1.0, 3600.0, 1.0) var time_scale: float = 144.0:
 	set = _set_time_scale
 
+@export_group("Effects Schedule")
+
+## When does the lights on/off effect happens.
+@export var lights_schedule: EffectSchedule = preload("uid://cb514qccge0gq")
+
+## When does the cloud shadows effect happens.
+@export var clouds_shadows_schedule: EffectSchedule = preload("uid://jytd1cp6ogb3")
+
+## When does the fog effect happens.
+@export var fog_schedule: EffectSchedule = preload("uid://bcoehk7j53s33")
+
 @export_group("Debugging")
 
 ## Display debugging information on screen.
@@ -129,20 +140,23 @@ func set_time(new_time: float) -> void:
 	_seek_animation(new_time)
 
 	# Change game state darkness so artificial lights can turn on/off.
-	var lights_on := new_time < 5 or new_time >= 19
+	var lights_on := new_time < lights_schedule.stop_time or new_time >= lights_schedule.start_time
 	GameState.scene.set_lights_on(lights_on, true)
-	_schedule_timer(lights_off_timer, 5, new_time)
-	_schedule_timer(lights_on_timer, 19, new_time)
+	_schedule_timer(lights_off_timer, lights_schedule.stop_time, new_time)
+	_schedule_timer(lights_on_timer, lights_schedule.start_time, new_time)
 
 	# Cloud shadows during the day:
-	clouds_shadow.visible = new_time >= 6 and new_time < 17
-	_schedule_timer(clouds_shadow_start_timer, 6, new_time)
-	_schedule_timer(clouds_shadow_stop_timer, 17, new_time)
+	clouds_shadow.visible = (
+		new_time >= clouds_shadows_schedule.start_time
+		and new_time < clouds_shadows_schedule.stop_time
+	)
+	_schedule_timer(clouds_shadow_start_timer, clouds_shadows_schedule.start_time, new_time)
+	_schedule_timer(clouds_shadow_stop_timer, clouds_shadows_schedule.stop_time, new_time)
 
 	# Fog during late night and early in the morning:
-	fog.visible = new_time < 5 or new_time >= 22
-	_schedule_timer(fog_start_timer, 22, new_time)
-	_schedule_timer(fog_stop_timer, 5, new_time)
+	fog.visible = new_time < fog_schedule.stop_time or new_time >= fog_schedule.start_time
+	_schedule_timer(fog_start_timer, fog_schedule.start_time, new_time)
+	_schedule_timer(fog_stop_timer, fog_schedule.stop_time, new_time)
 
 
 ## Get the current time.

--- a/scenes/game_elements/fx/time_and_weather/components/time_and_weather.gd
+++ b/scenes/game_elements/fx/time_and_weather/components/time_and_weather.gd
@@ -78,8 +78,8 @@ const SECONDS_PER_DAY: float = 24 * 60 * 60
 @onready var fog_start_timer: Timer = %FogStartTimer
 @onready var fog_stop_timer: Timer = %FogStopTimer
 
-## Label to show debug information.
-@onready var debug_label: Label = %DebugLabel
+## Layer with the debug label.
+@onready var debug_canvas_layer: CanvasLayer = %DebugCanvasLayer
 
 
 func _set_use_system_time(new_use_system_time: bool) -> void:
@@ -103,10 +103,10 @@ func _set_show_debug_label(new_show_debug_label: bool) -> void:
 	show_debug_label = new_show_debug_label
 	if Engine.is_editor_hint():
 		return
-	if not debug_label:
+	if not is_node_ready():
 		return
-	debug_label.visible = show_debug_label
-	debug_label.process_mode = (
+	debug_canvas_layer.visible = show_debug_label
+	debug_canvas_layer.process_mode = (
 		Node.PROCESS_MODE_INHERIT if show_debug_label else Node.PROCESS_MODE_DISABLED
 	)
 

--- a/scenes/game_elements/fx/time_and_weather/time_and_weather.tscn
+++ b/scenes/game_elements/fx/time_and_weather/time_and_weather.tscn
@@ -92,7 +92,7 @@ tracks/0/path = NodePath("CanvasModulate:color")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 4, 6, 7, 9.990001, 14, 17, 18, 20, 24),
+"times": PackedFloat32Array(0, 3, 5, 6, 10, 14, 18, 19, 21, 24),
 "transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
 "update": 0,
 "values": [Color(0.28800002, 0.36479995, 0.48, 1), Color(0.28800002, 0.36479995, 0.48, 1), Color(0.68226564, 0.84817696, 0.92506266, 1), Color(0.88227075, 0.9292479, 0.8883446, 1), Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(0.92, 0.83628, 0.6808, 1), Color(0.92, 0.7482667, 0.55200005, 1), Color(0.28800002, 0.36479995, 0.48, 1), Color(0.28800002, 0.36479995, 0.48, 1)]
@@ -104,7 +104,7 @@ tracks/1/path = NodePath("WorldEnvironment:environment:adjustment_contrast")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0, 4, 10, 14, 20, 24),
+"times": PackedFloat32Array(0, 3, 10, 14, 21, 24),
 "transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1),
 "update": 0,
 "values": [1.2, 1.2, 1.0, 1.0, 1.2, 1.2]
@@ -116,7 +116,7 @@ tracks/2/path = NodePath("WorldEnvironment:environment:adjustment_saturation")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(0, 10, 12, 14, 18, 24),
+"times": PackedFloat32Array(0, 10, 12, 14, 19, 24),
 "transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1),
 "update": 0,
 "values": [1.0, 1.0, 0.9, 1.0, 1.2, 1.0]
@@ -128,7 +128,7 @@ tracks/3/path = NodePath(".:night_lights_enabled")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
-"times": PackedFloat32Array(0, 5, 19, 24),
+"times": PackedFloat32Array(0, 4, 20, 24),
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 1,
 "values": [true, false, true, true]
@@ -152,7 +152,7 @@ tracks/5/path = NodePath("WorldEnvironment:environment:background_color")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
-"times": PackedFloat32Array(0, 4, 6, 10, 14, 18, 20, 24),
+"times": PackedFloat32Array(0, 3, 5, 10, 14, 19, 21, 24),
 "transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1),
 "update": 0,
 "values": [Color(0.09333344, 0, 0.4, 1), Color(0.48, 0.48, 0.48, 1), Color(0.9, 0.9, 0.9, 1), Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(0.48, 0.48, 0.48, 1), Color(0.09333344, 0, 0.4, 1)]
@@ -216,20 +216,20 @@ one_shot = true
 unique_name_in_owner = true
 one_shot = true
 
-[node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=1435119273]
+[node name="DebugCanvasLayer" type="CanvasLayer" parent="." unique_id=1435119273]
+unique_name_in_owner = true
 
-[node name="PanelContainer" type="PanelContainer" parent="CanvasLayer" unique_id=1335958639]
+[node name="PanelContainer" type="PanelContainer" parent="DebugCanvasLayer" unique_id=1335958639]
 offset_right = 117.0
 offset_bottom = 22.0
 theme_type_variation = &"FlatContainer"
 
-[node name="MarginContainer" type="MarginContainer" parent="CanvasLayer/PanelContainer" unique_id=423612586]
+[node name="MarginContainer" type="MarginContainer" parent="DebugCanvasLayer/PanelContainer" unique_id=423612586]
 layout_mode = 2
 theme_override_constants/margin_left = 8
 theme_override_constants/margin_right = 8
 
-[node name="DebugLabel" type="Label" parent="CanvasLayer/PanelContainer/MarginContainer" unique_id=1439776273]
-unique_name_in_owner = true
+[node name="DebugLabel" type="Label" parent="DebugCanvasLayer/PanelContainer/MarginContainer" unique_id=1439776273]
 layout_mode = 2
 size_flags_horizontal = 0
 theme_override_fonts/font = ExtResource("4_u1pcj")

--- a/scenes/game_elements/fx/time_and_weather/time_and_weather.tscn
+++ b/scenes/game_elements/fx/time_and_weather/time_and_weather.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://dc3bqwr0cvimn" path="res://scenes/game_elements/fx/time_and_weather/components/time_and_weather.gd" id="1_rr8fb"]
 [ext_resource type="PackedScene" uid="uid://c0374lgarm8gj" path="res://scenes/game_elements/fx/clouds_shadow/clouds_shadow.tscn" id="2_oruto"]
 [ext_resource type="PackedScene" uid="uid://dpbsi065gmh8a" path="res://scenes/game_elements/fx/fog/fog.tscn" id="3_uf36w"]
+[ext_resource type="FontFile" uid="uid://b0tjcgrk504qg" path="res://assets/third_party/fonts/jersey/Jersey10-Regular.ttf" id="4_u1pcj"]
 [ext_resource type="Script" uid="uid://qrbdfx4ka2o8" path="res://scenes/game_elements/fx/time_and_weather/components/debug_label.gd" id="4_uf36w"]
 
 [sub_resource type="Gradient" id="Gradient_duxxr"]
@@ -217,10 +218,22 @@ one_shot = true
 
 [node name="CanvasLayer" type="CanvasLayer" parent="." unique_id=1435119273]
 
-[node name="DebugLabel" type="Label" parent="CanvasLayer" unique_id=1439776273]
+[node name="PanelContainer" type="PanelContainer" parent="CanvasLayer" unique_id=1335958639]
+offset_right = 117.0
+offset_bottom = 22.0
+theme_type_variation = &"FlatContainer"
+
+[node name="MarginContainer" type="MarginContainer" parent="CanvasLayer/PanelContainer" unique_id=423612586]
+layout_mode = 2
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_right = 8
+
+[node name="DebugLabel" type="Label" parent="CanvasLayer/PanelContainer/MarginContainer" unique_id=1439776273]
 unique_name_in_owner = true
-offset_right = 119.0
-offset_bottom = 23.0
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_fonts/font = ExtResource("4_u1pcj")
+theme_override_font_sizes/font_size = 19
 text = "What time is it?"
 script = ExtResource("4_uf36w")
 


### PR DESCRIPTION
Full night is now 6 hours, 2 hours less than before.

Adjust start/stop effects: fog and lights are reduced by 2 hours. While clouds
shadows is reduced by 1 hour, because the fade out looks better when is getting
dark.

### TimeAndWeather: Use panel and same font as signs for debug label

Otherwise it is unreadable under some weather conditions. Check the museum for
example.

### Add effect schedule resource

To de-hardcode the start/stop times of effects in the script. Also export them
so learners can change them.

Resolves https://github.com/endlessm/threadbare/issues/2355