### PR TITLE
title_screen: Make MainMenu the 0th child of the TabContainer

### DIFF
--- a/scenes/menus/title/components/touchscreen_warning.gd
+++ b/scenes/menus/title/components/touchscreen_warning.gd
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MPL-2.0
 extends Control
 
+signal dismissed
+
 
 func _ready() -> void:
 	if _should_show_touchscreen_warning():
@@ -21,4 +23,4 @@ func _should_show_touchscreen_warning() -> bool:
 
 
 func _on_dismiss_button_pressed() -> void:
-	hide()
+	dismissed.emit()

--- a/scenes/menus/title/title_screen.tscn
+++ b/scenes/menus/title/title_screen.tscn
@@ -45,29 +45,30 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxEmpty_2ijyo")
-current_tab = 1
+current_tab = 0
 tabs_visible = false
-
-[node name="TouchscreenWarning" parent="Pages" unique_id=2046863085 instance=ExtResource("6_5uobg")]
-visible = false
-layout_mode = 2
 
 [node name="MainMenu" parent="Pages" unique_id=422406702 instance=ExtResource("5_0vy2n")]
 unique_name_in_owner = true
 layout_mode = 2
-metadata/_tab_index = 1
+metadata/_tab_index = 0
 
 [node name="Credits" parent="Pages" unique_id=999256361 instance=ExtResource("6_2ijyo")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-metadata/_tab_index = 2
+metadata/_tab_index = 1
 
 [node name="Options" parent="Pages" unique_id=1924255406 instance=ExtResource("8_5uobg")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 size_flags_vertical = 3
+metadata/_tab_index = 2
+
+[node name="TouchscreenWarning" parent="Pages" unique_id=2046863085 instance=ExtResource("6_5uobg")]
+visible = false
+layout_mode = 2
 metadata/_tab_index = 3
 
 [connection signal="continue_pressed" from="Pages/MainMenu" to="." method="_on_main_menu_continue_pressed"]
@@ -76,3 +77,4 @@ metadata/_tab_index = 3
 [connection signal="start_pressed" from="Pages/MainMenu" to="." method="_on_start_pressed"]
 [connection signal="back" from="Pages/Credits" to="." method="_on_credits_back"]
 [connection signal="back" from="Pages/Options" to="." method="_on_options_back"]
+[connection signal="dismissed" from="Pages/TouchscreenWarning" to="Pages/MainMenu" method="show"]


### PR DESCRIPTION
Previously, the new `TouchscreenWarning` node was the 0th child of the
`Pages` `TabContainer`, but `MainMenu` was set to be the visible tab
(i.e. `current_tab` was set to `1`, and `MainMenu` was made visible, which
are equivalent).

Unfortunately there is a bug in Godot itself where this property gets
reset to `0` in the exported project, so the touchscreen warning is
always shown on all devices.

https://github.com/godotengine/godot/issues/109291

Move the `TouchscreenWarning` node to be the last child of `Pages` so
that `MainMenu` is tab 0 and so is selected by default. The logic in
touchscreen_warning.gd will show `TouchscreenWarning` if necessary.

Then we need to change the "dismiss" logic, because `TabContainer`'s
behaviour when the visible tab hides itself is to show the adjacent tab:
this was correct when the only adjacent tab was `MainMenu` but is wrong
when the only adjacent tab is `Options`. Be more explicit: emit a
`dismissed` signal from the page when dismissed, and connect it to
`show()` on the MainMenu page.

Resolves https://github.com/endlessm/threadbare/issues/2358#issuecomment-4802280706

