### PR TITLE
stella stealth: Fix Y-sorting player and trees

### DIFF
--- a/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
+++ b/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
@@ -225,6 +225,7 @@ dialogue = ExtResource("14_wgqmn")
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="OnTheGround" type="Node2D" parent="." unique_id=1431743695]
+y_sort_enabled = true
 
 [node name="Player" parent="OnTheGround" unique_id=1098139999 instance=ExtResource("3_qvtgt")]
 position = Vector2(108, 385)
@@ -510,6 +511,7 @@ sprite_frames = SubResource("SpriteFrames_24u5l")
 autoplay = "default"
 
 [node name="Trees" parent="OnTheGround" unique_id=586987874 instance=ExtResource("16_0ownb")]
+y_sort_enabled = true
 position = Vector2(2605, 424)
 scale = Vector2(0.846067, 0.908392)
 


### PR DESCRIPTION
stella stealth: Fix Y-sorting player and trees

I missed these notes in a previous change to fix Y-sorting in this
scene.
