### PR TITLE
renya: Set music as looping

### DIFF
--- a/scenes/quests/story_quests/renya_beyond_sorrow/Complementos/music/1. Echoes of Solitude (Loop).ogg.import
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/Complementos/music/1. Echoes of Solitude (Loop).ogg.import
@@ -12,8 +12,8 @@ dest_files=["res://.godot/imported/1. Echoes of Solitude (Loop).ogg-d70d3bf48f74
 
 [params]
 
-loop=false
-loop_offset=0
-bpm=0
+loop=true
+loop_offset=0.0
+bpm=75.0
 beat_count=0
 bar_beats=4

--- a/scenes/quests/story_quests/renya_beyond_sorrow/Complementos/music/2. Whispers of Yesterday (Loop).ogg.import
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/Complementos/music/2. Whispers of Yesterday (Loop).ogg.import
@@ -12,8 +12,8 @@ dest_files=["res://.godot/imported/2. Whispers of Yesterday (Loop).ogg-0f252a248
 
 [params]
 
-loop=false
-loop_offset=0
-bpm=0
+loop=true
+loop_offset=0.0
+bpm=90.0
 beat_count=0
 bar_beats=4

--- a/scenes/quests/story_quests/renya_beyond_sorrow/Complementos/music/4. Fading Memories (Loop).ogg.import
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/Complementos/music/4. Fading Memories (Loop).ogg.import
@@ -12,8 +12,8 @@ dest_files=["res://.godot/imported/4. Fading Memories (Loop).ogg-3645c51dcf166c0
 
 [params]
 
-loop=false
-loop_offset=0
-bpm=0
+loop=true
+loop_offset=0.0
+bpm=70.0
 beat_count=0
 bar_beats=4

--- a/scenes/quests/story_quests/renya_beyond_sorrow/Complementos/music/6. Embers of Hope (Loop).ogg.import
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/Complementos/music/6. Embers of Hope (Loop).ogg.import
@@ -12,8 +12,8 @@ dest_files=["res://.godot/imported/6. Embers of Hope (Loop).ogg-3c9959926493368f
 
 [params]
 
-loop=false
-loop_offset=0
-bpm=0
+loop=true
+loop_offset=0.0
+bpm=110.0
 beat_count=0
-bar_beats=4
+bar_beats=3

--- a/scenes/quests/story_quests/renya_beyond_sorrow/Complementos/music/7. Silent Longing (Loop).ogg.import
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/Complementos/music/7. Silent Longing (Loop).ogg.import
@@ -12,8 +12,8 @@ dest_files=["res://.godot/imported/7. Silent Longing (Loop).ogg-91dd04e9ce6aa4da
 
 [params]
 
-loop=false
-loop_offset=0
-bpm=0
+loop=true
+loop_offset=0.0
+bpm=140.0
 beat_count=0
-bar_beats=4
+bar_beats=3


### PR DESCRIPTION
All these tracks are designed to loop, but the loop flag was not set in
their import settings, so the music would simply stop at the end of the
track rather than looping.

Set the loop flag. While we're here, set the beats per bar and bpm (both
of which seem to be regular throughout each piece) in case someone wants
to do something fancy with them in future.
