### PR TITLE
Restore boss health to desired value

### DIFF
--- a/scenes/quests/story_quests/after_the_tremor/3_combat/after_the_tremor_combat.tscn
+++ b/scenes/quests/story_quests/after_the_tremor/3_combat/after_the_tremor_combat.tscn
@@ -497,6 +497,7 @@ monitorable = false
 [node name="BossHealth" parent="." unique_id=1226340713 instance=ExtResource("8_tmljt")]
 position = Vector2(716, 392)
 script = ExtResource("18_fq20r")
+needed_amount = 50
 
 [node name="HitBox" parent="BossHealth" index="2" unique_id=1847617565]
 position = Vector2(-2, 54)


### PR DESCRIPTION
The boss in the combat scene should have 50 health. I reverted to 3 for testing purposes and never restored it.

Reverting an accidental change made in #2464 