### PR TITLE
Check if mushroom AudioStreamPlayers are in scene tree before reveal

### DIFF
--- a/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd
+++ b/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd
@@ -31,5 +31,5 @@ func _on_player_detector_body_entered(body: Node2D) -> void:
 
 
 func _on_player_detector_body_exited(body: Node2D) -> void:
-	if body.is_in_group(&"player"):
+	if body.is_in_group(&"player") and reveal_player.is_inside_tree():
 		_reveal()

--- a/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd
+++ b/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd
@@ -19,7 +19,9 @@ func _hide() -> void:
 func _reveal() -> void:
 	animated_sprite_2d.visible = true
 	animated_sprite_2d.play(&"reveal")
-	reveal_player.play()
+	# A body may call body_exit while simultaneously switching scenes, causing this to be freed
+	if reveal_player.is_inside_tree():
+		reveal_player.play()
 	await animated_sprite_2d.animation_finished
 	if animated_sprite_2d.animation == &"reveal":
 		animated_sprite_2d.play(&"idle")

--- a/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd
+++ b/scenes/game_elements/props/decoration/hiding_mushroom/hiding_mushroom.gd
@@ -33,5 +33,5 @@ func _on_player_detector_body_entered(body: Node2D) -> void:
 
 
 func _on_player_detector_body_exited(body: Node2D) -> void:
-	if body.is_in_group(&"player") and reveal_player.is_inside_tree():
+	if body.is_in_group(&"player"):
 		_reveal()


### PR DESCRIPTION
Check that the nodes associated with the `_reveal()` function for the hiding mushroom exist in the scene tree before calling it. Gets rid of the error when using Abandon Quest while `Player` is within range of the mushroom.

Resolves #2589 