### PR TITLE
After the Tremor: Remove now-incorrect control hints from dialogue

### DIFF
--- a/scenes/quests/story_quests/after_the_tremor/2_colegiojuego/after_the_tremor_stealth.dialogue
+++ b/scenes/quests/story_quests/after_the_tremor/2_colegiojuego/after_the_tremor_stealth.dialogue
@@ -3,7 +3,7 @@
 ~ start
 Bryan esta en peligro! Has lo que puedas para salvarlo!
 
-Usa el cable(Barra espaciadora o Click izquierdo) para unir los cabos sueltos y hacer que la palanca funcione otra vez!
+Usa el cable para unir los cabos sueltos y hacer que la palanca funcione otra vez!
 
 Cuando los hayas unido todos, los cables se encenderan!
 


### PR DESCRIPTION
After the Tremor: Remove now-incorrect control hints from dialogue

This predates the change to the control scheme. Space no longer throws
the grappling hook.

I don't think we need to say what the buttons are in dialogue because
it's shown on-screen.
