### PR TITLE
Ink combat round 3: remove ink follows player

### DIFF
--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
@@ -135,7 +135,6 @@ attack_sound_stream = ExtResource("11_7kldn")
 projectile_scene = ExtResource("12_ms350")
 projectile_speed = 20.0
 projectile_duration = 10.0
-projectile_follows_player = true
 walking_range = 0.0
 walking_speed = 20.0
 
@@ -149,7 +148,6 @@ idle_sound_stream = ExtResource("10_uyhkg")
 attack_sound_stream = ExtResource("11_7kldn")
 projectile_scene = ExtResource("12_ms350")
 projectile_duration = 10.0
-projectile_follows_player = true
 walking_range = 0.0
 walking_speed = 20.0
 


### PR DESCRIPTION
This makes the ink blobs to go in a straight line, as expected.

Fix https://github.com/endlessm/threadbare/issues/2440