### PR TITLE
GameState: Set scene when not persisting progress

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -82,6 +82,7 @@ func _ready() -> void:
 	if not persist_progress:
 		if current_scene:
 			guess_quest(current_scene.scene_file_path)
+			set_scene(current_scene.scene_file_path)
 		# Grant all debug player abilities:
 		for ability: Enums.PlayerAbilities in DEBUG_PLAYER_ABILITIES:
 			player.set_ability(ability, true)


### PR DESCRIPTION
When progress is not persisted, that is when the game runs from a specific scene that is not the main one, GameState.scene should be set to a new PerSceneState resource. Otherwise the game may fail to access its properties like lights_on.

Fix https://github.com/endlessm/threadbare/issues/2543