### PR TITLE
SceneLink: Add a special case for "go home"

### DIFF
--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_1c.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_1c.tscn
@@ -55,7 +55,7 @@ stream = ExtResource("7_6gt1w")
 
 [node name="SceneLink" type="Node2D" parent="." unique_id=132922410]
 script = ExtResource("7_x585a")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 enter_transition = 1
 exit_transition = 3
 metadata/_custom_type_script = "uid://d2vp62mjrf6gn"

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_2c.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_2c.tscn
@@ -58,7 +58,7 @@ stream = ExtResource("7_pxo7o")
 
 [node name="SceneLink" type="Node2D" parent="." unique_id=606561375]
 script = ExtResource("7_x2dnf")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 enter_transition = 1
 exit_transition = 3
 metadata/_custom_type_script = "uid://d2vp62mjrf6gn"

--- a/scenes/eternal_loom_sokoban/levels/sokoban_level_3c.tscn
+++ b/scenes/eternal_loom_sokoban/levels/sokoban_level_3c.tscn
@@ -56,7 +56,7 @@ stream = ExtResource("7_om8f1")
 
 [node name="SceneLink" type="Node2D" parent="." unique_id=426227306]
 script = ExtResource("7_1s00a")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 enter_transition = 1
 exit_transition = 3
 metadata/_custom_type_script = "uid://d2vp62mjrf6gn"

--- a/scenes/globals/scene_switcher/scene_link.gd
+++ b/scenes/globals/scene_switcher/scene_link.gd
@@ -8,10 +8,29 @@ extends Node2D
 ## This can be used directly, but acts primarily a base class for other
 ## components: [Cinematic], [CollectibleItem], and the Teleporter scene.
 
+enum Target {
+	## The scene specified in [member SceneLink.next_scene].
+	SPECIFIED_SCENE,
+	## The scene from [constant ThreadbareProjectSettings.HOME_SCENE], typically
+	## Fray's End. Use this at the end of quests.
+	HOME_SCENE,
+}
+
+@export var target: Target = Target.SPECIFIED_SCENE:
+	set(new_value):
+		target = new_value
+		_update_available_spawn_points()
+
 ## Scene to switch to when the player enters this teleport. If empty, the player
 ## will teleport within the current scene, to the position specified by [member
 ## spawn_point_path].
 @export_file("*.tscn") var next_scene: String:
+	get():
+		if target == Target.HOME_SCENE:
+			return ThreadbareProjectSettings.get_setting(ThreadbareProjectSettings.HOME_SCENE)
+
+		return next_scene
+
 	set(new_value):
 		next_scene = new_value
 		_update_available_spawn_points()
@@ -127,6 +146,11 @@ func _update_available_spawn_points() -> void:
 
 func _validate_property(property: Dictionary) -> void:
 	match property.name:
+		"next_scene":
+			if target == Target.HOME_SCENE:
+				property.usage |= PROPERTY_USAGE_READ_ONLY
+				property.usage &= ~PROPERTY_USAGE_STORAGE
+
 		"open_next_scene":
 			var next_scene_path: String = _get_next_scene_path()
 			var edited_scene_root := get_tree().edited_scene_root if is_inside_tree() else null

--- a/scenes/quests/lore_quests/quest_001/4_closing_transition/closing_transition.tscn
+++ b/scenes/quests/lore_quests/quest_001/4_closing_transition/closing_transition.tscn
@@ -383,7 +383,7 @@ autoplay = "idle"
 script = ExtResource("4_3dlh8")
 dialogue = ExtResource("5_offe2")
 animation_player = NodePath("AnimationPlayer")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="ClosingTransitionCinematic" unique_id=744023009]
 libraries/ = SubResource("AnimationLibrary_gyhjf")

--- a/scenes/quests/lore_quests/quest_002/4_closing_transition/closing_transition.tscn
+++ b/scenes/quests/lore_quests/quest_002/4_closing_transition/closing_transition.tscn
@@ -387,7 +387,7 @@ stream = ExtResource("2_wfapt")
 script = ExtResource("4_wfapt")
 dialogue = ExtResource("5_nphcy")
 animation_player = NodePath("../AnimationPlayer")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="TileMapLayers" type="Node2D" parent="." unique_id=1076311957]

--- a/scenes/quests/lore_quests/quest_004/mythical_meadows.tscn
+++ b/scenes/quests/lore_quests/quest_004/mythical_meadows.tscn
@@ -90,7 +90,7 @@ editor_draw_limits = true
 [node name="CollectibleItem" parent="OnTheGround" unique_id=327991066 instance=ExtResource("12_q0isu")]
 position = Vector2(1945, 338)
 item = SubResource("Resource_g27r7")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 
 [node name="InTheWater" type="Node2D" parent="." unique_id=2028481663]
 z_index = -1

--- a/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.tscn
+++ b/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.tscn
@@ -213,7 +213,7 @@ revealed = false
 item = SubResource("Resource_idy4y")
 collected_dialogue = ExtResource("19_gwj3x")
 dialogue_title = &"collected"
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 
 [node name="InTheWater" type="Node2D" parent="." unique_id=921358741]
 z_index = -1

--- a/scenes/quests/lore_quests/song_sanctuary_3/1_ink_drinker_levels/ink_combat_round_6.tscn
+++ b/scenes/quests/lore_quests/song_sanctuary_3/1_ink_drinker_levels/ink_combat_round_6.tscn
@@ -237,7 +237,7 @@ position = Vector2(593, 356)
 revealed = false
 item = SubResource("Resource_rlfef")
 dialogue_title = &"well_done"
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 
 [node name="Camera2D" type="Camera2D" parent="." unique_id=170542824]
 position = Vector2(0, -3)

--- a/scenes/quests/story_quests/after_the_tremor/4_outro/outrofinal/outro_3.tscn
+++ b/scenes/quests/story_quests/after_the_tremor/4_outro/outrofinal/outro_3.tscn
@@ -471,7 +471,7 @@ libraries/ = SubResource("AnimationLibrary_3bxfr")
 script = ExtResource("5_ui13s")
 dialogue = ExtResource("6_2f23v")
 animation_player = NodePath("../OnTheGround/AnimationPlayer")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Shaker" type="Node2D" parent="." unique_id=644476481 node_paths=PackedStringArray("target")]

--- a/scenes/quests/story_quests/champ/4_outro/champ_outro.tscn
+++ b/scenes/quests/story_quests/champ/4_outro/champ_outro.tscn
@@ -63,7 +63,7 @@ autoplay = "idle"
 [node name="Cinematic" type="Node2D" parent="." unique_id=2129269220]
 script = ExtResource("4_jdkp3")
 dialogue = ExtResource("5_f2mqr")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Champ" type="CharacterBody2D" parent="." unique_id=514818323]

--- a/scenes/quests/story_quests/el_abrigo/4_el_abrigo_outro/el_abrigo_outro.tscn
+++ b/scenes/quests/story_quests/el_abrigo/4_el_abrigo_outro/el_abrigo_outro.tscn
@@ -157,7 +157,7 @@ position = Vector2(750, 208)
 [node name="Cinematic" type="Node2D" parent="." unique_id=471937151]
 script = ExtResource("4_qrcvu")
 dialogue = ExtResource("5_soumh")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Rock" parent="." unique_id=553827148 instance=ExtResource("7_dkqu7")]

--- a/scenes/quests/story_quests/el_juguete_perdido/4_outro/outro.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/4_outro/outro.tscn
@@ -147,5 +147,5 @@ autoplay = "idle"
 [node name="Cinematic" type="Node2D" parent="." unique_id=1524101461]
 script = ExtResource("4_c4l1a")
 dialogue = ExtResource("5_c3cc3")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"

--- a/scenes/quests/story_quests/el_ojo_revelador/4_outro/el_ojo_revelador_outro.tscn
+++ b/scenes/quests/story_quests/el_ojo_revelador/4_outro/el_ojo_revelador_outro.tscn
@@ -61,7 +61,7 @@ autoplay = "idle"
 [node name="Cinematic" type="Node2D" parent="." unique_id=660383072]
 script = ExtResource("4_qs8h0")
 dialogue = ExtResource("5_f32la")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Arboles" type="Node" parent="." unique_id=1133400546]

--- a/scenes/quests/story_quests/eldrune/4_outro/eldrune_outro.tscn
+++ b/scenes/quests/story_quests/eldrune/4_outro/eldrune_outro.tscn
@@ -44,7 +44,7 @@ autoplay = "idle"
 [node name="Cinematic" type="Node2D" parent="." unique_id=705688625]
 script = ExtResource("4_lc4pr")
 dialogue = ExtResource("5_kf28u")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="BackgroundMusic" type="Node" parent="." unique_id=426613615]

--- a/scenes/quests/story_quests/renya_beyond_sorrow/4_outro/renya_beyond_sorrow_outro.tscn
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/4_outro/renya_beyond_sorrow_outro.tscn
@@ -110,5 +110,5 @@ autoplay = "idle"
 [node name="Cinematic" type="Node2D" parent="." unique_id=623316175]
 script = ExtResource("4_mbf3i")
 dialogue = ExtResource("5_4sglf")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"

--- a/scenes/quests/story_quests/shjourney/9_shjourney_outro_2/Outro2.tscn
+++ b/scenes/quests/story_quests/shjourney/9_shjourney_outro_2/Outro2.tscn
@@ -508,7 +508,7 @@ position = Vector2(1374.48, 1277.48)
 position = Vector2(3826.89, 577.63)
 scale = Vector2(0.773247, 0.975211)
 script = ExtResource("8_pkup3")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Area2D" type="Area2D" parent="." unique_id=1882220892]
@@ -526,7 +526,7 @@ sprite_frames = ExtResource("12_f0pqt")
 script = ExtResource("13_oxm0q")
 dialogue = ExtResource("14_oxm0q")
 animation_player = NodePath("../Node2D/AnimationPlayer")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Sounds" type="Node2D" parent="." unique_id=276263185]

--- a/scenes/quests/story_quests/stella/4_stella_outro/stella_outro.tscn
+++ b/scenes/quests/story_quests/stella/4_stella_outro/stella_outro.tscn
@@ -61,5 +61,5 @@ autoplay = "idle"
 [node name="Cinematic" type="Node2D" parent="." unique_id=620214402]
 script = ExtResource("4_rctxc")
 dialogue = ExtResource("5_veri0")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"

--- a/scenes/quests/story_quests/verso/4_verso_outro/verso_outro.tscn
+++ b/scenes/quests/story_quests/verso/4_verso_outro/verso_outro.tscn
@@ -110,7 +110,7 @@ autoplay = "idle"
 [node name="Cinematic" type="Node2D" parent="." unique_id=445286266]
 script = ExtResource("4_4mb86")
 dialogue = ExtResource("5_vpp8x")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Trees" type="Node" parent="." unique_id=1243134056]

--- a/scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro.tscn
@@ -53,7 +53,7 @@ autoplay = "idle"
 [node name="Cinematic" type="Node2D" parent="." unique_id=1957659485]
 script = ExtResource("1_wgmu0")
 dialogue = ExtResource("2_wgmu0")
-next_scene = "uid://cufkthb25mpxy"
+target = 1
 metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 
 [node name="Forest" type="StaticBody2D" parent="." unique_id=1541633486]


### PR DESCRIPTION
Previously, the last scene of every quest (and Sokoban trio) hardcoded
the path (or rather UID) to Fray's End.

I want to make a stripped-back version of the repo that does not contain
Fray's End or any StoryQuests or LoreQuests as a StoryQuest kit; yet the
last scene of the template quest hardcodes the UID to Fray's End. I want
to make it possible to change the scene that follows a quest being
completed without modifying every quest in the game.

Add a flag to SceneLink (represented with an `enum` with two values for
future extensibility and self-documentation reasons) which, if set,
means that the link points to the "home scene" configured in the project
settings rather than a specific path/UID.

Update the final scene of all quests, and all Sokoban trios, to use this
new flag rather than hardcoding the Fray's End UID, with one exception.
I kept the explicit reference to Fray's End in
`scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn`
because it also sets a particular spawn point, and doing that doesn't
make sense with a generic "home scene" link.

Helps https://github.com/endlessm/threadbare/issues/2563
