### PR TITLE
Pause overlay: Save game state on Exit to Title

### DIFF
--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -95,6 +95,7 @@ func _on_back_button_pressed() -> void:
 
 
 func _on_title_screen_button_pressed() -> void:
+	GameState.save()
 	toggle_pause()
 	SceneSwitcher.change_to_file_with_transition(
 		title_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE


### PR DESCRIPTION
I believe this was like this before and it has regressed lately.