### PR TITLE
teleporter_test_2: Use blank next_scene to mean "same scene"

### DIFF
--- a/scenes/dev/basics/teleporter/teleporter_test_2.tscn
+++ b/scenes/dev/basics/teleporter/teleporter_test_2.tscn
@@ -57,7 +57,6 @@ tile_set = ExtResource("1_ns3or")
 
 [node name="ToIslandTeleporter" parent="Teleporters" unique_id=1779636661 instance=ExtResource("8_hhhwu")]
 position = Vector2(736, 416)
-next_scene = "uid://m0f3uc2tme4l"
 spawn_point_path = NodePath("../../SpawnPoints/GoingOutSpawnPoint")
 use_transition = false
 
@@ -66,7 +65,6 @@ shape = SubResource("RectangleShape2D_pp1gq")
 
 [node name="FromIslandTeleporter" parent="Teleporters" unique_id=1148082502 instance=ExtResource("8_hhhwu")]
 position = Vector2(672, -288)
-next_scene = "uid://m0f3uc2tme4l"
 spawn_point_path = NodePath("../../SpawnPoints/ComingBackSpawnPoint")
 enter_transition = 5
 exit_transition = 5


### PR DESCRIPTION
Previously these explicitly specified the path/uid to the current scene.
This works, but the documentation says to use a blank value to mean
"same scene".

Doing this matches the documentation, and also means that an internal
teleporter copy-pasted into another scene will remain an internal
teleporter.

Follow-up to https://github.com/endlessm/threadbare/pull/2636.
