### PR TITLE
Stealth/sequence combo: Save puzzle progress

### DIFF
--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -69,7 +69,6 @@ func _ready() -> void:
 
 	_set_item(item)
 	_update_based_on_revealed()
-	sprite_2d.modulate = Color.WHITE if revealed else Color.TRANSPARENT
 
 	if Engine.is_editor_hint():
 		return
@@ -115,5 +114,8 @@ func _update_based_on_revealed() -> void:
 		interact_area.disabled = not revealed
 	if sprite_2d:
 		sprite_2d.visible = revealed
+		# If we are playing the reveal animation, this will be set back to
+		# TRANSPARENT immediately then tweened to white.
+		sprite_2d.modulate = Color.WHITE if revealed else Color.TRANSPARENT
 	if physical_collider:
 		physical_collider.disabled = not revealed

--- a/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.gd
+++ b/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.gd
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Node
+
+const FACT_NAME := "combo_puzzle_progress"
+
+@onready var sequence_puzzle: SequencePuzzle = %SequencePuzzle
+@onready var collectible_item: CollectibleItem = %CollectibleItem
+
+
+func _ready() -> void:
+	if FACT_NAME in GameState.quest.facts:
+		sequence_puzzle.set_progress(GameState.quest.facts[FACT_NAME])
+
+	if sequence_puzzle.is_solved():
+		collectible_item.revealed = true
+
+	sequence_puzzle.step_solved.connect(_on_sequence_puzzle_step_solved)
+	sequence_puzzle.solved.connect(_on_sequence_puzzle_solved)
+
+
+func _on_sequence_puzzle_step_solved(step_index: int) -> void:
+	GameState.quest.facts[FACT_NAME] = step_index
+
+
+func _on_sequence_puzzle_solved() -> void:
+	collectible_item.reveal()

--- a/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.gd.uid
+++ b/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.gd.uid
@@ -1,0 +1,1 @@
+uid://dly53ymp3a6hv

--- a/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.tscn
+++ b/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://dnp0tjloec2d7" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_gqxgg"]
 [ext_resource type="TileSet" uid="uid://oynx002hv8tl" path="res://tiles/water.tres" id="1_stmf1"]
+[ext_resource type="Script" uid="uid://dly53ymp3a6hv" path="res://scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.gd" id="1_w6fk3"]
 [ext_resource type="TileSet" uid="uid://bjx3gvah0ycl1" path="res://tiles/foam_2.tres" id="2_stmf1"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="3_82mjw"]
 [ext_resource type="TileSet" uid="uid://do0ffypatd77h" path="res://tiles/bridges.tres" id="3_f4ekw"]
@@ -49,6 +50,7 @@ metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="StealthSequenceCombo" type="Node2D" unique_id=1761996320]
 y_sort_enabled = true
+script = ExtResource("1_w6fk3")
 
 [node name="TileMapLayers" type="Node2D" parent="." unique_id=1025468685]
 y_sort_enabled = true
@@ -83,6 +85,7 @@ tile_set = ExtResource("3_f4ekw")
 script = ExtResource("1_gqxgg")
 
 [node name="SequencePuzzle" type="Node2D" parent="." unique_id=1138211408]
+unique_name_in_owner = true
 y_sort_enabled = true
 script = ExtResource("14_qhjva")
 metadata/_custom_type_script = "uid://c68oh8dtr21ti"
@@ -204,6 +207,7 @@ position = Vector2(208, 2340)
 curve = SubResource("Curve2D_qhjva")
 
 [node name="CollectibleItem" parent="OnTheGround" unique_id=1864211007 instance=ExtResource("8_u3d8g")]
+unique_name_in_owner = true
 position = Vector2(2429, 1936)
 revealed = false
 item = SubResource("Resource_idy4y")
@@ -253,5 +257,3 @@ color = Color(0.481789, 0.48179, 0.481789, 1)
 [node name="HUD" parent="." unique_id=1968200192 instance=ExtResource("7_axovk")]
 
 [node name="ScreenOverlay" type="CanvasLayer" parent="." unique_id=1806885507]
-
-[connection signal="solved" from="SequencePuzzle" to="OnTheGround/CollectibleItem" method="reveal"]


### PR DESCRIPTION
This is similar code to music_puzzle but with a few tweaks to handle
revealing the collectible. This is necessary because the `solved` signal
is not emitted when the puzzle's progress is changed in code rather than
through player interaction.

I think this makes the level fairer because you no longer have to
repeatedly solve the early steps before you can make another attempt at
the more difficult third step, or (worse!) solve all three steps again
if you are caught while running towards the exit!
