### PR TITLE
SceneLink: Don't crash when inspected in running game

### DIFF
--- a/scenes/globals/scene_switcher/scene_link.gd
+++ b/scenes/globals/scene_switcher/scene_link.gd
@@ -133,10 +133,14 @@ func _validate_property(property: Dictionary) -> void:
 	match property.name:
 		"open_next_scene":
 			var next_scene_path: String = _get_next_scene_path()
-			if not next_scene_path:
-				property.usage |= PROPERTY_USAGE_READ_ONLY
-			elif (
-				is_inside_tree() and next_scene_path == get_tree().edited_scene_root.scene_file_path
+			var edited_scene_root: Node = get_tree().edited_scene_root
+			if (
+				not next_scene_path
+				or (
+					is_inside_tree()
+					and edited_scene_root
+					and next_scene_path == edited_scene_root.scene_file_path
+				)
 			):
 				property.usage |= PROPERTY_USAGE_READ_ONLY
 


### PR DESCRIPTION
Previously this code asumed get_tree().edited_scene_root would be
non-null in the case where SceneLink.next_scene is set and the node is
inside the tree.

This is not the case (at least) when running the game and inspecting a
SceneLink(-derived) node in the remote scene tree:
get_tree().edited_scene_root is documented to be blank outside the
editor.

Handle that case.
