### PR TITLE
Change PlayerState abilities for Dev Archipelago quests

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -118,7 +118,7 @@ func restore_quest() -> void:
 ## Note that this does not switch scenes into the quest.
 func set_quest(new_quest: Quest) -> void:
 	var quest_player_state: PlayerState
-	if new_quest is LoreQuest:
+	if new_quest is not StoryQuest:
 		# Duplicate the current global player state. If the quest is completed,
 		# it will be copied back; if abandoned, it will be discarded.
 		quest_player_state = global.player.duplicate()

--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -112,7 +112,6 @@ func restore_quest() -> void:
 		# Add any lore abilities that the player gained since suspending this
 		# quest.
 		quest.player.abilities |= global.player.abilities
-	# TODO: There might be an edge case for resuming a dev quest that contains modifiers
 	elif quest.quest is not StoryQuest:
 		for ability: Enums.PlayerAbilities in DEBUG_PLAYER_ABILITIES:
 			quest.player.set_ability(ability, true)

--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -112,6 +112,10 @@ func restore_quest() -> void:
 		# Add any lore abilities that the player gained since suspending this
 		# quest.
 		quest.player.abilities |= global.player.abilities
+	# TODO: There might be an edge case for resuming a dev quest that contains modifiers
+	elif quest.quest is not StoryQuest:
+		for ability: Enums.PlayerAbilities in DEBUG_PLAYER_ABILITIES:
+			player.set_ability(ability, true)
 
 
 ## Sets [member quest], setting up a new [PlayerState] if necessary.
@@ -125,9 +129,10 @@ func set_quest(new_quest: Quest) -> void:
 		quest_player_state.reset_lives()
 	elif new_quest is not StoryQuest:
 		# For quests that are not LoreQuests or StoryQuests (e.g. dev archipelago quests)
-		# grant all debug player abilities.
+		# use a fresh player state and grant all debug player abilities.
+		quest_player_state = PlayerState.new()
 		for ability: Enums.PlayerAbilities in DEBUG_PLAYER_ABILITIES:
-			player.set_ability(ability, true)
+			quest_player_state.set_ability(ability, true)
 	else:
 		# Use a fresh player state for StoryQuests
 		quest_player_state = PlayerState.new()

--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -115,7 +115,7 @@ func restore_quest() -> void:
 	# TODO: There might be an edge case for resuming a dev quest that contains modifiers
 	elif quest.quest is not StoryQuest:
 		for ability: Enums.PlayerAbilities in DEBUG_PLAYER_ABILITIES:
-			player.set_ability(ability, true)
+			quest.player.set_ability(ability, true)
 
 
 ## Sets [member quest], setting up a new [PlayerState] if necessary.

--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -118,11 +118,16 @@ func restore_quest() -> void:
 ## Note that this does not switch scenes into the quest.
 func set_quest(new_quest: Quest) -> void:
 	var quest_player_state: PlayerState
-	if new_quest is not StoryQuest:
+	if new_quest is LoreQuest:
 		# Duplicate the current global player state. If the quest is completed,
 		# it will be copied back; if abandoned, it will be discarded.
 		quest_player_state = global.player.duplicate()
 		quest_player_state.reset_lives()
+	elif new_quest is not StoryQuest:
+		# For quests that are not LoreQuests or StoryQuests (e.g. dev archipelago quests)
+		# grant all debug player abilities.
+		for ability: Enums.PlayerAbilities in DEBUG_PLAYER_ABILITIES:
+			player.set_ability(ability, true)
 	else:
 		# Use a fresh player state for StoryQuests
 		quest_player_state = PlayerState.new()


### PR DESCRIPTION
Quests accessible from Dev Archipelago should start the player with `DEBUG_PLAYER_ABILITIES` (basic repel and grapple). Before this change, entering a quest in Dev Archipelago would reset the `PlayerState`, removing all abilities from the player. 

Makes #2533 easier