### PR TITLE
SceneLink: Don't call get_tree() if not in tree

### DIFF
--- a/scenes/globals/scene_switcher/scene_link.gd
+++ b/scenes/globals/scene_switcher/scene_link.gd
@@ -133,14 +133,10 @@ func _validate_property(property: Dictionary) -> void:
 	match property.name:
 		"open_next_scene":
 			var next_scene_path: String = _get_next_scene_path()
-			var edited_scene_root: Node = get_tree().edited_scene_root
+			var edited_scene_root := get_tree().edited_scene_root if is_inside_tree() else null
 			if (
 				not next_scene_path
-				or (
-					is_inside_tree()
-					and edited_scene_root
-					and next_scene_path == edited_scene_root.scene_file_path
-				)
+				or (edited_scene_root and next_scene_path == edited_scene_root.scene_file_path)
 			):
 				property.usage |= PROPERTY_USAGE_READ_ONLY
 


### PR DESCRIPTION
SceneLink: Don't call get_tree() if not in tree

commit 72b6e1ae4c153b08b7e9f0610371a9cf80826241 introduced a regression
that would show this error when (I think!) opening the editor with more
than one scene open, so that a scene that is not the active tab is
loaded:

    ERROR: scene/main/node.h:559 - Parameter "data.tree" is null.
    ERROR: res://scenes/globals/scene_switcher/scene_link.gd:136 -
        Invalid access to property or key 'edited_scene_root' on a base
        object of type 'null instance'.

This is because calling `get_tree()` is an error if `is_inside_tree()`
is `false`, but in that commit I moved the `get_tree()` call to before
the `is_inside_tree()` check.

(Arguably the complexity here is not worth the payoff of "the button is
insensitive when the link is to the same scene the node is in".)
