### PR TITLE
Retelling townies: Increase walking speed

### DIFF
--- a/scenes/world_map/components/retelling_townie.gd
+++ b/scenes/world_map/components/retelling_townie.gd
@@ -54,7 +54,7 @@ func go_to_the_loom() -> void:
 
 	# Randomize the speed of each townie, for variation:
 	path_walk_behavior.speeds = CharacterSpeeds.new()
-	path_walk_behavior.speeds.walk_speed = randf_range(100, 200)
+	path_walk_behavior.speeds.walk_speed = randf_range(200, 300)
 
 	townie.randomize_character()
 	townie.visible = true


### PR DESCRIPTION
## Summary

I increased the randomized walking-speed range for retelling townies from 100–200 px/s to 200–300 px/s. This keeps variation between townies while avoiding the unusually slow movement that can make the retelling cutscene drag.

## Validation

I ran:

- `pre-commit run --files scenes/world_map/components/retelling_townie.gd`
- `gdlint scenes/world_map/components/retelling_townie.gd`
- `gdformat --check scenes/world_map/components/retelling_townie.gd`
- `git diff --check`

I did not run a full game export locally; I left the full export to CI because this focused GDScript change is covered by the repository's lint and formatting checks.

Resolves https://github.com/endlessm/threadbare/issues/2620
