### PR TITLE
Cinematic: Chain up to SceneLink._validate_property()

### DIFF
--- a/scenes/ui_elements/cinematic/cinematic.gd
+++ b/scenes/ui_elements/cinematic/cinematic.gd
@@ -38,6 +38,7 @@ func _ready() -> void:
 
 
 func _validate_property(property: Dictionary) -> void:
+	super._validate_property(property)
 	match property.name:
 		"dialogue_title":
 			if dialogue:


### PR DESCRIPTION
This was previously missing and meant that (for example) the special
handling of `spawn_point_path` was not used for Cinematic nodes.
