### PR TITLE
Bind skipping dialogue to space/Xbox A

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -172,8 +172,9 @@ dialogue_next={
 }
 dialogue_skip={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194306,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":1,"pressure":0.0,"pressed":true,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194306,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 sokoban_undo={

--- a/scenes/menus/credits/data/community.csv
+++ b/scenes/menus/credits/data/community.csv
@@ -44,3 +44,4 @@ Tobías Romero,,Mentors
 Victor Avalos,,Mentors
 Victoria Ciallela,,Mentors
 Universidad Tecnológica del Perú,,Special Thanks
+Bonnie Jo Mayer,,Playtesting


### PR DESCRIPTION
Previously Tab (or Xbox B) skips typing-out of the current line of
dialogue and shows it all at once. I chose a different key to the "next
line"/"accept choice" button (Space / A) because I didn't want people to
skip dialogue by accident.

But watching people at Serious Play testing the game (as I am doing
now), everyone expects to be able to use the same key that advances to
the next line of dialogue, to skip the typing out of the dialogue.

Change the binding.

Credit the playtester who specifically suggested this!

