### PR TITLE
powerup: Fix crash if ability has no name

### DIFF
--- a/scenes/game_elements/props/powerup/components/powerup.gd
+++ b/scenes/game_elements/props/powerup/components/powerup.gd
@@ -66,7 +66,7 @@ func _update_ability_name() -> void:
 	if GameState.quest and GameState.quest.quest is StoryQuest:
 		var sq := GameState.quest.quest as StoryQuest
 		abilities_names = sq.abilities_names
-	ability_name = abilities_names.get(ability)
+	ability_name = abilities_names.get(ability, "")
 
 
 func _ready() -> void:


### PR DESCRIPTION
powerup: Fix crash if ability has no name

`ability_name` has type `String`. `abilities_names.get(ability)` returns
`null` if the key `ability` is not present in `ability_names`. `null`
cannot be assigned to a `String` variable.

Fix this with the two-argument form of `Dictionary.get`, passing `""` as
the value to return if the key is not present.

The surrounding code deals with `ability_name` being `""`: the interact
prompt is "Collect $ability_name" if it is non-empty, and "Collect" if
it is empty.
