### PR TITLE
Storybook: Page content fades in and out

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -36,10 +36,10 @@ var _current_list_page: int = 0
 @onready var ui_container: Control = %StoryBookContent
 
 
-func _fade_out_ui():
+func _fade_out_ui() -> void:
+	ui_container.visible = false
 	var tween := create_tween()
 	tween.tween_property(ui_container, "modulate:a", 0.0, fade_duration)
-	return tween.finished
 
 
 func _fade_in_ui() -> void:
@@ -180,7 +180,6 @@ func _switch_to_page(spread_index: int) -> void:
 
 	if old_index != -1:
 		await _fade_out_ui()
-		ui_container.visible = false
 
 		if spread_index > old_index or (spread_index == 0 and old_index == total_spreads - 1):
 			animated_book.play("book_right")

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -18,6 +18,7 @@ signal selected(quest: Quest, restart: bool)
 	set(value):
 		quests_per_page = value
 		quests_per_spread = value * 2
+@export var fade_duration: float = 0.15
 
 var quests_per_spread: int = 16
 
@@ -33,6 +34,18 @@ var _current_list_page: int = 0
 @onready var back_button: Button = %BackButton
 @onready var animated_book: AnimatedSprite2D = %AnimatedSprite2D
 @onready var ui_container: Control = %StoryBookContent
+
+
+func _fade_out_ui():
+	var tween := create_tween()
+	tween.tween_property(ui_container, "modulate:a", 0.0, fade_duration)
+	return tween.finished
+
+
+func _fade_in_ui() -> void:
+	ui_container.visible = true
+	var tween := create_tween()
+	tween.tween_property(ui_container, "modulate:a", 1.0, fade_duration)
 
 
 func _ready() -> void:
@@ -166,6 +179,9 @@ func _switch_to_page(spread_index: int) -> void:
 	_current_spread_index = spread_index
 
 	if old_index != -1:
+		await _fade_out_ui()
+		ui_container.visible = false
+
 		if spread_index > old_index or (spread_index == 0 and old_index == total_spreads - 1):
 			animated_book.play("book_right")
 		else:
@@ -177,9 +193,9 @@ func _switch_to_page(spread_index: int) -> void:
 
 
 func _on_animation_finished() -> void:
-	_navigation_locked = false
-	ui_container.visible = true
+	_fade_in_ui()
 	_update_page_visibility()
+	_navigation_locked = false
 
 
 func _on_left_button_pressed() -> void:

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -37,9 +37,10 @@ var _current_list_page: int = 0
 
 
 func _fade_out_ui() -> void:
-	ui_container.visible = false
 	var tween := create_tween()
 	tween.tween_property(ui_container, "modulate:a", 0.0, fade_duration)
+	await tween.finished
+	ui_container.visible = false
 
 
 func _fade_in_ui() -> void:


### PR DESCRIPTION
When you flip a page in the Storybook, what's currently on the page will fade out, the page flipping animation will play, and then the new page content will fade in.

Resolves #2645