### PR TITLE
Retelling: Show spools in responses

### DIFF
--- a/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
+++ b/scenes/game_elements/props/eternal_loom/components/eternal_loom.gd
@@ -53,21 +53,6 @@ func has_spirit() -> bool:
 	return _has_magical_thread_of_type(InventoryItem.ItemType.SPIRIT)
 
 
-func memory_text() -> String:
-	var has_it := _has_magical_thread_of_type(InventoryItem.ItemType.MEMORY)
-	return "(Memory available!)" if has_it else ""
-
-
-func imagination_text() -> String:
-	var has_it := _has_magical_thread_of_type(InventoryItem.ItemType.IMAGINATION)
-	return "(Imagination available!)" if has_it else ""
-
-
-func spirit_text() -> String:
-	var has_it := _has_magical_thread_of_type(InventoryItem.ItemType.SPIRIT)
-	return "(Spirit available!)" if has_it else ""
-
-
 func _give_upgrade(type: InventoryItem.ItemType) -> void:
 	var has_it := _has_magical_thread_of_type(type)
 	if not has_it:

--- a/scenes/quests/lore_quests/quest_000/quest_000_retelling.dialogue
+++ b/scenes/quests/lore_quests/quest_000/quest_000_retelling.dialogue
@@ -3,18 +3,18 @@
 ~ start
 Townies: Was the journey here difficult? Tell us!
 StoryWeaver: Arun guided me all the way here, and...
-- He told me what happened to his village {{ memory_text() }}
+- He told me what happened to his village [#thread=memory]
 	StoryWeaver: The Void left him all alone. I'm glad I found him!
 	if has_memory()
 		do give_memory_upgrade()
 		Townie: I think I visited his village as a child!
-- I learnt to grapple {{ imagination_text() }}
+- I learnt to grapple [#thread=imagination]
 	StoryWeaver: I threw my thread and pulled myself across the water.
 	StoryWeaver: As I flew through the air, I felt so free!
 	if has_imagination()
 		do give_imagination_upgrade()
 		Townie: That sounds like a dream come true.
-- I had to sneak through some caves {{ spirit_text() }}
+- I had to sneak through some caves [#thread=spirit]
 	StoryWeaver: The caves were full of StoryVores.
 	StoryWeaver: I was so glad the KnitWitches were there to help me on my way.
 	if has_spirit()

--- a/scenes/quests/lore_quests/quest_001/quest_001_retelling.dialogue
+++ b/scenes/quests/lore_quests/quest_001/quest_001_retelling.dialogue
@@ -3,9 +3,9 @@
 ~ start
 Townies: Tell us a story about your last adventure!
 StoryWeaver: I went on a quest with the musician and I...
-- Learned a forgotten song {{ memory_text() }} => retell_memory
-- Slipped past the guards {{ imagination_text() }} => retell_imagination
-- Fought off some InkDrinkers {{ spirit_text() }} => retell_spirit
+- Learned a forgotten song [#thread=memory] => retell_memory
+- Slipped past the guards [#thread=imagination] => retell_imagination
+- Fought off some InkDrinkers [#thread=spirit] => retell_spirit
 
 ~ retell_memory
 StoryWeaver: Let me whistle it to you...
@@ -23,7 +23,7 @@ if has_imagination()
 
 ~ retell_spirit
 StoryWeaver: Because they had stolen the ink!
-if has_imagination()
+if has_spirit()
 	do give_spirit_upgrade()
 	Townie: Ha! I feel brave now!
 => END

--- a/scenes/quests/lore_quests/quest_002/quest_002_retelling.dialogue
+++ b/scenes/quests/lore_quests/quest_002/quest_002_retelling.dialogue
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
+Townies: Tell us a story about your last adventure!
 StoryWeaver: I went on a quest with the monk and I...
-- Had to run! {{ spirit_text() }} => retell_spirit
-- Found inventive ways of moving {{ imagination_text() }} => retell_imagination
-- Delivered a story to the town {{ memory_text() }} => retell_memory
+- Had to run! [#thread=spirit] => retell_spirit
+- Found inventive ways of moving [#thread=imagination] => retell_imagination
+- Delivered a story to the town [#thread=memory] => retell_memory
 
 ~ retell_memory
-Townies: Tell us a story about your last adventure!
 StoryWeaver: We saved the story from The Void...
 if has_memory()
 	do give_memory_upgrade()
@@ -23,7 +23,7 @@ if has_imagination()
 
 ~ retell_spirit
 StoryWeaver: The Void was eating the floor behind me, but I managed to escape!
-if has_imagination()
+if has_spirit()
 	do give_spirit_upgrade()
 	Townie: Whoa. I feel brave now!
 => END

--- a/scenes/ui_elements/dialogue/balloon.tscn
+++ b/scenes/ui_elements/dialogue/balloon.tscn
@@ -4,6 +4,8 @@
 [ext_resource type="Texture2D" uid="uid://dh4tixu06hfwt" path="res://assets/third_party/tiny-swords/UI/Banners/Carved_9Slides.png" id="3_1s4ug"]
 [ext_resource type="PackedScene" uid="uid://ckvgyvclnwggo" path="res://addons/dialogue_manager/dialogue_label.tscn" id="4_3tiik"]
 [ext_resource type="Script" uid="uid://bb52rsfwhkxbn" path="res://addons/dialogue_manager/dialogue_responses_menu.gd" id="5_gjlrd"]
+[ext_resource type="Texture2D" uid="uid://brspc1u02oawt" path="res://assets/first_party/collectibles/memory.png" id="5_oh0dh"]
+[ext_resource type="Script" uid="uid://bj58s4f3rjsqs" path="res://scenes/ui_elements/dialogue/components/response_button.gd" id="5_u3aeq"]
 [ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="6_y5co6"]
 [ext_resource type="Texture2D" uid="uid://bbvedlx2ahdxk" path="res://assets/third_party/kenney_input_prompts/keyboard-&-mouse_sheet_default.png" id="7_u3aeq"]
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="8_saw5e"]
@@ -123,8 +125,12 @@ response_template = NodePath("ResponseExample")
 
 [node name="ResponseExample" type="Button" parent="Balloon/BalloonContainer/MarginContainer/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ResponsesMenu" unique_id=957333658]
 layout_mode = 2
+size_flags_horizontal = 4
 theme_type_variation = &"FlatButton"
 text = "Response example"
+icon = ExtResource("5_oh0dh")
+icon_alignment = 2
+script = ExtResource("5_u3aeq")
 
 [node name="NextButton" type="Button" parent="Balloon/BalloonContainer/MarginContainer" unique_id=1047703477]
 unique_name_in_owner = true

--- a/scenes/ui_elements/dialogue/components/response_button.gd
+++ b/scenes/ui_elements/dialogue/components/response_button.gd
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Button
+## Dialogue response button, possibly with an icon depending on tags
+
+var response: DialogueResponse:
+	set = set_response
+
+
+func set_response(value: DialogueResponse) -> void:
+	response = value
+	text = response.text
+
+	var thread_type := response.get_tag_value("thread")
+	if thread_type and thread_type.to_upper() in InventoryItem.ItemType:
+		icon = InventoryItem.HUD_TEXTURES[InventoryItem.ItemType[thread_type.to_upper()]]
+	else:
+		icon = null

--- a/scenes/ui_elements/dialogue/components/response_button.gd.uid
+++ b/scenes/ui_elements/dialogue/components/response_button.gd.uid
@@ -1,0 +1,1 @@
+uid://bj58s4f3rjsqs


### PR DESCRIPTION
Previously the text "(Memory available!)" was shown next to the
retelling dialogue branch that related to the thread of Memory (resp.
other threads). The text was not shown if no Memory thread had been
collected.

Instead, show the icon for the thread of Memory. Use Dialogue Manager's
tags feature to get this information from the dialogue file through to
the balloon. Add a script to the response button that has a `response`
property, which causes Dialogue Manager to assign the DialogueResponse
resource to this property rather than setting a `text` property.

Position the icon to the right of the text. Configure the button to
shrink to the centre so that the icon is aligned to the right edge of
the label rather than all 3 icons being right-justified.

It is not possible (as far as I can tell) to conditionally apply the
tag. Unconditionally apply the tags. We could in future consider
disabling the retelling branches for threads the player did not collect,
but currently all the threads are mandatory.

Fix the `has_imagination()` check in two places to be `has_spirit()` as
intended, and move “Tell us a story about your last adventure!” to the
right place in the Void retelling.

