### PR TITLE
Storybook: Add test scene with mock quests

### DIFF
--- a/scenes/menus/storybook/components/storybook_test.gd
+++ b/scenes/menus/storybook/components/storybook_test.gd
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Node2D
+
+const STORYBOOK_SCENE := preload("uid://bhm7fdjvppt8b")
+
+@export_range(0, 100, 1, "or_greater") var quests_amount: int = 30
+
+var titles := [
+	"Lord of the Needles",
+	"The Secret of Crochet",
+	"The Dark Knit",
+	"The Needle and the Sorcerer",
+	"Conan the Weaver",
+	"Return to Fray's End",
+	"The Little HushRoom",
+]
+
+
+func _ready() -> void:
+	var quests: Array[Quest] = []
+	for i in range(quests_amount):
+		var q := Quest.new()
+		q.title = titles.pick_random()
+		quests.append(q)
+	var storybook := STORYBOOK_SCENE.instantiate()
+	storybook.quests = quests
+	add_child(storybook)

--- a/scenes/menus/storybook/components/storybook_test.gd.uid
+++ b/scenes/menus/storybook/components/storybook_test.gd.uid
@@ -1,0 +1,1 @@
+uid://3jqylhm2tfq6

--- a/scenes/menus/storybook/components/storybook_test.tscn
+++ b/scenes/menus/storybook/components/storybook_test.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://dsqpknfunm81y"]
+
+[ext_resource type="Script" uid="uid://3jqylhm2tfq6" path="res://scenes/menus/storybook/components/storybook_test.gd" id="1_yxans"]
+
+[node name="StorybookTest" type="Node2D" unique_id=2085607078]
+script = ExtResource("1_yxans")


### PR DESCRIPTION
For now, mock tests have just a title to test the index.

Helps https://github.com/endlessm/threadbare/issues/1757