### PR TITLE
credits: Add playtesters from Serious Play in Mainz

### DIFF
--- a/scenes/menus/credits/data/community.csv
+++ b/scenes/menus/credits/data/community.csv
@@ -44,4 +44,11 @@ Tobías Romero,,Mentors
 Victor Avalos,,Mentors
 Victoria Ciallela,,Mentors
 Universidad Tecnológica del Perú,,Special Thanks
+Annekatrin Baumann,,Playtesting
+Verena Freund,,Playtesting
+Erik Harpstead,,Playtesting
+Nathaly Kalantar,,Playtesting
 Bonnie Jo Mayer,,Playtesting
+Janneke Neumahr,,Playtesting
+Paul Riesch,,Playtesting
+Vincenzo Santalucia,,Playtesting


### PR DESCRIPTION
credits: Add playtesters from Serious Play in Mainz

We had Threadbare in an arcade cabinet at this event last week. I took
the opportunity to watch a number of people playing the game and made
extensive notes.

Thanks to all these individuals whose names I noted for their time spent
playing the game and discussing it with me. (I believe I checked with
each person named here that they were happy to be credited.) Thanks also
to those whose names I did not record, and to those who declined to be
credited.
