### PR TITLE
ThreadbareProjectSettings: Fix hint_string misuse

### DIFF
--- a/addons/threadbare_project_settings/threadbare_project_settings.gd
+++ b/addons/threadbare_project_settings/threadbare_project_settings.gd
@@ -4,7 +4,10 @@
 class_name ThreadbareProjectSettings
 extends Node
 
+## Display a letterbox overlay in the game, to debug aspect ratio
 const DEBUG_ASPECT_RATIO = "threadbare/debugging/debug_aspect_ratio"
+
+## Skip the splash screen and title menu, and resume the game state. Like when clicking Continue.
 const SKIP_SPLASH = "threadbare/debugging/skip_splash"
 
 static var settings_configuration = {
@@ -12,14 +15,11 @@ static var settings_configuration = {
 	{
 		value = false,
 		type = TYPE_BOOL,
-		hint_string = "Display a letterbox overlay in the game, to debug aspect ratio issues.",
 	},
 	SKIP_SPLASH:
 	{
 		value = false,
 		type = TYPE_BOOL,
-		hint_string =
-		"Skip the splash screen and title menu, and resume the game state. Like when clicking Continue.",
 	},
 }
 
@@ -40,5 +40,5 @@ static func setup_threadbare_settings() -> void:
 				"hint_string": setting_config.get("hint_string", "")
 			}
 		)
-		ProjectSettings.set_as_basic(setting_name, not setting_config.has("is_advanced"))
-		ProjectSettings.set_as_internal(setting_name, setting_config.has("is_hidden"))
+		ProjectSettings.set_as_basic(setting_name, not setting_config.get("is_advanced", false))
+		ProjectSettings.set_as_internal(setting_name, setting_config.get("is_hidden", false))


### PR DESCRIPTION
This is not a docstring for the custom setting. It's like custom object
properties: a string property with PROPERTY_HINT_FILE expects a
hint_string with a wildcard pattern for the accepted file types (e.g.
`"*.tscn"`).

Move the documentation for these two boolean settings to the `const`s
for the setting names. This still does not show in the Project Settings
window. As best I can tell, it is not possible to add docstrings there,
at least not from GDScript.

Also improve how the "is_advanced" and "is_hidden" keys in the
dictionary are used. I would expect `is_hidden = false` to cause the
property not to be hidden, but previously it would make it hidden.
