### PR TITLE
Pause menu: Hide Abandon Quest in Fray's End

### DIFF
--- a/scenes/globals/pause/pause_overlay.gd
+++ b/scenes/globals/pause/pause_overlay.gd
@@ -44,7 +44,9 @@ func toggle_pause() -> void:
 			abandon_quest_button.hide()
 		else:
 			skip_tutorial_button.hide()
-			abandon_quest_button.show()
+			abandon_quest_button.visible = (
+				get_tree().current_scene.scene_file_path != ResourceUID.ensure_path(home_scene)
+			)
 		pause_menu.show()
 		back_button.grab_focus()
 


### PR DESCRIPTION
The pause menu now resolves the configured home-scene UID before comparing it with the current scene. This keeps Abandon Quest available during non-skippable quests elsewhere, but hides it after the player returns to Fray's End so the quest must be completed at the Eternal Loom.

Assisted-by: Codex:GPT-5.6-sol

Resolves #2511