### PR TITLE
NO_EDIT: Add BackgroundMusic nodes

### DIFF
--- a/scenes/quests/template_quests/NO_EDIT/0_NO_EDIT_intro/NO_EDIT_intro.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/0_NO_EDIT_intro/NO_EDIT_intro.tscn
@@ -6,6 +6,8 @@
 [ext_resource type="Resource" uid="uid://cqjngitoc5yx7" path="res://scenes/quests/template_quests/NO_EDIT/0_NO_EDIT_intro/NO_EDIT_intro_components/NO_EDIT_intro.dialogue" id="2_jlqtq"]
 [ext_resource type="SpriteFrames" uid="uid://vwf8e1v8brdp" path="res://scenes/quests/template_quests/NO_EDIT/NO_EDIT_player_components/NO_EDIT_player.tres" id="3_bol4n"]
 [ext_resource type="PackedScene" uid="uid://v3usqiwy5wpr" path="res://scenes/game_elements/props/decoration/rock/rock.tscn" id="6_f3ghw"]
+[ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="7_pmwiv"]
+[ext_resource type="AudioStream" uid="uid://ofn2fhr2a2n8" path="res://assets/first_party/music/Threadbare Loop_Main_Intro_01.ogg" id="8_ilacg"]
 
 [sub_resource type="Animation" id="Animation_ld06i"]
 length = 0.001
@@ -148,3 +150,8 @@ metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=49807179]
 libraries/ = SubResource("AnimationLibrary_qdpvj")
+
+[node name="BackgroundMusic" type="Node" parent="." unique_id=691091775]
+script = ExtResource("7_pmwiv")
+stream = ExtResource("8_ilacg")
+metadata/_custom_type_script = "uid://c8405c212rbn6"

--- a/scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth.tscn
@@ -14,6 +14,8 @@
 [ext_resource type="Resource" uid="uid://dpv4wurvaamhb" path="res://scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth_components/NO_EDIT_collected.dialogue" id="11_f7iof"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="12_bs0vj"]
 [ext_resource type="Resource" uid="uid://cggywn8t6s4le" path="res://scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth_components/NO_EDIT_stealth.dialogue" id="13_y0fxw"]
+[ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="15_axd4p"]
+[ext_resource type="AudioStream" uid="uid://dk10o5q87xbct" path="res://assets/first_party/music/Threadbare Loop_Main_Bridge_01.ogg" id="16_1foft"]
 
 [sub_resource type="Curve2D" id="Curve2D_vnsq3"]
 _data = {
@@ -124,3 +126,8 @@ next_scene = "uid://thwcu5akkqp5"
 script = ExtResource("12_bs0vj")
 dialogue = ExtResource("13_y0fxw")
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
+
+[node name="BackgroundMusic" type="Node" parent="." unique_id=213555345]
+script = ExtResource("15_axd4p")
+stream = ExtResource("16_1foft")
+metadata/_custom_type_script = "uid://c8405c212rbn6"

--- a/scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat.tscn
@@ -15,6 +15,8 @@
 [ext_resource type="PackedScene" uid="uid://y8ha8abfyap2" path="res://scenes/game_elements/props/filling_barrel/filling_barrel.tscn" id="12_2eyq6"]
 [ext_resource type="PackedScene" uid="uid://dmevaymmt6wco" path="res://scenes/game_elements/props/powerup/powerup.tscn" id="14_6xf5p"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="14_ttfgd"]
+[ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="16_t2kes"]
+[ext_resource type="AudioStream" uid="uid://df7ldbesilfry" path="res://assets/first_party/music/Threadbare Loop_Main_Bridge_02.ogg" id="17_84odo"]
 
 [sub_resource type="Resource" id="Resource_a51xm"]
 script = ExtResource("11_4lmqk")
@@ -121,6 +123,11 @@ limit_right = 960
 limit_bottom = 640
 position_smoothing_enabled = true
 editor_draw_limits = true
+
+[node name="BackgroundMusic" type="Node" parent="." unique_id=596208504]
+script = ExtResource("16_t2kes")
+stream = ExtResource("17_84odo")
+metadata/_custom_type_script = "uid://c8405c212rbn6"
 
 [connection signal="cinematic_finished" from="Cinematic" to="FillGameLogic" method="start"]
 [connection signal="goal_reached" from="FillGameLogic" to="OnTheGround/CollectibleItem" method="reveal"]

--- a/scenes/quests/template_quests/NO_EDIT/3_NO_EDIT_sequence_puzzle/NO_EDIT_sequence_puzzle.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/3_NO_EDIT_sequence_puzzle/NO_EDIT_sequence_puzzle.tscn
@@ -22,6 +22,7 @@
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="17_757eh"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="18_fip7f"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="19_7si2r"]
+[ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="23_42ab1"]
 
 [sub_resource type="Resource" id="Resource_u8qfb"]
 script = ExtResource("15_5fyey")
@@ -145,5 +146,9 @@ text = "First melody: yellow, green, blue."
 script = ExtResource("19_7si2r")
 dialogue = ExtResource("16_bt1lb")
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
+
+[node name="BackgroundMusic" type="Node" parent="." unique_id=2097088263]
+script = ExtResource("23_42ab1")
+metadata/_custom_type_script = "uid://c8405c212rbn6"
 
 [connection signal="solved" from="OnTheGround/SequencePuzzle" to="OnTheGround/CollectibleItem" method="reveal"]

--- a/scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro.tscn
@@ -9,6 +9,8 @@
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="7_skqne"]
 [ext_resource type="SpriteFrames" uid="uid://2ek86nvw6y28" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_yellow.tres" id="8_srdr1"]
 [ext_resource type="SpriteFrames" uid="uid://d36eq8tqdaxdy" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_green.tres" id="9_skqne"]
+[ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="10_oqtmv"]
+[ext_resource type="AudioStream" uid="uid://dw8t48jn57bp" path="res://assets/first_party/music/Threadbare Loop_Main_Cresendo_01.ogg" id="11_3p7xq"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_0e5tb"]
 size = Vector2(1205, 431)
@@ -436,3 +438,8 @@ sprite_frames = ExtResource("8_srdr1")
 [node name="Tree87" parent="Forest" unique_id=2091134076 instance=ExtResource("7_skqne")]
 position = Vector2(985.18787, 284.2967)
 scale = Vector2(1.0405519, 1.1536475)
+
+[node name="BackgroundMusic" type="Node" parent="." unique_id=350570253]
+script = ExtResource("10_oqtmv")
+stream = ExtResource("11_3p7xq")
+metadata/_custom_type_script = "uid://c8405c212rbn6"


### PR DESCRIPTION
NO_EDIT: Add BackgroundMusic nodes

This will help guide learners to use these rather than hand-configured
AudioStreamPlayer nodes (which don't cross-fade between scenes and tend
not to be assigned to the correct bus).

I picked different clips of the main title theme as placeholder music
for each. For the sequence puzzle I left the stream unset.

Resolves https://github.com/endlessm/threadbare/issues/2136
