### PR TITLE
Move SPAWN_POINT_GROUP_NAME constant to SpawnPoint

### DIFF
--- a/scenes/game_elements/props/spawn_point/components/spawn_point.gd
+++ b/scenes/game_elements/props/spawn_point/components/spawn_point.gd
@@ -10,11 +10,13 @@ extends Marker2D
 ## which SpawnPoint was used (or if no SpawnPoint at all was used).
 signal player_teleported
 
+const GROUP_NAME := "spawn_point"
+
 @export var look_at_side_on_spawn: Enums.LookAtSide = Enums.LookAtSide.UNSPECIFIED
 
 
 func _init() -> void:
-	add_to_group("spawn_point", true)
+	add_to_group(GROUP_NAME, true)
 
 
 func _ready() -> void:

--- a/scenes/globals/scene_switcher/scene_link.gd
+++ b/scenes/globals/scene_switcher/scene_link.gd
@@ -8,8 +8,6 @@ extends Node2D
 ## This can be used directly, but acts primarily a base class for other
 ## components: [Cinematic], [CollectibleItem], and the Teleporter scene.
 
-const SPAWN_POINT_GROUP_NAME: String = "spawn_point"
-
 ## Scene to switch to when the player enters this teleport. If empty, the player
 ## will teleport within the current scene, to the position specified by [member
 ## spawn_point_path].
@@ -103,7 +101,7 @@ func _update_available_spawn_points() -> void:
 
 	var next_scene_path: String = _get_next_scene_path()
 	if not next_scene_path or next_scene_path == get_tree().edited_scene_root.scene_file_path:
-		var spawn_points := get_tree().get_nodes_in_group("spawn_point")
+		var spawn_points := get_tree().get_nodes_in_group(SpawnPoint.GROUP_NAME)
 		_available_spawn_points.assign(
 			spawn_points.map(func(spawn_point: Node) -> String: return get_path_to(spawn_point))
 		)
@@ -118,7 +116,7 @@ func _update_available_spawn_points() -> void:
 			var instance := scene_state.get_node_instance(i)
 			if instance:
 				node_groups.append_array(instance.get_state().get_node_groups(0))
-			if SPAWN_POINT_GROUP_NAME in node_groups:
+			if SpawnPoint.GROUP_NAME in node_groups:
 				var node_path_as_string := String(path)
 
 				paths.push_back(NodePath(node_path_as_string.replace("./", "")))


### PR DESCRIPTION
Previously `scene_link.gd` defined a `const SPAWN_POINT_GROUP_NAME`, but
it did not use it consistently, and `spawn_point.gd` also hardcoded the
group name.

Move the `const` to `spawn_point.gd` and use it consistently in code.
