### PR TITLE
dev: Fix incorrect teleporter.tscn uid

### DIFF
--- a/scenes/dev/basics/teleporter/teleporter_test_1.tscn
+++ b/scenes/dev/basics/teleporter/teleporter_test_1.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/components/sprite_frames/storyweaver_blue.tres" id="3_gn71u"]
 [ext_resource type="TileSet" uid="uid://b778cuoftt88r" path="res://tiles/elevation_2.tres" id="3_ru1dy"]
 [ext_resource type="Script" uid="uid://0enyu5v4ra34" path="res://scenes/game_elements/props/spawn_point/components/spawn_point.gd" id="7_ru1dy"]
-[ext_resource type="PackedScene" uid="uid://o0yekbnbchb3" path="res://scenes/game_elements/props/teleporter/teleporter.tscn" id="8_b4723"]
+[ext_resource type="PackedScene" uid="uid://0ull24fvmhwk" path="res://scenes/game_elements/props/teleporter/teleporter.tscn" id="8_b4723"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="9_rqdwi"]
 [ext_resource type="PackedScene" uid="uid://djmdhrse34vgq" path="res://scenes/game_elements/props/decoration/bunny/bunny.tscn" id="10_dlvxh"]
 [ext_resource type="SpriteFrames" uid="uid://bsjdohkkb776w" path="res://scenes/game_elements/characters/components/sprite_frames/bunny_yellow.tres" id="11_k8vxi"]

--- a/scenes/dev/basics/teleporter/teleporter_test_2.tscn
+++ b/scenes/dev/basics/teleporter/teleporter_test_2.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="TileSet" uid="uid://b778cuoftt88r" path="res://tiles/elevation_2.tres" id="3_bmbbq"]
 [ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/components/sprite_frames/storyweaver_blue.tres" id="3_edlc4"]
 [ext_resource type="Script" uid="uid://0enyu5v4ra34" path="res://scenes/game_elements/props/spawn_point/components/spawn_point.gd" id="7_bmbbq"]
-[ext_resource type="PackedScene" uid="uid://o0yekbnbchb3" path="res://scenes/game_elements/props/teleporter/teleporter.tscn" id="8_hhhwu"]
+[ext_resource type="PackedScene" uid="uid://0ull24fvmhwk" path="res://scenes/game_elements/props/teleporter/teleporter.tscn" id="8_hhhwu"]
 [ext_resource type="PackedScene" uid="uid://d0c4l7ev6ca3c" path="res://scenes/game_elements/props/spawn_point/spawn_point.tscn" id="8_x52rp"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="10_x52rp"]
 [ext_resource type="PackedScene" uid="uid://djmdhrse34vgq" path="res://scenes/game_elements/props/decoration/bunny/bunny.tscn" id="11_dbcqv"]

--- a/scenes/dev/dev_archipelago.tscn
+++ b/scenes/dev/dev_archipelago.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="4_pr8dh"]
 [ext_resource type="TileSet" uid="uid://do0ffypatd77h" path="res://tiles/bridges.tres" id="5_onjm3"]
 [ext_resource type="TileSet" uid="uid://41pk6xbhypue" path="res://tiles/fence.tres" id="6_qihih"]
-[ext_resource type="PackedScene" uid="uid://o0yekbnbchb3" path="res://scenes/game_elements/props/teleporter/teleporter.tscn" id="7_xgiso"]
+[ext_resource type="PackedScene" uid="uid://0ull24fvmhwk" path="res://scenes/game_elements/props/teleporter/teleporter.tscn" id="7_xgiso"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="8_oxwdn"]
 [ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/components/sprite_frames/storyweaver_blue.tres" id="9_rl866"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="10_ee0kp"]


### PR DESCRIPTION
dev: Fix incorrect teleporter.tscn uid

    WARNING: res://scenes/dev/dev_archipelago.tscn:9 - ext_resource,
    invalid UID: uid://o0yekbnbchb3 - using text path instead:
    res://scenes/game_elements/props/teleporter/teleporter.tscn
