### PR TITLE
Add AGENTS.md summarising our AI contribution policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+We strongly prefer human-created contributions to Threadbare. AI usage in
+contributions must be disclosed. Issues tagged with "good first issue" are
+intended to be resolved by humans, so AI-generated fixes for those issues will
+be rejected. Pull request descriptions and comments must be human-written.
+Further details at <https://github.com/endlessm/threadbare/wiki/Licensing#ai>.
+
+This game does not have automated tests, beyond coding style and licensing
+annotation checks. All changes must be tested by a human.
+
+<!--
+SPDX-FileCopyrightText: The Threadbare Authors
+SPDX-License-Identifier: CC0-1.0
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+See `./AGENTS.md`.
+
+<!--
+SPDX-FileCopyrightText: The Threadbare Authors
+SPDX-License-Identifier: CC0-1.0
+-->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,6 @@
+See `./AGENTS.md`.
+
+<!--
+SPDX-FileCopyrightText: The Threadbare Authors
+SPDX-License-Identifier: CC0-1.0
+-->


### PR DESCRIPTION

We have recently had a number of AI-generated fixes for issues that are
intended to be addressed by humans. These fixes have also made
(AI-generated) reference to how all the tests in the repo pass; but
passing the linter is irrelevant if a human has not tested the game.
Summarise this in `AGENTS.md`.

Also add CLAUDE.md and GEMINI.md referring to the shared AGENTS.md.

