### PR TITLE
GameState: Fix "Guessed quest ..." message when running in editor

### DIFF
--- a/scenes/globals/game_state/game_state.gd
+++ b/scenes/globals/game_state/game_state.gd
@@ -151,10 +151,10 @@ func guess_quest(scene_path_or_uid: String) -> void:
 	while dir_path != "res://":
 		var quest_path := dir_path.path_join("quest.tres")
 		if ResourceLoader.exists(quest_path, "Resource"):
+			prints("Guessed quest", quest_path, "from scene", scene_path)
 			var q := ResourceLoader.load(quest_path) as Quest
 			quest = QuestState.new(q, PlayerState.new())
 			quest.challenge_start_scene = scene_path
-			prints("Guessed quest", quest.resource_path, "from scene", scene_path)
 			return
 
 		dir_path = dir_path.get_base_dir()


### PR DESCRIPTION
For reasons unknown (to me), `quest.resource_path` is blank in this code
path when I run a scene in the editor with F6:

> Guessed quest  from scene res://scenes/dev/basics/teleporter/teleporter_test_2.tscn

(Note the double space.)

We already know the quest's path because we loaded it by path after
guessing it. Print that instead. Move the print to before the
`ResourceLoader.load()` call: if that call fails, then the messages will
be in a more logical order.
