### PR TITLE
Spawn in front of elder after abandoning a StoryQuest

### DIFF
--- a/scenes/game_elements/characters/npcs/elder/components/elder.gd
+++ b/scenes/game_elements/characters/npcs/elder/components/elder.gd
@@ -19,6 +19,14 @@ const STORYBOOK_SCENE := preload("uid://bhm7fdjvppt8b")
 		eternal_loom = new_value
 		update_configuration_warnings()
 
+## Spawn point to place the player at if they abandon a quest started from this
+## elder. Should typically be just in front of the elder so that it is easy to
+## interact with the elder again.
+@export var abandon_point: SpawnPoint:
+	set(new_value):
+		abandon_point = new_value
+		update_configuration_warnings()
+
 ## The quest chosen by the player from the storybook
 var chosen_quest: Quest
 
@@ -105,6 +113,13 @@ func _on_interaction_ended() -> void:
 	if chosen_quest:
 		interact_area.disabled = true
 		GameState.set_quest(chosen_quest)
+
+		var current_scene := get_tree().current_scene
+		GameState.quest.abandon_scene_path = current_scene.scene_file_path
+		GameState.quest.abandon_spawn_point = (
+			current_scene.get_path_to(abandon_point) if abandon_point else ^""
+		)
+
 		if restart and chosen_quest.resource_path in GameState.global.suspended_quests:
 			GameState.global.suspended_quests.erase(chosen_quest.resource_path)
 

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -433,13 +433,21 @@ y_sort_enabled = true
 position = Vector2(690, 592)
 eternal_loom = NodePath("../../EternalLoom")
 
-[node name="StoryQuestElder" parent="OnTheGround/NPCs" unique_id=481001643 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("20_jqkod")]
+[node name="StoryQuestElder" parent="OnTheGround/NPCs" unique_id=481001643 node_paths=PackedStringArray("eternal_loom", "abandon_point") instance=ExtResource("20_jqkod")]
 position = Vector2(1310, 590)
 eternal_loom = NodePath("../../EternalLoom")
+abandon_point = NodePath("SpawnPoint")
 
-[node name="TemplateElder" parent="OnTheGround/NPCs" unique_id=45322364 node_paths=PackedStringArray("eternal_loom") instance=ExtResource("43_ppslc")]
+[node name="SpawnPoint" parent="OnTheGround/NPCs/StoryQuestElder" unique_id=747361445 instance=ExtResource("37_thm8h")]
+position = Vector2(0, 64)
+
+[node name="TemplateElder" parent="OnTheGround/NPCs" unique_id=45322364 node_paths=PackedStringArray("eternal_loom", "abandon_point") instance=ExtResource("43_ppslc")]
 position = Vector2(1455, 485)
 eternal_loom = NodePath("../../EternalLoom")
+abandon_point = NodePath("SpawnPoint")
+
+[node name="SpawnPoint" parent="OnTheGround/NPCs/TemplateElder" unique_id=679077598 instance=ExtResource("37_thm8h")]
+position = Vector2(0, 64)
 
 [node name="Axeman" parent="OnTheGround/NPCs" unique_id=1020611644 instance=ExtResource("17_0a1i7")]
 position = Vector2(1506, 1255)


### PR DESCRIPTION
This is roughly the point where StoryWeaver must have been to have
interacted with the elder and start the quest in the first place, unlike
the area in front of the Loom which is the default spawn point after
abandoning otherwise.

It also means that if we move the elder to another scene, the abandon
point will move with them.

Resolves https://github.com/endlessm/threadbare/issues/2496
