### PR TITLE
Storybook: Scroll to focused button

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -29,7 +29,7 @@ var _current_spread_index: int = -1
 var _navigation_locked: bool = false
 
 @onready var quest_list: VBoxContainer = %QuestList
-@onready var quest_container: Control = %QuestContainer
+@onready var quest_container: ScrollContainer = %QuestContainer
 @onready var storybook_page: StorybookPage = %StorybookPage
 @onready var back_button: Button = %BackButton
 @onready var animated_book: AnimatedSprite2D = %AnimatedSprite2D
@@ -52,6 +52,8 @@ func _ready() -> void:
 
 		button.pressed.connect(_on_quest_button_pressed.bind(button))
 		button.focus_next = back_button.get_path()
+
+		button.focus_entered.connect(quest_container.ensure_control_visible.bind(button))
 
 		if previous_button:
 			button.focus_neighbor_top = previous_button.get_path()


### PR DESCRIPTION
Previously, if you scrolled down in the storybook using the down arrow, you would eventually focus a button that is scrolled out of the visible area of the scroll container.

Scroll the container when a button is focused so that that button is in view.

Helps https://github.com/endlessm/threadbare/issues/1757
