### PR TITLE
Quest separator: Keep music playing

### DIFF
--- a/scenes/menus/quest_separator/components/keep_that_groove_going.gd
+++ b/scenes/menus/quest_separator/components/keep_that_groove_going.gd
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Node
+
+
+func _ready() -> void:
+	var bgm := get_parent() as BackgroundMusic
+	bgm.stream = MusicPlayer.background_music_player.stream

--- a/scenes/menus/quest_separator/components/keep_that_groove_going.gd.uid
+++ b/scenes/menus/quest_separator/components/keep_that_groove_going.gd.uid
@@ -1,0 +1,1 @@
+uid://bgffgm5flql38

--- a/scenes/menus/quest_separator/quest_separator.tscn
+++ b/scenes/menus/quest_separator/quest_separator.tscn
@@ -7,6 +7,8 @@
 [ext_resource type="Shortcut" uid="uid://c5pwgp1w8p3y1" path="res://scenes/ui_elements/shortcuts/back_shortcut.tres" id="5_wq0a1"]
 [ext_resource type="Script" uid="uid://b78blxbleps14" path="res://scenes/menus/quest_separator/components/timer_progress_bar.gd" id="6_amr4g"]
 [ext_resource type="Texture2D" uid="uid://dcwmaoqgu5t84" path="res://scenes/globals/scene_switcher/transitions/Radial.png" id="6_wq0a1"]
+[ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="8_mwkko"]
+[ext_resource type="Script" uid="uid://bgffgm5flql38" path="res://scenes/menus/quest_separator/components/keep_that_groove_going.gd" id="9_1wjdo"]
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_l1xe8"]
 animations = [{
@@ -155,3 +157,10 @@ unique_name_in_owner = true
 wait_time = 5.0
 one_shot = true
 autostart = true
+
+[node name="BackgroundMusic" type="Node" parent="." unique_id=1865452952]
+script = ExtResource("8_mwkko")
+metadata/_custom_type_script = "uid://c8405c212rbn6"
+
+[node name="KeepThatGrooveGoing" type="Node" parent="BackgroundMusic" unique_id=869865385]
+script = ExtResource("9_1wjdo")


### PR DESCRIPTION
Quest separator: Keep music playing

Previously the separator screen was silent. I don't like silence!

Add a `BackgroundMusic` node with no `stream` configured. In a child
node, copy the currently-playing AudioStream (which may be `null`) to
its `stream`. In practice this means that the bed from Fray's End keeps
playing uninterrupted until the quest begins. For now it would be
simpler to set the same music manually in the separator. But you could
imagine in future having different background music for different parts
of the world; this way whatever music happens to be playing will
continue playing.
