### PR TITLE
Sign post: Add unshaded material to label

### DIFF
--- a/scenes/game_elements/props/sign/sign.tscn
+++ b/scenes/game_elements/props/sign/sign.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://o54tdc374nxc" path="res://scenes/game_elements/props/sign/components/sign.gd" id="1_cb2ey"]
 [ext_resource type="Texture2D" uid="uid://cq5l1xle30ch7" path="res://assets/third_party/tiny-swords/Deco/17.png" id="2_85li6"]
 [ext_resource type="FontFile" uid="uid://b0tjcgrk504qg" path="res://assets/third_party/fonts/jersey/Jersey10-Regular.ttf" id="3_1ap0m"]
+[ext_resource type="Material" uid="uid://b41j6upvxttw3" path="res://scenes/ui_elements/components/unshaded_material.tres" id="3_7odj1"]
 [ext_resource type="Texture2D" uid="uid://b5ooaiyxdrp6a" path="res://scenes/game_elements/components/light_texture_256x256.tres" id="4_c8ong"]
 [ext_resource type="Script" uid="uid://bk52qjv58locq" path="res://scenes/game_logic/light2d_behaviors/artificial_light_behavior.gd" id="5_7odj1"]
 
@@ -37,6 +38,7 @@ offset_bottom = -76.0
 pivot_offset = Vector2(100, 50)
 
 [node name="PanelContainer" type="PanelContainer" parent="LabelContainer" unique_id=1780698378]
+material = ExtResource("3_7odj1")
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 8

--- a/scenes/ui_elements/components/unshaded_material.tres
+++ b/scenes/ui_elements/components/unshaded_material.tres
@@ -1,0 +1,4 @@
+[gd_resource type="CanvasItemMaterial" format=3 uid="uid://b41j6upvxttw3"]
+
+[resource]
+light_mode = 1


### PR DESCRIPTION
This label is not supposed to be part of the world. Add a new CanvasItemMaterial to the PanelContainer and set it to light mode: unshaded.