### PR TITLE
Push StoryQuest kit as Git tag

### DIFF
--- a/.github/workflows/make-storyquest-kit.yml
+++ b/.github/workflows/make-storyquest-kit.yml
@@ -3,6 +3,10 @@
 name: "Make StoryQuest Kit"
 on:
   workflow_dispatch:
+    inputs:
+      push_tag:
+        description: "Push Git tag for kit"
+        type: boolean
   pull_request:
     paths:
       - 'tools/sqckck.*'
@@ -10,6 +14,10 @@ on:
   release:
     types:
       - published
+
+permissions:
+  # Need to be able to push the bundle back to a Git tag and/or branch
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -59,6 +67,12 @@ jobs:
         with:
           path: ${{ steps.sqckck.outputs.zip_file }}
           archive: false
+
+      - name: Push git tag
+        if: ${{ github.event_name == 'release' || inputs.push_tag }}
+        shell: bash
+        run: |
+          git push origin "${{ steps.sqckck.outputs.tag_name }}"
 
       - name: Attach to release
         if: ${{ github.event_name == 'release' }}

--- a/tools/sqckck.gd
+++ b/tools/sqckck.gd
@@ -13,23 +13,6 @@ const HOME_SCENE := "res://scenes/dev/dev_archipelago.tscn"
 
 const TEMPLATE_QUEST := "res://scenes/quests/template_quests/NO_EDIT/quest.tres"
 
-const DELETE_PATHS := [
-	"res://assets/third_party/tiny-swords-non-cc0",
-	"res://scenes/quests/lore_quests",
-	"res://scenes/quests/story_quests",
-	"res://scenes/world_map",
-]
-
-
-func rm_rf(path: String) -> void:
-	# You can only delete empty folders, so using DirAccess.remove() means
-	# traversing the whole folder tree and deleting each leaf before its parent
-	# folder. But you can trash a non-empty folder in a single step!
-	var global_path := ProjectSettings.globalize_path(path)
-	var ret := OS.move_to_trash(global_path)
-	if ret != OK:
-		push_error("Failed to trash ", global_path, ": ", error_string(ret))
-
 
 func _process(_delta: float) -> bool:
 	var home_scene := ResourceUID.path_to_uid(HOME_SCENE)
@@ -43,8 +26,5 @@ func _process(_delta: float) -> bool:
 
 	if ProjectSettings.save() != OK:
 		push_error("Failed to save project settings")
-
-	for path: String in DELETE_PATHS:
-		rm_rf(path)
 
 	return true  # End the main loop

--- a/tools/sqckck.sh
+++ b/tools/sqckck.sh
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 set -ex
-: ${GODOT:=godot}
-pushd $(dirname "$(dirname "$0")")
+: "${GODOT:=godot}"
+: "${GITHUB_OUTPUT:=/dev/fd/1}"
+pushd "$(readlink -f "$(dirname "$0")/..")"
 
 VERSION=$(git describe --tags)
 declare -a PRUNE_FOLDERS=(
@@ -33,15 +34,15 @@ echo "::endgroup::"
 
 echo "::group::Committing pruned project"
 git switch --detach
-git commit --no-verify -am "Create StoryQuest kit for $VERSION"
+git add --update
+git commit --no-verify -m "Create StoryQuest kit for $VERSION"
+TAG_NAME="$VERSION-storyquest-kit"
+git tag --force -m "StoryQuest kit for $VERSION" "$TAG_NAME"
+echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
 echo "::endgroup::"
-
-# TODO: merge this to a special branch? Push this as a tag?
 
 echo "::group::Creating zip file"
 git archive --format=zip --prefix=threadbare-storyquest/ --output="threadbare-storyquest-$VERSION.zip" @
 echo "::endgroup::"
 
-if [[ -n "$GITHUB_OUTPUT" ]]; then
-  echo "zip_file=threadbare-storyquest-$VERSION.zip" >> "$GITHUB_OUTPUT"
-fi
+echo "zip_file=threadbare-storyquest-$VERSION.zip" >> "$GITHUB_OUTPUT"

--- a/tools/sqckck.sh
+++ b/tools/sqckck.sh
@@ -6,12 +6,19 @@ set -ex
 pushd $(dirname "$(dirname "$0")")
 
 VERSION=$(git describe --tags)
+declare -a PRUNE_FOLDERS=(
+	"assets/third_party/tiny-swords-non-cc0"
+	"scenes/quests/lore_quests"
+	"scenes/quests/story_quests"
+	"scenes/world_map"
+)
 
 echo "::group::Importing project"
 $GODOT --headless --import
 echo "::endgroup::"
 
 echo "::group::Pruning project"
+rm -r "${PRUNE_FOLDERS[@]}"
 $GODOT --headless --script tools/sqckck.gd
 rm -r .godot
 echo "::endgroup::"


### PR DESCRIPTION
The goal here is that, if we want to import a StoryQuest from Backstitch
back into Git, we can do so as follows:

1. Look in the project settings which Git version the StoryQuest kit
   came from;
2. Check out the tag for that kit;
3. Replace all files in the directory (except `.git`) with the
   Backstitch project;
4. Commit.
5. Now we have a clean commit for "add new StoryQuest" which we can
   rebase onto upstream main.

This would also be a useful thing to have if we want to continue to
support running Core: Threadbare in Git(Hub). Two ideas that would both
be better than what we have today:

1. Automatically sync these tags to the `main` branch of a separate
   `threadbare-storyquest-kit` Git repo, and adjust the setup script to
   fork that. Configure a workflow to close all pull requests on that
   separate repo with the "wrong target" message.

2. Rewrite the setup script so that rather than forking our repo, it
   instead creates a new one (not in a fork relationship with
   endlessm/threadbare) and pushes the latest such tag as its `main`.

I have a fancier version of this patch which synthesises a merge commit
between the commit that the kit is based on and the most recent commit
on a `storyquest-kit` branch but I decided that the complexity isn't
worth it unless we decide we want to go down one of those routes.

I also tacked on a change to move the `rm -r` from GDScript to shell. I think it's an improvement.
