### PR TITLE
Sokoban: Use SceneLink

### DIFF
--- a/scenes/eternal_loom_sokoban/components/system/rules/rule_engine.gd
+++ b/scenes/eternal_loom_sokoban/components/system/rules/rule_engine.gd
@@ -25,9 +25,6 @@ const RULE_REPEAT_LIMIT := 99
 ## Every tag being used by pieces need to be set here to be recognized as tags.
 @export var tags_legend: Array[StringName] = ["controllable"]
 
-## When all goals are met, the RuleEngine will attempt to load this scene next.
-@export_file("*.tscn") var next_scene: String
-
 ## Offer skipping to the next scene after this amount of seconds.
 @export var seconds_to_offer_skip: int = 120
 
@@ -97,9 +94,8 @@ func _reset() -> void:
 
 
 func _skip() -> void:
-	if not next_scene:
-		return
-	SceneSwitcher.change_to_file_with_transition(next_scene)
+	goals_reached.emit()
+	directional_input.enabled = false
 
 
 func _setup_first_state() -> void:
@@ -179,8 +175,6 @@ func _check_goal() -> void:
 	if result:
 		goals_reached.emit()
 		directional_input.enabled = false
-		if next_scene:
-			SceneSwitcher.change_to_file_with_transition(next_scene)
 
 
 func piece_can_move(piece: Piece2D, checked_pieces: Array[Piece2D]) -> bool:

--- a/scenes/eternal_loom_sokoban/levels/eternal_loom_template.tscn
+++ b/scenes/eternal_loom_sokoban/levels/eternal_loom_template.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="TileSet" uid="uid://dand23uvn70pg" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_tileset.tres" id="5_mdri7"]
 [ext_resource type="PackedScene" uid="uid://btpeaqx2nur3q" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_ruleset.tscn" id="6_yoiiu"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="8_5hoht"]
+[ext_resource type="Script" uid="uid://d2vp62mjrf6gn" path="res://scenes/globals/scene_switcher/scene_link.gd" id="9_5hoht"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="9_mdri7"]
 
 [node name="SokobanLevel1a" type="Node2D" unique_id=649017959]
@@ -57,7 +58,15 @@ tile_set = ExtResource("5_mdri7")
 
 [node name="EternalLoomRuleset" parent="." unique_id=1264941114 node_paths=PackedStringArray("board") instance=ExtResource("6_yoiiu")]
 board = NodePath("../Board2D")
-next_scene = "uid://c80o1bys5radq"
 
 [node name="BackgroundMusic" parent="." unique_id=1277927076 instance=ExtResource("8_5hoht")]
 stream = ExtResource("9_mdri7")
+
+[node name="SceneLink" type="Node2D" parent="." unique_id=1011300014]
+script = ExtResource("9_5hoht")
+next_scene = "uid://c80o1bys5radq"
+enter_transition = 1
+exit_transition = 1
+metadata/_custom_type_script = "uid://d2vp62mjrf6gn"
+
+[connection signal="goals_reached" from="EternalLoomRuleset" to="SceneLink" method="switch"]

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_1a.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_1a.tscn
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://btpeaqx2nur3q" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_ruleset.tscn" id="6_o38wy"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="8_pa2s2"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="9_jabbo"]
+[ext_resource type="Script" uid="uid://d2vp62mjrf6gn" path="res://scenes/globals/scene_switcher/scene_link.gd" id="9_pa2s2"]
 
 [node name="SokobanLevel1a" type="Node2D" unique_id=590285511]
 
@@ -55,7 +56,15 @@ tile_set = ExtResource("4_6ydvs")
 
 [node name="RuleEngine" parent="." unique_id=2131725369 node_paths=PackedStringArray("board") instance=ExtResource("6_o38wy")]
 board = NodePath("../Board2D")
-next_scene = "uid://c80o1bys5radq"
 
 [node name="BackgroundMusic" parent="." unique_id=575752160 instance=ExtResource("8_pa2s2")]
 stream = ExtResource("9_jabbo")
+
+[node name="SceneLink" type="Node2D" parent="." unique_id=1402402838]
+script = ExtResource("9_pa2s2")
+next_scene = "uid://c80o1bys5radq"
+enter_transition = 1
+exit_transition = 1
+metadata/_custom_type_script = "uid://d2vp62mjrf6gn"
+
+[connection signal="goals_reached" from="RuleEngine" to="SceneLink" method="switch"]

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_1b.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_1b.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Script" uid="uid://dppvw2f8yh4vu" path="res://scenes/eternal_loom_sokoban/components/system/board/board_2d.gd" id="5_644u0"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="6_1cxqe"]
 [ext_resource type="TileSet" uid="uid://dand23uvn70pg" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_tileset.tres" id="6_fr34n"]
+[ext_resource type="Script" uid="uid://d2vp62mjrf6gn" path="res://scenes/globals/scene_switcher/scene_link.gd" id="7_1cxqe"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="7_aqnm5"]
 
 [node name="SokobanLevel1b" type="Node2D" unique_id=1725715521]
@@ -49,7 +50,15 @@ tile_set = ExtResource("6_fr34n")
 
 [node name="RuleEngine" parent="." unique_id=1676328937 node_paths=PackedStringArray("board") instance=ExtResource("4_pdh5l")]
 board = NodePath("../Board2D")
-next_scene = "uid://cpv57hirgmyml"
 
 [node name="BackgroundMusic" parent="." unique_id=162178963 instance=ExtResource("6_1cxqe")]
 stream = ExtResource("7_aqnm5")
+
+[node name="SceneLink" type="Node2D" parent="." unique_id=1319966462]
+script = ExtResource("7_1cxqe")
+next_scene = "uid://cpv57hirgmyml"
+enter_transition = 1
+exit_transition = 1
+metadata/_custom_type_script = "uid://d2vp62mjrf6gn"
+
+[connection signal="goals_reached" from="RuleEngine" to="SceneLink" method="switch"]

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_1c.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_1c.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="TileSet" uid="uid://dand23uvn70pg" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_tileset.tres" id="6_bgod2"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="6_x585a"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="7_6gt1w"]
+[ext_resource type="Script" uid="uid://d2vp62mjrf6gn" path="res://scenes/globals/scene_switcher/scene_link.gd" id="7_x585a"]
 
 [node name="SokobanLevel1c" type="Node2D" unique_id=1148681911]
 
@@ -48,7 +49,15 @@ tile_set = ExtResource("6_bgod2")
 
 [node name="RuleEngine" parent="." unique_id=58907825 node_paths=PackedStringArray("board") instance=ExtResource("4_m55nv")]
 board = NodePath("../Board2D")
-next_scene = "uid://cufkthb25mpxy"
 
 [node name="BackgroundMusic" parent="." unique_id=690723734 instance=ExtResource("6_x585a")]
 stream = ExtResource("7_6gt1w")
+
+[node name="SceneLink" type="Node2D" parent="." unique_id=132922410]
+script = ExtResource("7_x585a")
+next_scene = "uid://cufkthb25mpxy"
+enter_transition = 1
+exit_transition = 3
+metadata/_custom_type_script = "uid://d2vp62mjrf6gn"
+
+[connection signal="goals_reached" from="RuleEngine" to="SceneLink" method="switch"]

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_2a.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_2a.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="TileSet" uid="uid://dand23uvn70pg" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_tileset.tres" id="6_fr34n"]
 [ext_resource type="PackedScene" uid="uid://btpeaqx2nur3q" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_ruleset.tscn" id="6_skgk4"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="8_2i86o"]
+[ext_resource type="Script" uid="uid://d2vp62mjrf6gn" path="res://scenes/globals/scene_switcher/scene_link.gd" id="9_2i86o"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="9_fxqqq"]
 
 [node name="SokobanLevel2a" type="Node2D" unique_id=574208078]
@@ -56,7 +57,15 @@ tile_set = ExtResource("6_fr34n")
 
 [node name="RuleEngine" parent="." unique_id=178462056 node_paths=PackedStringArray("board") instance=ExtResource("6_skgk4")]
 board = NodePath("../Board2D")
-next_scene = "uid://c6qwiy01e6jqd"
 
 [node name="BackgroundMusic" parent="." unique_id=327397104 instance=ExtResource("8_2i86o")]
 stream = ExtResource("9_fxqqq")
+
+[node name="SceneLink" type="Node2D" parent="." unique_id=43524158]
+script = ExtResource("9_2i86o")
+next_scene = "uid://c6qwiy01e6jqd"
+enter_transition = 1
+exit_transition = 1
+metadata/_custom_type_script = "uid://d2vp62mjrf6gn"
+
+[connection signal="goals_reached" from="RuleEngine" to="SceneLink" method="switch"]

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_2b.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_2b.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="TileSet" uid="uid://dand23uvn70pg" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_tileset.tres" id="2_p3sau"]
 [ext_resource type="PackedScene" uid="uid://btpeaqx2nur3q" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_ruleset.tscn" id="4_vc6vr"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="6_2kj74"]
+[ext_resource type="Script" uid="uid://d2vp62mjrf6gn" path="res://scenes/globals/scene_switcher/scene_link.gd" id="7_2kj74"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="7_ymlnt"]
 
 [node name="SokobanLevel2b" type="Node2D" unique_id=1366105123]
@@ -50,7 +51,15 @@ tile_set = ExtResource("2_p3sau")
 
 [node name="RuleEngine" parent="." unique_id=274230753 node_paths=PackedStringArray("board") instance=ExtResource("4_vc6vr")]
 board = NodePath("../Board2D")
-next_scene = "uid://ckfj7qm1jgr5a"
 
 [node name="BackgroundMusic" parent="." unique_id=1157040573 instance=ExtResource("6_2kj74")]
 stream = ExtResource("7_ymlnt")
+
+[node name="SceneLink" type="Node2D" parent="." unique_id=1134124891]
+script = ExtResource("7_2kj74")
+next_scene = "uid://ckfj7qm1jgr5a"
+enter_transition = 1
+exit_transition = 1
+metadata/_custom_type_script = "uid://d2vp62mjrf6gn"
+
+[connection signal="goals_reached" from="RuleEngine" to="SceneLink" method="switch"]

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_2c.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_2c.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://btpeaqx2nur3q" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_ruleset.tscn" id="4_cjklm"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="6_x2dnf"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="7_pxo7o"]
+[ext_resource type="Script" uid="uid://d2vp62mjrf6gn" path="res://scenes/globals/scene_switcher/scene_link.gd" id="7_x2dnf"]
 
 [node name="SokobanLevel2c" type="Node2D" unique_id=2076196464]
 
@@ -51,7 +52,15 @@ tile_set = ExtResource("2_7drnn")
 
 [node name="RuleEngine" parent="." unique_id=1233393235 node_paths=PackedStringArray("board") instance=ExtResource("4_cjklm")]
 board = NodePath("../Board2D")
-next_scene = "uid://cufkthb25mpxy"
 
 [node name="BackgroundMusic" parent="." unique_id=835603079 instance=ExtResource("6_x2dnf")]
 stream = ExtResource("7_pxo7o")
+
+[node name="SceneLink" type="Node2D" parent="." unique_id=606561375]
+script = ExtResource("7_x2dnf")
+next_scene = "uid://cufkthb25mpxy"
+enter_transition = 1
+exit_transition = 3
+metadata/_custom_type_script = "uid://d2vp62mjrf6gn"
+
+[connection signal="goals_reached" from="RuleEngine" to="SceneLink" method="switch"]

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_3a.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_3a.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="TileSet" uid="uid://dand23uvn70pg" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_tileset.tres" id="6_nr7ak"]
 [ext_resource type="PackedScene" uid="uid://btpeaqx2nur3q" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_ruleset.tscn" id="7_qga2c"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="8_20ol2"]
+[ext_resource type="Script" uid="uid://d2vp62mjrf6gn" path="res://scenes/globals/scene_switcher/scene_link.gd" id="9_20ol2"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="9_wwulk"]
 
 [node name="SokobanLevel3a" type="Node2D" unique_id=557135403]
@@ -55,7 +56,15 @@ tile_set = ExtResource("6_nr7ak")
 
 [node name="RuleEngine" parent="." unique_id=865867186 node_paths=PackedStringArray("board") instance=ExtResource("7_qga2c")]
 board = NodePath("../Board2D")
-next_scene = "uid://ughhyyuc83kk"
 
 [node name="BackgroundMusic" parent="." unique_id=350956816 instance=ExtResource("8_20ol2")]
 stream = ExtResource("9_wwulk")
+
+[node name="SceneLink" type="Node2D" parent="." unique_id=1810414418]
+script = ExtResource("9_20ol2")
+next_scene = "uid://ughhyyuc83kk"
+enter_transition = 1
+exit_transition = 1
+metadata/_custom_type_script = "uid://d2vp62mjrf6gn"
+
+[connection signal="goals_reached" from="RuleEngine" to="SceneLink" method="switch"]

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_3b.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_3b.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="TileSet" uid="uid://dand23uvn70pg" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_tileset.tres" id="6_fj6du"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="6_nx7po"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="7_ir0b6"]
+[ext_resource type="Script" uid="uid://d2vp62mjrf6gn" path="res://scenes/globals/scene_switcher/scene_link.gd" id="7_nx7po"]
 
 [node name="SokobanLevel3b" type="Node2D" unique_id=662374739]
 
@@ -48,7 +49,15 @@ tile_set = ExtResource("6_fj6du")
 
 [node name="RuleEngine" parent="." unique_id=1415539640 node_paths=PackedStringArray("board") instance=ExtResource("4_41qil")]
 board = NodePath("../Board2D")
-next_scene = "uid://ydbh5jddjnaf"
 
 [node name="BackgroundMusic" parent="." unique_id=1269579040 instance=ExtResource("6_nx7po")]
 stream = ExtResource("7_ir0b6")
+
+[node name="SceneLink" type="Node2D" parent="." unique_id=596099863]
+script = ExtResource("7_nx7po")
+next_scene = "uid://ydbh5jddjnaf"
+enter_transition = 1
+exit_transition = 1
+metadata/_custom_type_script = "uid://d2vp62mjrf6gn"
+
+[connection signal="goals_reached" from="RuleEngine" to="SceneLink" method="switch"]

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_3c.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_3c.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Script" uid="uid://dppvw2f8yh4vu" path="res://scenes/eternal_loom_sokoban/components/system/board/board_2d.gd" id="5_m5u3b"]
 [ext_resource type="TileSet" uid="uid://dand23uvn70pg" path="res://scenes/eternal_loom_sokoban/components/eternal_loom_tileset.tres" id="6_1qsr1"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="6_1s00a"]
+[ext_resource type="Script" uid="uid://d2vp62mjrf6gn" path="res://scenes/globals/scene_switcher/scene_link.gd" id="7_1s00a"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="7_om8f1"]
 
 [node name="SokobanLevel3c" type="Node2D" unique_id=281329305]
@@ -49,7 +50,15 @@ tile_set = ExtResource("6_1qsr1")
 
 [node name="RuleEngine" parent="." unique_id=933094656 node_paths=PackedStringArray("board") instance=ExtResource("4_3v6fr")]
 board = NodePath("../Board2D")
-next_scene = "uid://cufkthb25mpxy"
 
 [node name="BackgroundMusic" parent="." unique_id=393111310 instance=ExtResource("6_1s00a")]
 stream = ExtResource("7_om8f1")
+
+[node name="SceneLink" type="Node2D" parent="." unique_id=426227306]
+script = ExtResource("7_1s00a")
+next_scene = "uid://cufkthb25mpxy"
+enter_transition = 1
+exit_transition = 3
+metadata/_custom_type_script = "uid://d2vp62mjrf6gn"
+
+[connection signal="goals_reached" from="RuleEngine" to="SceneLink" method="switch"]


### PR DESCRIPTION
Previously the Sokoban `RuleEngine` had its own `next_scene` property and
manually triggered a switch to that scene.

Add a `SceneLink` to each level (and the template), configured to match
`RuleEngine.next_scene`. Use the same left-to-right wipe when switching
round-to-round; use a radial transition when returning to Fray's End.

Connect `RuleEngine.goal_reached` to `SceneLink.switch()`. Emit that
signal when skipping as well as when the goal is actually reached.
Remove `RuleEngine.next_scene`.
