### PR TITLE
GameState: Add global and per-quest generic facts

### DIFF
--- a/scenes/game_elements/characters/npcs/musician/components/sequence_puzzle_assistant.gd
+++ b/scenes/game_elements/characters/npcs/musician/components/sequence_puzzle_assistant.gd
@@ -22,6 +22,7 @@ func _ready() -> void:
 		return
 
 	puzzle.solved.connect(_on_puzzle_solved)
+	puzzle.progress_changed.connect(_on_puzzle_progress_changed)
 
 
 ## Call this method from dialogue to record that the player has been offered one more hint for the
@@ -45,6 +46,11 @@ func _get_configuration_warnings() -> PackedStringArray:
 		warnings.append("No puzzle assigned")
 
 	return warnings
+
+
+func _on_puzzle_progress_changed() -> void:
+	if puzzle.is_solved():
+		_on_puzzle_solved()
 
 
 func _on_puzzle_solved() -> void:

--- a/scenes/game_elements/characters/npcs/musician/components/sequence_puzzle_assistant.gd
+++ b/scenes/game_elements/characters/npcs/musician/components/sequence_puzzle_assistant.gd
@@ -15,10 +15,6 @@ extends Talker
 		puzzle = new_value
 		update_configuration_warnings()
 
-## The [member Talker.dialogue] configured on this node can check and modify this property to play
-## different dialogue for the player's first interaction with this NPC, if desired.
-var first_conversation: bool = true
-
 
 func _ready() -> void:
 	super._ready()

--- a/scenes/game_logic/sequence_puzzle.gd
+++ b/scenes/game_logic/sequence_puzzle.gd
@@ -3,6 +3,10 @@
 class_name SequencePuzzle
 extends Node2D
 
+## Emitted when the progress in the puzzle changes. This could be due to restoring saved state. For
+## the game change triggered by the player, see [member step_solved].
+signal progress_changed
+
 ## Emitted when the entire puzzle is solved
 signal solved
 
@@ -73,6 +77,7 @@ func _find_objects() -> void:
 
 
 func _update_current_step() -> void:
+	var previous_step := _current_step
 	for i in range(_current_step, steps.size()):
 		# We find the next fire that is not solved, and that's the _current_step
 		if steps[i].hint_sign.is_solved:
@@ -80,6 +85,9 @@ func _update_current_step() -> void:
 			_position = 0
 		else:
 			break
+
+	if _current_step != previous_step:
+		progress_changed.emit()
 
 	if interactive_hints and _current_step < steps.size():
 		steps[_current_step].hint_sign.interactive_hint = true
@@ -132,6 +140,14 @@ func _on_kicked(object: SequencePuzzleObject) -> void:
 
 func get_progress() -> int:
 	return _current_step
+
+
+func set_progress(step: int) -> void:
+	for i in range(steps.size()):
+		if i <= step:
+			steps[i].hint_sign.is_solved = true
+
+	_update_current_step()
 
 
 func is_solved() -> bool:

--- a/scenes/globals/game_state/global_state.gd
+++ b/scenes/globals/game_state/global_state.gd
@@ -36,6 +36,9 @@ signal helper_changed
 		completed_quests_changed.emit()
 		emit_changed()
 
+## Generic game state facts. For quests, use [member QuestState.facts] instead.
+@export var facts: Dictionary[String, Variant]
+
 ## Global player state. During a quest, [member QuestState.player] should be
 ## used instead. [GameState.player] always points to the correct instance.
 @export var player: PlayerState = PlayerState.new()

--- a/scenes/globals/game_state/quest_state.gd
+++ b/scenes/globals/game_state/quest_state.gd
@@ -5,7 +5,8 @@ extends Resource
 
 @export var quest: Quest
 
-## Generic game state facts about the current quest. Outside quests, use [member GlobalState.facts] instead.
+## Generic game state facts about the current quest. Outside quests, use [member GlobalState.facts]
+## instead.
 @export var facts: Dictionary[String, Variant]
 
 ## Resource path of [member quest], which is what is actually saved to disk.

--- a/scenes/globals/game_state/quest_state.gd
+++ b/scenes/globals/game_state/quest_state.gd
@@ -5,7 +5,7 @@ extends Resource
 
 @export var quest: Quest
 
-## Generic game state facts. Outside quests, use [member GlobalState.facts] instead.
+## Generic game state facts about the current quest. Outside quests, use [member GlobalState.facts] instead.
 @export var facts: Dictionary[String, Variant]
 
 ## Resource path of [member quest], which is what is actually saved to disk.

--- a/scenes/globals/game_state/quest_state.gd
+++ b/scenes/globals/game_state/quest_state.gd
@@ -5,6 +5,9 @@ extends Resource
 
 @export var quest: Quest
 
+## Generic game state facts. Outside quests, use [member GlobalState.facts] instead.
+@export var facts: Dictionary[String, Variant]
+
 ## Resource path of [member quest], which is what is actually saved to disk.
 ## Use [member quest] instead.
 @export_storage var quest_path: String:

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/musician.dialogue
@@ -7,10 +7,10 @@ if thread.revealed:
 if puzzle.is_solved():
 	=> item_hint
 
-if not first_conversation:
+if GameState.quest.facts.spoke_to_musician:
 	=> hello_again
 
-set first_conversation = false
+set GameState.quest.facts.spoke_to_musician = true
 
 Musician: Ah! Another wanderer. Welcome to the Song Sanctuary. Or what's left of it.
 StoryWeaver: What happened here?

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
@@ -13,19 +13,21 @@ func _ready() -> void:
 		sequence_puzzle.set_progress(GameState.quest.facts.music_puzzle_progress)
 
 
-func _change_music(step_index: int) -> void:
+func _get_next_clip_name(step_index: int) -> StringName:
 	# This assumes that the clip indexes correspond to the puzzle indexes.
 	var stream := background_music.stream as AudioStreamInteractive
-	var next_clip := stream.get_clip_name(step_index + 1)
-	MusicPlayer.switch_to_clip(next_clip)
+	return stream.get_clip_name(step_index)
 
 
 func _on_sequence_puzzle_step_solved(step_index: int) -> void:
 	# Persist the state:
 	GameState.quest.facts.music_puzzle_progress = step_index
 
-	_change_music(step_index)
+	var next_clip := _get_next_clip_name(step_index)
+	MusicPlayer.switch_to_clip(next_clip)
 
 
 func _on_sequence_puzzle_progress_changed() -> void:
-	_change_music(sequence_puzzle.get_progress())
+	var step_index := sequence_puzzle.get_progress()
+	var next_clip := _get_next_clip_name(step_index)
+	MusicPlayer.play_stream(background_music.stream as AudioStreamInteractive, next_clip)

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/music_puzzle.gd
@@ -4,10 +4,28 @@ extends Node2D
 
 @onready var background_music: BackgroundMusic = %BackgroundMusic
 @onready var thread: CollectibleItem = %CollectibleItem
+@onready var sequence_puzzle: SequencePuzzle = %SequencePuzzle
 
 
-func _on_sequence_puzzle_step_solved(step_index: int) -> void:
+func _ready() -> void:
+	# Restore from saved state:
+	if "music_puzzle_progress" in GameState.quest.facts:
+		sequence_puzzle.set_progress(GameState.quest.facts.music_puzzle_progress)
+
+
+func _change_music(step_index: int) -> void:
 	# This assumes that the clip indexes correspond to the puzzle indexes.
 	var stream := background_music.stream as AudioStreamInteractive
 	var next_clip := stream.get_clip_name(step_index + 1)
 	MusicPlayer.switch_to_clip(next_clip)
+
+
+func _on_sequence_puzzle_step_solved(step_index: int) -> void:
+	# Persist the state:
+	GameState.quest.facts.music_puzzle_progress = step_index
+
+	_change_music(step_index)
+
+
+func _on_sequence_puzzle_progress_changed() -> void:
+	_change_music(sequence_puzzle.get_progress())

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1569,4 +1569,5 @@ script = ExtResource("45_ps6xw")
 stream = ExtResource("47_orlow")
 metadata/_custom_type_script = "uid://c8405c212rbn6"
 
+[connection signal="progress_changed" from="OnTheGround/SequencePuzzle" to="." method="_on_sequence_puzzle_progress_changed"]
 [connection signal="step_solved" from="OnTheGround/SequencePuzzle" to="." method="_on_sequence_puzzle_step_solved"]

--- a/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/musician.dialogue
+++ b/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/musician.dialogue
@@ -4,10 +4,10 @@
 if puzzle.is_solved():
 	=> item_hint
 
-if puzzle.get_progress() >= 1 or not first_conversation:
+if puzzle.get_progress() >= 1 or GameState.quest.facts.spoke_to_musician:
 	=> hints
 
-set first_conversation = false
+set GameState.quest.facts.spoke_to_musician = true
 
 {{npc_name}}: We meet again, {{player_name}}!
 {{npc_name}}: Once again, you must relight the altars by playing a melody on the colorful rocks.


### PR DESCRIPTION
And use the per-quest for the musical puzzle.

### GameState: Add global and per-quest generic facts

A generic database of facts about the world. Quests also have their own, for
per-quest facts.

### Musician: Use generic game state fact for checking first conversation

Remove the variable from the script and use a fact instead, making this persist
when the game is saved.

In lore quests quest_001 and song_sancturary_2. Note that these are 2 separate
facts, because they are for different quests.

### Lore quest_001: Persist progress in music puzzle

Add a setter to SequencePuzzle for it. And also a separate signal for when the
progress (the step) changes. It has to be a separate signal because we want to
persist state when step_solved is emitted, and only do the side effects when
progress_changed is emitted.

----

Helps https://github.com/endlessm/threadbare/issues/2279

Co-authored-by: Will Thompson <wjt@endlessaccess.org>


