### PR TITLE
tutorial: Say "altar" not "plinth"

### DIFF
--- a/scenes/quests/lore_quests/quest_000/3_sequence_puzzle/components/tutorial_sequence_puzzle.dialogue
+++ b/scenes/quests/lore_quests/quest_000/3_sequence_puzzle/components/tutorial_sequence_puzzle.dialogue
@@ -8,10 +8,10 @@ Arun: This way! Follow me!
 match puzzle.get_progress()
 	when 0:
 		Arun: We'll have to tap the rocks in a particular order to open the door.
-		Arun: But I can't remember the sequence. Maybe those plinths are a clue?
+		Arun: But I can't remember the sequence. Maybe those altars hold a clue?
 	when 1:
 		Arun: You're half-way there!
-		Arun: It looks like the second plinth has a different symbol on it...
+		Arun: It looks like the second altar has a different symbol on it...
 	else:
 		Arun: You did it!
 		Arun: Let's go north together.


### PR DESCRIPTION
tutorial: Say "altar" not "plinth"

Plinth is a less familiar word (particularly to non-native speakers), is
not the word we use in the musician quest, and is also less accurate
since a plinth is a stand that you put something else on top of.
