### PR TITLE
CollectibleItem: Don't flash thread for 1 frame while revealing

### DIFF
--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -76,12 +76,22 @@ func _ready() -> void:
 	interact_area.interaction_started.connect(self._on_interacted)
 
 
-## Make the collectible appear
+## Make the collectible appear with an animation, ultimately setting [member revealed].
+##
+## This does nothing if [member revealed] is [code]true[/code], or if the collectible is already
+## being revealed.
+##
+## To reveal the collectible immediately without any animation or sound, set [member revealed]
+## directly.
 func reveal() -> void:
-	revealed = true
+	if revealed or animation_player.current_animation == &"reveal":
+		return
+
 	appear_sound.play()
 	animation_player.play("reveal")
 	await animation_player.animation_finished
+
+	revealed = true
 
 
 ## When interacted with, the collectible will display a brief animation
@@ -114,8 +124,6 @@ func _update_based_on_revealed() -> void:
 		interact_area.disabled = not revealed
 	if sprite_2d:
 		sprite_2d.visible = revealed
-		# If we are playing the reveal animation, this will be set back to
-		# TRANSPARENT immediately then tweened to white.
 		sprite_2d.modulate = Color.WHITE if revealed else Color.TRANSPARENT
 	if physical_collider:
 		physical_collider.disabled = not revealed


### PR DESCRIPTION

Commit cf47b8a90fcb274e0def1c03060fbaf9b2c76b98 caused a regression
where calling `reveal()` would sometimes show the fully-opaque thread
for 1 frame before fading in from transparent. This depended
on what stage of the mainloop `reveal()` was called from: calling it
from an `_input` callback worked correctly, but calling it from a
`Timer.timeout` signal handler did not.

Move the assigment `revealed = true` to after the animation is complete.
The animation already sets `visible` on the `Sprite2D` to `true`; and
it's fine for the thread to be non-interactive and non-collidable for
the 0.5s duration of the reveal animation.

Document `reveal()` and make it a no-op in the case where the thread is
already revealed or is being revealed.

Resolves https://github.com/endlessm/threadbare/issues/2517

