### PR TITLE
Lore Jam quest: Add SPDX license headers to dialogue files

### DIFF
--- a/scenes/quests/lore_quests/quest_004/01_dream_threshold/noria.dialogue
+++ b/scenes/quests/lore_quests/quest_004/01_dream_threshold/noria.dialogue
@@ -1,6 +1,6 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
 ~ start
-
-# TODO: This should be moved to ABILITY_A_MODIFIER_1
 if GameState.player.has_ability(Enums.PlayerAbilities.ABILITY_C)
 	Noria NeedleNest: (lets out a little chuckle) Leaving so soon, little knot? [wave amp=25 freq=5]Hee, hee.[/wave]
 	Noria NeedleNest: I'll tell you a secret: the loom never closes all the way. Where the threads are thickest... there's always a gap for those who know how to look.

--- a/scenes/quests/lore_quests/quest_004/02_caretaker_of_growth/sable_farewell.dialogue
+++ b/scenes/quests/lore_quests/quest_004/02_caretaker_of_growth/sable_farewell.dialogue
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
 ~ start
 Sable Seedkeeper: (leaning in the doorway) Not bad, little weaver. Not bad at all. Noria wove your way this far — she asked me to keep it open.
 Sable Seedkeeper: One thing before you go. If you see a woman out there... a strange hat, a diary that [wave amp=30 freq=4]floats beside her[/wave]... follow her.

--- a/scenes/quests/lore_quests/quest_004/02_caretaker_of_growth/sable_intro.dialogue
+++ b/scenes/quests/lore_quests/quest_004/02_caretaker_of_growth/sable_intro.dialogue
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
 ~ start
 Sable Seedkeeper: (looks up from a watering can, startled — then grins) Well, well. One of Noria's knots, aren't you? She always sends the interesting ones.
 Sable Seedkeeper: Listen. Those grey stones out there — they're not asleep. They're remembering. Hum near one and it'll remember it exists... for a little while. Long enough to grab.

--- a/scenes/quests/lore_quests/quest_004/03_the_fading_woman/page_1.dialogue
+++ b/scenes/quests/lore_quests/quest_004/03_the_fading_woman/page_1.dialogue
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
 ~ start
 [i]"The flowers lean toward where I am going. But I am not going anywhere. So — toward whom do they lean?"[/i]
 (The ink is still wet. The handwriting is hers.)

--- a/scenes/quests/lore_quests/quest_004/03_the_fading_woman/willomena_1.dialogue
+++ b/scenes/quests/lore_quests/quest_004/03_the_fading_woman/willomena_1.dialogue
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
 ~ start
 Willomena Wanderweave: (she writes in a diary that floats beside her, never looking up) The forest moved again. Three steps north, and the north was gone.
 Willomena Wanderweave: I've mapped this valley seven times. Every map is correct. It's the valley that's wrong.

--- a/scenes/quests/lore_quests/quest_004/03_the_fading_woman/willomena_2.dialogue
+++ b/scenes/quests/lore_quests/quest_004/03_the_fading_woman/willomena_2.dialogue
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
 ~ start
 Willomena Wanderweave: (fainter now — you can see the rock through her — and she does not rise) Oh. You're still here. You followed. Good.
 Willomena Wanderweave: I'm tired, little weaver. Will you remember the flower for me? When you find it. Just... remember it. That's all I ask.

--- a/scenes/quests/lore_quests/quest_004/03_the_fading_woman/willomena_3.dialogue
+++ b/scenes/quests/lore_quests/quest_004/03_the_fading_woman/willomena_3.dialogue
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
 ~ start
 Willomena Wanderweave: (almost gone — a shimmer, a held breath — so close you could touch her) I'm close now. I can almost feel the flower. Almost.
 Willomena Wanderweave: Will you see it for me? Will you tell me what it looks like? I... I don't remember anymore.


### PR DESCRIPTION
Adds the missing SPDX-FileCopyrightText / SPDX-License-Identifier headers to the 7 .dialogue files in quest_004 (Mythical Meadows), resolving the reuse lint failures that were blocking #2606 .