### PR TITLE
InventoryItem: Remove "name" property

### DIFF
--- a/scenes/globals/game_state/inventory/inventory_item.gd
+++ b/scenes/globals/game_state/inventory/inventory_item.gd
@@ -29,7 +29,6 @@ const WORLD_TEXTURES: Dictionary[ItemType, Texture2D] = {
 	ItemType.SPIRIT: preload("uid://cepg1o3ihp055")
 }
 
-@export var name: String
 @export var type: ItemType
 
 

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
@@ -79,7 +79,6 @@ size = Vector2(52, 61)
 
 [sub_resource type="Resource" id="Resource_8l6e1"]
 script = ExtResource("23_amu0w")
-name = "Memory"
 metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_amu0w"]

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_start.tscn
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_start.tscn
@@ -65,7 +65,6 @@ _data = {
 
 [sub_resource type="Resource" id="Resource_kr8u1"]
 script = ExtResource("8_jqq45")
-name = "Imagination"
 type = 1
 metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 


### PR DESCRIPTION
InventoryItem: Remove "name" property

This is never read, and was only set in two scenes. It's also not
persisted to the game state.

What we use instead is the `InventoryItem.type_name()` function which
returns "Memory", "Imagination", or "Spirit" based on the `type`
property.
