### PR TITLE
Remove oneshot sign from teleporter_test_2.tscn

### DIFF
--- a/scenes/dev/basics/teleporter/teleporter_test_2.tscn
+++ b/scenes/dev/basics/teleporter/teleporter_test_2.tscn
@@ -117,13 +117,6 @@ direction = 1
 text = "Teleportation can also exist between
 two points in the same scene!"
 
-[node name="Sign2" parent="OnTheGround" unique_id=1495489743 instance=ExtResource("10_x52rp")]
-position = Vector2(1442, -169)
-text = "The point-to-point teleporters only work once,
-to avoid getting stuck in a transition.
-Once you go back to the main land, you can't return
-until the scene is restarted!"
-
 [node name="Sign3" parent="OnTheGround" unique_id=284069038 instance=ExtResource("10_x52rp")]
 position = Vector2(968, -351)
 text = "Speaking of transitions...


### PR DESCRIPTION
After going back to read #2636, I realized that `teleporter_test_2.tscn` not only needed the target scenes removed but also the sign explaining why they only work once. Said sign is now removed.