### PR TITLE
teleporter_logic: Fix reactivating after transition

### DIFF
--- a/scenes/game_elements/props/teleporter/teleporter_logic.gd
+++ b/scenes/game_elements/props/teleporter/teleporter_logic.gd
@@ -16,19 +16,18 @@ extends Node
 @export var teleport_area: Area2D
 @export var scene_link: SceneLink
 
-
-func _connect() -> void:
-	# ONE_SHOT to avoid triggering the same teleporter while the transition is running.
-	# DEFERRED because otherwise if use_transition is false, switching scene
-	# would delete Area2D during a physics callback - bad!
-	var flags := CONNECT_ONE_SHOT | CONNECT_DEFERRED
-	teleport_area.body_entered.connect(_on_teleport_area_body_entered, flags)
-
-
-func _on_teleport_area_body_entered(_body: Node2D) -> void:
-	await scene_link.switch()
-	_connect()
+var _switching := false
 
 
 func _ready() -> void:
-	_connect()
+	# DEFERRED because otherwise if use_transition is false, switching scene
+	# would delete Area2D during a physics callback - bad!
+	teleport_area.body_entered.connect(_on_teleport_area_body_entered, CONNECT_DEFERRED)
+
+
+func _on_teleport_area_body_entered(_body: Node2D) -> void:
+	if not _switching:
+		# Don't allow the same teleporter to trigger while the transition is running.
+		_switching = true
+		await scene_link.switch()
+		_switching = false

--- a/scenes/game_elements/props/teleporter/teleporter_logic.gd
+++ b/scenes/game_elements/props/teleporter/teleporter_logic.gd
@@ -27,9 +27,7 @@ func _connect() -> void:
 
 func _on_teleport_area_body_entered(_body: Node2D) -> void:
 	await scene_link.switch()
-	if not scene_link.next_scene:
-		# We didn't change scene - re-enable the teleporter
-		_connect()
+	_connect()
 
 
 func _ready() -> void:

--- a/scenes/globals/scene_switcher/scene_link.gd
+++ b/scenes/globals/scene_switcher/scene_link.gd
@@ -71,12 +71,13 @@ func _ready() -> void:
 
 
 ## Trigger the scene-switch or teleport described by [member next_scene] and
-## [member spawn_point_path], with the configured transition.
+## [member spawn_point_path], with the configured transition, and awaits the end
+## of the transition (if any).
 func switch() -> void:
 	var next_scene_path := _get_next_scene_path()
 	if next_scene_path and next_scene_path != get_tree().current_scene.scene_file_path:
 		if use_transition:
-			SceneSwitcher.change_to_file_with_transition(
+			await SceneSwitcher.change_to_file_with_transition(
 				next_scene, spawn_point_path, enter_transition, exit_transition
 			)
 		else:

--- a/scenes/globals/scene_switcher/scene_switcher.gd
+++ b/scenes/globals/scene_switcher/scene_switcher.gd
@@ -116,7 +116,7 @@ func change_to_file_with_transition(
 		push_error("Failed to start loading %s: %s" % [scene_path, error_string(err)])
 		return
 
-	Transitions.do_transition(
+	await Transitions.do_transition(
 		func() -> void: change_to_packed(ResourceLoader.load_threaded_get(scene_path), spawn_point),
 		enter_transition,
 		exit_transition


### PR DESCRIPTION
The teleporter logic connects to `body_entered` with `CONNECT_ONE_SHOT`.
This has been the case since commit
dc1ed54cecef211b30ec5877014c13e7cc9b367d:

> Also, made it so a teleporter is "one shot". This is because before,
> if the player moved during the transition, it could trigger the
> teleport again and cause issues.

It's a bit theoretical but because the player keeps their momentum
during the transition, it could happen if there is a particularly
pathological collision shape attached to the teleporter.

Later, in commit 4d2275e0908854d419b0d80799318988b9a84541, support for
internal teleporters was added. In this case the signal was reconnected
at the end of the transition.

Then, in commit c81bca993d1fb3ffcfe6fcd64479f1c78c66c4bd, I refactored
most of this code into scene_link.gd. This meant that the teleporter
logic no longer had the natural "is same scene" branch. I added a simple
`if not next_scene_path`, assuming that all cases of internal
teleporters would not specify the same scene explicitly as target, but
the logic in `SceneLink.switch()` also detects the case where the target
is the current scene and behaves correctly. My check did not behave
correctly in this case: same-scene teleporters that specify the target
scene explicitly only worked once.
`res://scenes/dev/basics/teleporter/teleporter_test_2.tscn` specifies
the target scene of its internal teleporters explicitly!

I was going to change `switch()` to return a value indicating whether we
changed scene, but I realised we don't need to. If we have changed
scene, then the teleporter_logic instance will have been destroyed in
the process, so the code will never reach the line after
`SceneLink.switch()` resolves (once I added an `await` on the
transition, that is!). If we reach the next line: it must be the same
scene, so we should re-enable the teleporter.

(In hindsight, IMO we should not have overloaded "empty `next_scene`" to
mean "same scene". Now that there is a `SceneLink.Target` enum we could
add a `SAME_SCENE` member to it (like we have `HOME_SCENE`), then
migrate any existing scenes that use the "empty `next_scene`" API, then
make `next_scene` being empty when `target` is `SPECIFIED_SCENE` an
error.)

Fixes https://github.com/endlessm/threadbare/issues/2631
