### PR TITLE
Add CollectibleFact and use it in buttons

### DIFF
--- a/scenes/game_elements/props/button_item/button_item.tscn
+++ b/scenes/game_elements/props/button_item/button_item.tscn
@@ -3,6 +3,8 @@
 [ext_resource type="Script" uid="uid://nejfw5t8xub5" path="res://scenes/game_elements/props/button_item/components/button_item.gd" id="1_14phb"]
 [ext_resource type="Texture2D" uid="uid://dpaqpkkj38f16" path="res://scenes/game_elements/props/button_item/components/button-yellow.png" id="1_i5psm"]
 [ext_resource type="Texture2D" uid="uid://dlpjjca2udf42" path="res://scenes/game_elements/props/button_item/components/button-shadow.png" id="2_14phb"]
+[ext_resource type="Script" uid="uid://cr6tdw8frg4a1" path="res://scenes/game_logic/collectible_fact/collectible_fact.gd" id="4_ympcj"]
+[ext_resource type="Script" uid="uid://dxvv340yej4py" path="res://scenes/game_logic/fact_counter/fact_counter.gd" id="5_7lbsr"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_14phb"]
 atlas = ExtResource("1_i5psm")
@@ -235,4 +237,13 @@ unique_name_in_owner = true
 position = Vector2(0, -24)
 shape = SubResource("CircleShape2D_i5psm")
 
+[node name="CollectibleFact" type="Node" parent="." unique_id=947240438 node_paths=PackedStringArray("collectible")]
+script = ExtResource("4_ympcj")
+collectible = NodePath("..")
+
+[node name="FactCounter" type="Node" parent="." unique_id=398358109]
+script = ExtResource("5_7lbsr")
+prefix = "buttons_collected"
+
+[connection signal="collected" from="." to="FactCounter" method="increment"]
 [connection signal="area_entered" from="Area2D" to="." method="_on_area_2d_area_entered"]

--- a/scenes/game_elements/props/button_item/components/button_item.gd
+++ b/scenes/game_elements/props/button_item/components/button_item.gd
@@ -45,10 +45,3 @@ func _on_area_2d_area_entered(area: Area2D) -> void:
 		collected.emit()
 		_emit_shine_particles()
 		queue_free()
-
-
-## Called from [CollectibleFact] when the game state already has this button
-## marked as collected.
-func start_collected() -> void:
-	visible = false
-	queue_free()

--- a/scenes/game_elements/props/button_item/components/button_item.gd
+++ b/scenes/game_elements/props/button_item/components/button_item.gd
@@ -40,7 +40,15 @@ func _emit_shine_particles() -> void:
 
 func _on_area_2d_area_entered(area: Area2D) -> void:
 	# TODO: This is not added to an inventory or anything, is just cosmetic.
+	# Although now is persisted in game state.
 	if area.owner.is_in_group(&"player"):
 		collected.emit()
 		_emit_shine_particles()
 		queue_free()
+
+
+## Called from [CollectibleFact] when the game state already has this button
+## marked as collected.
+func start_collected() -> void:
+	visible = false
+	queue_free()

--- a/scenes/game_elements/props/hookable_button_item/components/hookable_button_item.gd
+++ b/scenes/game_elements/props/hookable_button_item/components/hookable_button_item.gd
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: MPL-2.0
 extends CharacterBody2D
 
+@onready var button_item: ButtonItem = %ButtonItem
+
+
+func _ready() -> void:
+	if not button_item or button_item.is_queued_for_deletion():
+		queue_free()
+
 
 func _on_button_item_collected() -> void:
 	queue_free()

--- a/scenes/game_logic/collectible_fact/collectible_fact.gd
+++ b/scenes/game_logic/collectible_fact/collectible_fact.gd
@@ -64,7 +64,12 @@ func _on_collectible_ready() -> void:
 		if collectible.has_method("start_collected"):
 			collectible.start_collected()
 		else:
+			# Fallback to just free the collectible:
 			collectible.queue_free()
+		# If the game state indicates that the collectible was collected, we can safely free this
+		# node after applying the effects (calling start_collected() on them or its fallback).
+		# In the future, we may want to revisit this, if we add a way to bring back the collected
+		# items while the game is running.
 		queue_free()
 	else:
 		collectible.connect(COLLECTED_SIGNAL_NAME, _on_collectible_collected)

--- a/scenes/game_logic/collectible_fact/collectible_fact.gd
+++ b/scenes/game_logic/collectible_fact/collectible_fact.gd
@@ -12,7 +12,7 @@ extends Node
 
 const COLLECTED_SIGNAL_NAME := "collected"
 
-## A node with a signal named [member COLLECTED_SIGNAL_NAME]. Also if the node has a method named
+## A node with a signal named [constant COLLECTED_SIGNAL_NAME]. Also if the node has a method named
 ## "start_collected", it may be called when restoring the game state.
 @export var collectible: Node2D:
 	set = _set_collectible

--- a/scenes/game_logic/collectible_fact/collectible_fact.gd
+++ b/scenes/game_logic/collectible_fact/collectible_fact.gd
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name CollectibleFact
+extends Node
+## Persist and restore the collected state of a collectible. For example, a
+## [ButtonItem].
+##
+## Persist one Array per scene file, using the current scene file path as key for
+## the fact. And use the collectible node path inside the scene for identifying
+## each collectible.
+
+const COLLECTED_SIGNAL_NAME := "collected"
+
+## A node with a signal named [member COLLECTED_SIGNAL_NAME]. Also if the node has a method named
+## "start_collected", it may be called when restoring the game state.
+@export var collectible: Node2D:
+	set = _set_collectible
+
+var _fact_name: String
+var _fact_value: String
+var _facts: Dictionary
+
+
+func _enter_tree() -> void:
+	if not collectible and get_parent() is Node2D:
+		collectible = get_parent()
+
+
+func _set_collectible(new_collectible: Node2D) -> void:
+	collectible = new_collectible
+	if not Engine.is_editor_hint():
+		if collectible.is_node_ready():
+			_on_collectible_ready()
+		else:
+			collectible.ready.connect(_on_collectible_ready)
+	update_configuration_warnings()
+
+
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings: PackedStringArray
+	if not collectible:
+		warnings.append("Collectible must be set.")
+	elif not collectible.has_signal(COLLECTED_SIGNAL_NAME):
+		warnings.append("Collectible must have a signal named %s." % COLLECTED_SIGNAL_NAME)
+	return warnings
+
+
+func _get_fact_name() -> String:
+	return "collected_in_%s" % get_tree().current_scene.scene_file_path
+
+
+func _get_fact_dict() -> Dictionary:
+	return GameState.quest.facts if GameState.quest else GameState.global.facts
+
+
+func _on_collectible_ready() -> void:
+	if not GameState.persist_progress:
+		queue_free()
+		return
+
+	_fact_name = _get_fact_name()
+	_fact_value = collectible.get_path()
+	_facts = _get_fact_dict()
+
+	if _fact_value in _facts.get(_fact_name, []):
+		# Restore from saved state:
+		if collectible.has_method("start_collected"):
+			collectible.start_collected()
+		else:
+			collectible.visible = false
+			collectible.queue_free()
+		queue_free()
+	else:
+		collectible.connect(COLLECTED_SIGNAL_NAME, _on_collectible_collected)
+
+
+func _on_collectible_collected() -> void:
+	# Persist the state:
+	if _fact_name not in _facts:
+		_facts[_fact_name] = []
+	(_facts[_fact_name] as Array).append(_fact_value)

--- a/scenes/game_logic/collectible_fact/collectible_fact.gd
+++ b/scenes/game_logic/collectible_fact/collectible_fact.gd
@@ -64,7 +64,6 @@ func _on_collectible_ready() -> void:
 		if collectible.has_method("start_collected"):
 			collectible.start_collected()
 		else:
-			collectible.visible = false
 			collectible.queue_free()
 		queue_free()
 	else:

--- a/scenes/game_logic/collectible_fact/collectible_fact.gd
+++ b/scenes/game_logic/collectible_fact/collectible_fact.gd
@@ -56,7 +56,7 @@ func _get_fact_dict() -> Dictionary:
 
 func _on_collectible_ready() -> void:
 	_fact_name = _get_fact_name()
-	_fact_value = collectible.get_path()
+	_fact_value = get_tree().current_scene.get_path_to(collectible)
 	_facts = _get_fact_dict()
 
 	if _fact_value in _facts.get(_fact_name, []):

--- a/scenes/game_logic/collectible_fact/collectible_fact.gd
+++ b/scenes/game_logic/collectible_fact/collectible_fact.gd
@@ -55,10 +55,6 @@ func _get_fact_dict() -> Dictionary:
 
 
 func _on_collectible_ready() -> void:
-	if not GameState.persist_progress:
-		queue_free()
-		return
-
 	_fact_name = _get_fact_name()
 	_fact_value = collectible.get_path()
 	_facts = _get_fact_dict()

--- a/scenes/game_logic/collectible_fact/collectible_fact.gd
+++ b/scenes/game_logic/collectible_fact/collectible_fact.gd
@@ -13,7 +13,7 @@ extends Node
 const COLLECTED_SIGNAL_NAME := "collected"
 
 ## A node with a signal named [constant COLLECTED_SIGNAL_NAME]. Also if the node has a method named
-## "start_collected", it may be called when restoring the game state.
+## [code]start_collected[/code], it may be called when restoring the game state.
 @export var collectible: Node2D:
 	set = _set_collectible
 

--- a/scenes/game_logic/collectible_fact/collectible_fact.gd.uid
+++ b/scenes/game_logic/collectible_fact/collectible_fact.gd.uid
@@ -1,0 +1,1 @@
+uid://cr6tdw8frg4a1

--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -129,8 +129,8 @@ func set_quest(new_quest: Quest) -> void:
 	quest = QuestState.new(new_quest, quest_player_state)
 
 
-## Guess which quest the given scene is part of, and set [member current_quest]
-## accordingly. If the quest cannot be determined, unset [member current_quest].
+## Guess which quest the given scene is part of, and set [member quest]
+## accordingly. If the quest cannot be determined, unset [member quest].
 ## [br][br]
 ## This is for use when jumping to a particular scene during development (e.g.
 ## with F6 in the editor, the URL hash in the browser, or in future if we add a


### PR DESCRIPTION
The exported property `collectible` is any Node2D that has a "collected" signal.

Persist one Array per scene file, using the current scene file path as key for the fact. And use the collectible node path inside the scene for identifying each collectible.

Adapt hookable button item to be freed when ready, if the wrapped button item is freed too (or queued for deletion).

Also add a FactCounter named "buttons_collected" to buttons.

Resolve https://github.com/endlessm/threadbare/issues/2279