### PR TITLE
Store initial quest & home scene in project settings

### DIFF
--- a/addons/threadbare_project_settings/threadbare_project_settings.gd
+++ b/addons/threadbare_project_settings/threadbare_project_settings.gd
@@ -4,6 +4,14 @@
 class_name ThreadbareProjectSettings
 extends Node
 
+## The scene to return to when a quest is completed, skipped, or abandoned.
+## (This is Fray's End in normal builds of Threadbare.)
+const HOME_SCENE = "threadbare/general/home_scene"
+
+## The [Quest] to start from the “New Game” title screen item. (This is the
+## tutorial in normal builds of Threadbare.)
+const OPENING_QUEST = "threadbare/general/opening_quest"
+
 ## Display a letterbox overlay in the game, to debug aspect ratio
 const DEBUG_ASPECT_RATIO = "threadbare/debugging/debug_aspect_ratio"
 
@@ -11,6 +19,20 @@ const DEBUG_ASPECT_RATIO = "threadbare/debugging/debug_aspect_ratio"
 const SKIP_SPLASH = "threadbare/debugging/skip_splash"
 
 static var settings_configuration = {
+	HOME_SCENE:
+	{
+		value = "uid://cufkthb25mpxy",
+		type = TYPE_STRING,
+		hint = PROPERTY_HINT_FILE,
+		hint_string = "*.tscn",
+	},
+	OPENING_QUEST:
+	{
+		value = "uid://0dcffjdxn6g2",
+		type = TYPE_STRING,
+		hint = PROPERTY_HINT_FILE,
+		hint_string = "*.tres,*.res",
+	},
 	DEBUG_ASPECT_RATIO:
 	{
 		value = false,
@@ -42,3 +64,11 @@ static func setup_threadbare_settings() -> void:
 		)
 		ProjectSettings.set_as_basic(setting_name, not setting_config.get("is_advanced", false))
 		ProjectSettings.set_as_internal(setting_name, setting_config.get("is_hidden", false))
+
+
+## Gets a Threadbare-specific setting, returning its default value if unset in
+## the project settings. [param key] should be one of the constants defined in
+## [ThreadbareProjectSettings].
+static func get_setting(key: String) -> Variant:
+	assert(key in settings_configuration)
+	return ProjectSettings.get_setting(key, settings_configuration[key].value)

--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: MPL-2.0
 extends CanvasLayer
 
+## The target for "Exit to Title"
 @export_file("*.tscn") var title_scene: String
-@export_file("*.tscn") var frays_end: String
+
+## Dialogue to play after abandoning a quest.
 @export var abandon_dialogue: DialogueResource
 
+var home_scene: String
 @onready var tab_container: TabContainer = %TabContainer
 @onready var pause_menu: Control = %Menu
 @onready var back_button: Button = %BackButton
@@ -15,6 +18,7 @@ extends CanvasLayer
 
 
 func _ready() -> void:
+	home_scene = ThreadbareProjectSettings.get_setting(ThreadbareProjectSettings.HOME_SCENE)
 	visible = false
 
 
@@ -61,7 +65,7 @@ func abandon_quest(suspend: bool = true) -> void:
 	if abandon_scene:
 		abandon_spawn_point = GameState.quest.abandon_spawn_point
 	else:
-		abandon_scene = frays_end
+		abandon_scene = home_scene
 
 	GameState.abandon_quest(suspend)
 	SceneSwitcher.change_to_file_with_transition(
@@ -82,7 +86,7 @@ func _on_skip_tutorial_pressed() -> void:
 		GameState.player.set_ability(ability, true)
 	GameState.mark_quest_completed()
 	SceneSwitcher.change_to_file_with_transition(
-		frays_end, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+		home_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE
 	)
 
 

--- a/scenes/globals/pause/pause_overlay.tscn
+++ b/scenes/globals/pause/pause_overlay.tscn
@@ -32,7 +32,6 @@ process_mode = 3
 layer = 2
 script = ExtResource("1_lf64b")
 title_scene = "uid://stdqc6ttomff"
-frays_end = "uid://cufkthb25mpxy"
 abandon_dialogue = ExtResource("2_xccck")
 
 [node name="ColorRect" type="ColorRect" parent="." unique_id=694994481]

--- a/scenes/menus/title/components/title_screen.gd
+++ b/scenes/menus/title/components/title_screen.gd
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 extends Control
 
-@export var tutorial_quest: Quest
+var opening_quest: Quest
 
 @onready var main_menu: Control = %MainMenu
 @onready var options: Control = %Options
@@ -10,6 +10,10 @@ extends Control
 
 
 func _ready() -> void:
+	opening_quest = load(
+		ThreadbareProjectSettings.get_setting(ThreadbareProjectSettings.OPENING_QUEST)
+	)
+
 	if ProjectSettings.get_setting(ThreadbareProjectSettings.SKIP_SPLASH):
 		if GameState.can_restore():
 			_on_main_menu_continue_pressed()
@@ -37,9 +41,9 @@ func _on_main_menu_continue_pressed() -> void:
 func _on_start_pressed() -> void:
 	GameState.clear()
 
-	GameState.set_quest(tutorial_quest)
+	GameState.set_quest(opening_quest)
 	SceneSwitcher.change_to_file_with_transition(
-		tutorial_quest.first_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE
+		opening_quest.first_scene, ^"", Transition.Effect.FADE, Transition.Effect.FADE
 	)
 
 

--- a/scenes/menus/title/title_screen.tscn
+++ b/scenes/menus/title/title_screen.tscn
@@ -1,7 +1,6 @@
 [gd_scene format=3 uid="uid://stdqc6ttomff"]
 
 [ext_resource type="Script" uid="uid://c6nc0jka32ow2" path="res://scenes/menus/title/components/title_screen.gd" id="2_0vy2n"]
-[ext_resource type="Resource" uid="uid://0dcffjdxn6g2" path="res://scenes/quests/lore_quests/quest_000/quest.tres" id="3_5uobg"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="4_c6kyi"]
 [ext_resource type="PackedScene" uid="uid://wgmdsj1sbmja" path="res://scenes/menus/title/components/main_menu.tscn" id="5_0vy2n"]
 [ext_resource type="AudioStream" uid="uid://kc657macgib4" path="res://assets/first_party/music/Threadbare_Main_Loud.ogg" id="5_5uobg"]
@@ -20,7 +19,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("2_0vy2n")
-tutorial_quest = ExtResource("3_5uobg")
 
 [node name="BackgroundMusic" parent="." unique_id=2002868584 instance=ExtResource("4_c6kyi")]
 stream = ExtResource("5_5uobg")


### PR DESCRIPTION
Previously the initial quest (i.e. the tutorial) was configured as a
property of the title screen scene; and the path to what I am now
calling the "home scene" (i.e. Fray's End) was configured as a property
of the pause menu.

I want these to be stored in a more neutral location, so that they can
more easily be modified in alternative builds of Threadbare.

Add them as custom project settings. Add a helper function to fetch
them, since default-valued settings are not stored so
`ProjectSettings.get()` returns `null` in that case. Update the pause &
title screens to fetch these paths from settings.

Helps https://github.com/endlessm/threadbare/issues/2250
Helps https://github.com/endlessm/threadbare/issues/2563
