### PR TITLE
storyquest_bootstrap: Fix setting quest description

### DIFF
--- a/addons/storyquest_bootstrap/new_storyquest_dialog.tscn
+++ b/addons/storyquest_bootstrap/new_storyquest_dialog.tscn
@@ -129,4 +129,5 @@ text = "Create"
 [connection signal="text_changed" from="PanelContainer/VBoxContainer/GridContainer/FolderEdit" to="." method="_on_folder_edit_text_changed"]
 [connection signal="text_submitted" from="PanelContainer/VBoxContainer/GridContainer/FolderEdit" to="." method="submit" unbinds=1]
 [connection signal="gui_input" from="PanelContainer/VBoxContainer/DescriptionEdit" to="." method="_on_description_edit_gui_input"]
+[connection signal="text_changed" from="PanelContainer/VBoxContainer/DescriptionEdit" to="." method="_on_description_edit_text_changed"]
 [connection signal="pressed" from="PanelContainer/VBoxContainer/MarginContainer2/CreateButton" to="." method="submit"]


### PR DESCRIPTION
I accidentally removed an important signal connection while tweaking
this dialog in commit 1ad24df997af7d38d227328a8853244c50bf831e.
