### PR TITLE
Upgrade Flatpak build to Godot 4.7

### DIFF
--- a/linux/org.endlessaccess.threadbare.yml
+++ b/linux/org.endlessaccess.threadbare.yml
@@ -4,7 +4,7 @@ id: org.endlessaccess.threadbare
 runtime: org.freedesktop.Platform
 runtime-version: '25.08'
 base: org.godotengine.godot.BaseApp
-base-version: '4.6'
+base-version: '4.7'
 sdk: org.freedesktop.Sdk
 command: godot-runner
 finish-args:


### PR DESCRIPTION
Upgrade Flatpak build to Godot 4.7

Deferred due to
https://github.com/flathub/org.godotengine.godot.BaseApp/issues/76 which
is now fixed.
