### PR TITLE
Link Dev Archipelago to Fray's End

### DIFF
--- a/scenes/dev/dev_archipelago.tscn
+++ b/scenes/dev/dev_archipelago.tscn
@@ -96,6 +96,7 @@ tile_set = ExtResource("6_qihih")
 [node name="Teleporter" parent="Teleporters" unique_id=1779636661 instance=ExtResource("7_xgiso")]
 position = Vector2(32, 1309)
 target = 1
+spawn_point_path = NodePath("OnTheGround/DevIslandPath/SpawnPoint")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Teleporters/Teleporter" unique_id=1543850848]
 position = Vector2(4.5, -0.5)

--- a/scenes/game_elements/characters/npcs/elder/components/lore_quest_starter.dialogue
+++ b/scenes/game_elements/characters/npcs/elder/components/lore_quest_starter.dialogue
@@ -31,8 +31,8 @@ LoreQuest Elder: Go back to the Song Sanctuary, and see if Bridget needs any mor
 => END
 
 ~ mythical_meadows_prompt
-LoreQuest Elder: Thanks to you, the villagers were able to rebuild the path to the Mythical Meadows.
-LoreQuest Elder: Go and see what's happening.
+LoreQuest Elder: Thanks to you, the path to the west is open again.
+LoreQuest Elder: Try to find the [shake]Mythical Meadows[/shake]!
 => END
 
 ~ go_to_loom

--- a/scenes/world_map/components/frays_end.dialogue
+++ b/scenes/world_map/components/frays_end.dialogue
@@ -41,10 +41,47 @@ Farmer: Guess it was only funny in my head.
 => END
 
 ~ beach
-if mythical_meadows_unlocker.is_satisfied():
-	Dolores: Wow, where did this bridge come from?!
-	Dolores: Perhaps this is the way to the Mythical Meadows.
-else:
-	% Dolores: I love this little beach!
-	% Dolores: This beach is so peaceful!
+if not dev_island_unlocker.is_satisfied():
+	=> beach_dev_island_intro
+
+Dolores: Tell me about Dev Archipelago!
+- I haven't been there yet.
+	=> beach_go_to_dev_island
+- I didn't know sheep could do that!
+	% Dolores: Maybe my mum was telling the truth about the annual ovine volleyball competition.
+	% Dolores: We all have hidden talents.
+	=> END
+- Can you close the path again?
+	Dolores: I'll do my best.
+	do wait(0.5)
+	set GameState.global.facts.dev_island_unlocked = false
+	# TODO: no change notification for facts :(
+	do dev_island_unlocker.refresh()
+	do wait(0.5)
+	Dolores: Talk to me again if you change your mind.
+	=> END
+
+~ beach_dev_island_intro
+Dolores: My mother used to tell me about the people who created this world.
+Dolores: I think she called them “Threadbare contributors”.
+Dolores: She said they’re still out there, even if I can’t see them... and that they always welcomed newcomers.
+Dolores: Supposedly, they created a special area for themselves, as a playground to try out new things.
+Dolores: It was called “Dev Archipelago”.
+Dolores: Do you want to see it for yourself?
+- Not right now...
+	Dolores: OK! There are lots of other places to explore.
+	Dolores: Talk to me again if you change your mind.
+	=> END
+- Yes, I'm ready!
+	Dolores: That's the spirit!
+	do wait(0.5)
+	set GameState.global.facts.dev_island_unlocked = true
+	# TODO: no change notification for facts :(
+	do dev_island_unlocker.refresh()
+	do wait(0.5)
+	Dolores: Wow, how did that bridge fix itself?
+	=> beach_go_to_dev_island
+
+~ beach_go_to_dev_island
+Dolores: Go on! Go across the bridge to Dev Archipelago.
 => END

--- a/scenes/world_map/components/frays_end.gd
+++ b/scenes/world_map/components/frays_end.gd
@@ -5,7 +5,7 @@ extends Node2D
 @onready var hud: CanvasLayer = %HUD
 @onready var eternal_loom: EternalLoom = %EternalLoom
 @onready var void_quest_unlocker: QuestProgressUnlocker = %VoidQuestUnlocker
-@onready var mythical_meadows_unlocker: QuestProgressUnlocker = %MythicalMeadowsUnlocker
+@onready var dev_island_unlocker: QuestProgressUnlocker = %DevIslandUnlocker
 @onready var exit_blocker: Area2D = %ExitBlocker
 
 

--- a/scenes/world_map/components/quest_progress_unlocker.gd
+++ b/scenes/world_map/components/quest_progress_unlocker.gd
@@ -25,23 +25,33 @@ signal toggled(satisfied: bool)
 @export var required_quests: Array[Quest]:
 	set = _set_required_quests
 
+## Keys in [member GlobalState.facts] which must be present with a truthy value
+## to unlock [member targets].
+@export var required_facts: Array[String]:
+	set = _set_required_facts
+
 
 func _set_required_quests(new_value: Array[Quest]) -> void:
 	required_quests = new_value
 	update_configuration_warnings()
 
 
+func _set_required_facts(new_value: Array[String]) -> void:
+	required_facts = new_value
+	update_configuration_warnings()
+
+
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: PackedStringArray
-	if not required_quests:
-		warnings.append("At least one required quest should be set")
+	if not required_quests and not required_facts:
+		warnings.append("At least one required quest or fact should be set")
 	return warnings
 
 
 func _ready() -> void:
 	_connect_targets()
 
-	GameState.global.completed_quests_changed.connect(_on_completed_quests_changed)
+	GameState.global.completed_quests_changed.connect(refresh)
 
 	# To ensure the targets are ready, we do a "call_deferred"
 	_initialize_toggle_state.call_deferred()
@@ -57,7 +67,7 @@ func _initialize_toggle_state() -> void:
 	initialized.emit(is_satisfied())
 
 
-func _on_completed_quests_changed() -> void:
+func refresh() -> void:
 	toggled.emit(is_satisfied())
 
 
@@ -65,6 +75,10 @@ func _on_completed_quests_changed() -> void:
 func is_satisfied() -> bool:
 	for quest: Quest in required_quests:
 		if quest not in GameState.global.completed_quests:
+			return false
+
+	for fact: String in required_facts:
+		if not GameState.global.facts.get(fact):
 			return false
 
 	return true

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -45,19 +45,15 @@
 [ext_resource type="PackedScene" uid="uid://ccpgw7k4rlmea" path="res://scenes/game_elements/props/decoration/crops/barley.tscn" id="42_eodqy"]
 [ext_resource type="PackedScene" uid="uid://c78fj5em5tpm5" path="res://scenes/game_elements/props/decoration/crops/carrot.tscn" id="42_ljovl"]
 [ext_resource type="PackedScene" uid="uid://7vg52qj6ude" path="res://scenes/world_map/components/retelling_townie.tscn" id="42_qgpx3"]
-[ext_resource type="PackedScene" uid="uid://vb5o7hh5an8j" path="res://scenes/game_elements/characters/npcs/elder/template_elder.tscn" id="43_ppslc"]
 [ext_resource type="PackedScene" uid="uid://c0104ickpm3ru" path="res://scenes/game_elements/props/decoration/flower/flower.tscn" id="45_cjmkx"]
 [ext_resource type="PackedScene" uid="uid://b2mj4jggli0ci" path="res://scenes/quests/lore_quests/quest_000/tutorial_npc/tutorial_npc.tscn" id="50_qgpx3"]
 [ext_resource type="PackedScene" uid="uid://cr65lmm5b0ueo" path="res://scenes/game_elements/characters/npcs/cat/cat.tscn" id="52_ppslc"]
 [ext_resource type="PackedScene" uid="uid://0ull24fvmhwk" path="res://scenes/game_elements/props/teleporter/teleporter.tscn" id="53_2vvub"]
 [ext_resource type="PackedScene" uid="uid://dgrrudegturnw" path="res://scenes/game_elements/characters/npcs/townie.tscn" id="54_duxxr"]
-[ext_resource type="Resource" uid="uid://doovydomib7rj" path="res://scenes/quests/lore_quests/quest_001/quest.tres" id="55_6fau3"]
 [ext_resource type="PackedScene" uid="uid://daqd67aro1o1m" path="res://scenes/game_elements/fx/time_and_weather/time_and_weather.tscn" id="55_ojao8"]
 [ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="56_ojao8"]
-[ext_resource type="PackedScene" uid="uid://bcy28nucscyep" path="res://scenes/game_elements/props/teleporter/quest_teleporter.tscn" id="58_6b07c"]
 [ext_resource type="Script" uid="uid://uaaaiviytliw" path="res://scenes/world_map/components/quest_progress_unlocker.gd" id="58_ojao8"]
 [ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="59_qgpx3"]
-[ext_resource type="Resource" uid="uid://cgr54yigkbxp3" path="res://scenes/quests/lore_quests/quest_004/quest.tres" id="59_t7c6s"]
 [ext_resource type="Resource" uid="uid://t50glay2iqhg" path="res://scenes/quests/lore_quests/quest_002/quest.tres" id="60_6b07c"]
 [ext_resource type="Script" uid="uid://0enyu5v4ra34" path="res://scenes/game_elements/props/spawn_point/components/spawn_point.gd" id="61_6b07c"]
 [ext_resource type="Script" uid="uid://b8pt5e5ec6hgx" path="res://scenes/world_map/components/cutscene_layer.gd" id="61_ulm71"]
@@ -122,7 +118,7 @@ size = Vector2(128, 128)
 size = Vector2(640, 20)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_f3823"]
-size = Vector2(64, 20)
+size = Vector2(194, 33)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_7kfal"]
 size = Vector2(20, 256)
@@ -229,21 +225,16 @@ tile_map_data = PackedByteArray("AAAAAAsADQACAAEAAAD//wsADQAAAAEAAAD//woADQAAAAE
 tile_set = ExtResource("12_f3823")
 script = ExtResource("14_f3823")
 
-[node name="MythicalMeadowsBridgeWater" type="TileMapLayer" parent="TileMapLayers" unique_id=1161187540]
-tile_map_data = PackedByteArray("AAApABwAAAAAAAAAAAApAB0AAAAAAAAAAAApAB4AAAAAAAAAAAApAB8AAAAAAAAAAAA=")
-tile_set = ExtResource("4_6ss6a")
-script = ExtResource("14_f3823")
-
-[node name="ModulateAsSkyBehavior" type="Node" parent="TileMapLayers/MythicalMeadowsBridgeWater" unique_id=1849846621 node_paths=PackedStringArray("canvas_item")]
-script = ExtResource("5_duxxr")
-canvas_item = NodePath("..")
-metadata/_custom_type_script = "uid://ctko5bdas16ah"
-
-[node name="MythicalMeadowsBridge" type="TileMapLayer" parent="TileMapLayers" unique_id=2088215943]
+[node name="DevIslandBridgeFixed" type="TileMapLayer" parent="TileMapLayers" unique_id=12215457]
 tile_map_data = PackedByteArray("AAApACAAAwAAAAMAAAApAB8AAwAAAAIAAAApAB4AAwAAAAIAAAApAB0AAwAAAAIAAAApABwAAwAAAAIAAAApABsAAwAAAAEAAAA=")
 tile_set = ExtResource("8_ns5r3")
 script = ExtResource("14_f3823")
 invert = true
+
+[node name="DevIslandBridgeBroken" type="TileMapLayer" parent="TileMapLayers" unique_id=2088215943]
+tile_map_data = PackedByteArray("AAApACAAAwAAAAMAAAApAB8AAwAAAAIAAAApAB4AAwAAAAIAAAApAB0AAwAAAAIAAAApABwAAwABAAMAAAApABsAAwAAAAEAAAA=")
+tile_set = ExtResource("8_ns5r3")
+script = ExtResource("14_f3823")
 
 [node name="OnTheGround" type="Node2D" parent="." unique_id=444049774]
 y_sort_enabled = true
@@ -437,14 +428,6 @@ eternal_loom = NodePath("../../EternalLoom")
 abandon_point = NodePath("SpawnPoint")
 
 [node name="SpawnPoint" parent="OnTheGround/NPCs/StoryQuestElder" unique_id=747361445 instance=ExtResource("37_thm8h")]
-position = Vector2(0, 64)
-
-[node name="TemplateElder" parent="OnTheGround/NPCs" unique_id=45322364 node_paths=PackedStringArray("eternal_loom", "abandon_point") instance=ExtResource("43_ppslc")]
-position = Vector2(1455, 485)
-eternal_loom = NodePath("../../EternalLoom")
-abandon_point = NodePath("SpawnPoint")
-
-[node name="SpawnPoint" parent="OnTheGround/NPCs/TemplateElder" unique_id=679077598 instance=ExtResource("37_thm8h")]
 position = Vector2(0, 64)
 
 [node name="Axeman" parent="OnTheGround/NPCs" unique_id=1020611644 instance=ExtResource("17_0a1i7")]
@@ -1415,29 +1398,25 @@ text = "LinenVille"
 position = Vector2(-270, 31)
 look_at_side_on_spawn = -1
 
-[node name="SouthPath" type="Node2D" parent="OnTheGround" unique_id=1017604237]
+[node name="DevIslandPath" type="Node2D" parent="OnTheGround" unique_id=1017604237]
 y_sort_enabled = true
 position = Vector2(2651, 1910)
 
-[node name="MythicalMeadowsUnlocker" type="Node" parent="OnTheGround/SouthPath" unique_id=974922506 node_paths=PackedStringArray("targets")]
+[node name="DevIslandUnlocker" type="Node" parent="OnTheGround/DevIslandPath" unique_id=974922506 node_paths=PackedStringArray("targets")]
 unique_name_in_owner = true
 script = ExtResource("58_ojao8")
-targets = [NodePath("../../../TileMapLayers/MythicalMeadowsBridgeWater"), NodePath("../../../TileMapLayers/MythicalMeadowsBridge")]
-required_quests = Array[ExtResource("59_qgpx3")]([ExtResource("55_6fau3"), ExtResource("60_6b07c")])
+targets = [NodePath("../../../TileMapLayers/DevIslandBridgeBroken"), NodePath("../../../TileMapLayers/DevIslandBridgeFixed")]
+required_facts = Array[String](["dev_island_unlocked"])
 
-[node name="SpawnPoint" type="Marker2D" parent="OnTheGround/SouthPath" unique_id=1082798107 groups=["spawn_point"]]
-position = Vector2(0, -151)
-script = ExtResource("61_6b07c")
-look_at_side_on_spawn = 1
-metadata/_custom_type_script = "uid://0enyu5v4ra34"
+[node name="SpawnPoint" parent="OnTheGround/DevIslandPath" unique_id=1551543155 instance=ExtResource("37_thm8h")]
+position = Vector2(4, -154)
 
-[node name="QuestTeleporter" parent="OnTheGround/SouthPath" unique_id=1779636661 node_paths=PackedStringArray("abandon_point") instance=ExtResource("58_6b07c")]
-position = Vector2(5, 7)
-quest = ExtResource("59_t7c6s")
-abandon_point = NodePath("../SpawnPoint")
+[node name="Teleporter" parent="OnTheGround/DevIslandPath" unique_id=1779636661 instance=ExtResource("53_2vvub")]
+next_scene = "uid://bhdpwut7lgfnm"
 enter_transition = 4
+exit_transition = 1
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/SouthPath/QuestTeleporter" unique_id=2120778996]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/DevIslandPath/Teleporter" unique_id=1907127794]
 shape = SubResource("RectangleShape2D_uxfrp")
 
 [node name="WestPath" type="Node2D" parent="OnTheGround" unique_id=2042146768]
@@ -1458,7 +1437,7 @@ metadata/_custom_type_script = "uid://0enyu5v4ra34"
 [node name="Teleporter" parent="OnTheGround/WestPath" unique_id=1239083044 instance=ExtResource("53_2vvub")]
 position = Vector2(-63, 704)
 next_scene = "uid://c3pi5sjiy5tlg"
-spawn_point_path = NodePath("SpawnPoint")
+spawn_point_path = NodePath("OnTheGround/FraysEndPath/SpawnPoint")
 enter_transition = 2
 exit_transition = 2
 
@@ -1503,7 +1482,7 @@ shape = SubResource("RectangleShape2D_wymun")
 debug_color = Color(0.9610079, 0, 0.5155429, 0.41960785)
 
 [node name="CollisionShape2D4" type="CollisionShape2D" parent="ExitBlocker" unique_id=1923277754]
-position = Vector2(1671, 986)
+position = Vector2(1607, 639)
 shape = SubResource("RectangleShape2D_f3823")
 debug_color = Color(0.9610079, 0, 0.5155429, 0.41960785)
 

--- a/scenes/world_map/frays_end_west.tscn
+++ b/scenes/world_map/frays_end_west.tscn
@@ -25,35 +25,24 @@
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/interact_area.gd" id="13_otyi0"]
 [ext_resource type="Texture2D" uid="uid://d2kjk3oiu5o6o" path="res://scenes/game_elements/props/buildings/house/components/House_Wool_Blue_02.png" id="13_qm4wv"]
 [ext_resource type="Resource" uid="uid://d4kkr5cifitfm" path="res://scenes/world_map/components/sigurd.dialogue" id="14_otyi0"]
+[ext_resource type="PackedScene" uid="uid://bcy28nucscyep" path="res://scenes/game_elements/props/teleporter/quest_teleporter.tscn" id="17_kxo1k"]
+[ext_resource type="Resource" uid="uid://cgr54yigkbxp3" path="res://scenes/quests/lore_quests/quest_004/quest.tres" id="18_k2nu1"]
 [ext_resource type="SpriteFrames" uid="uid://7yx2vrxg6ytx" path="res://scenes/game_elements/props/decoration/bush/components/bush_spriteframes_blue_large.tres" id="22_y5day"]
 [ext_resource type="SpriteFrames" uid="uid://c4da2w5tt3u7j" path="res://scenes/game_elements/props/decoration/bush/components/bush_spriteframes_blue_small.tres" id="23_5eaun"]
 [ext_resource type="PackedScene" uid="uid://c4vbokn408f2c" path="res://scenes/game_elements/props/decoration/sheep/sheep.tscn" id="23_8o6qx"]
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_kxo1k"]
+size = Vector2(52, 61)
+
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_8hv4q"]
 size = Vector2(128, 128)
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_kxo1k"]
-size = Vector2(52, 61)
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_jbkpe"]
+size = Vector2(128, 128)
 
 [node name="FraysEndWest" type="Node2D" unique_id=1575051889]
 metadata/_edit_vertical_guides_ = [1281.0]
 metadata/_edit_horizontal_guides_ = [772.0]
-
-[node name="Teleporter" parent="." unique_id=1779636661 instance=ExtResource("1_ovokv")]
-position = Vector2(1349, 705)
-next_scene = "uid://cufkthb25mpxy"
-spawn_point_path = NodePath("OnTheGround/WestPath/SpawnPointWestPath")
-enter_transition = 1
-exit_transition = 1
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Teleporter" unique_id=1496141142]
-shape = SubResource("RectangleShape2D_8hv4q")
-
-[node name="SpawnPoint" type="Marker2D" parent="." unique_id=1903956882 groups=["spawn_point"]]
-position = Vector2(1223, 706)
-script = ExtResource("7_q3i8o")
-look_at_side_on_spawn = -1
-metadata/_custom_type_script = "uid://0enyu5v4ra34"
 
 [node name="BackgroundMusic" parent="." unique_id=1461759951 instance=ExtResource("8_svupf")]
 stream = ExtResource("9_8d0tu")
@@ -65,7 +54,7 @@ tile_map_data = PackedByteArray("AAATAAoAAQABAAEAAAATAAkAAQABAAEAAAATAAgAAQABAAE
 tile_set = ExtResource("1_6wkkr")
 
 [node name="Paths" type="TileMapLayer" parent="TileMapLayers" unique_id=1663042993]
-tile_map_data = PackedByteArray("AAAVAAsABQACAAIAAAAVAAoABQACAAAAAAAUAAsABQABAAIAAAAUAAoABQABAAAAAAATAAsABQABAAIAAAATAAoABQABAAAAAAASAAsABQAAAAIAAAASAAoABQABAAAAAAARAAoABQABAAMAAAAQAAoABQABAAMAAAAPAAoABQABAAMAAAAOAAoABQAAAAIAAAAOAAkABQADAAEAAAAOAAgABQACAAEAAAAOAAcABQADAAEAAAAOAAYABQADAAEAAAAOAAUABQADAAEAAAANAAQABQABAAMAAAAOAAQABQACAAEAAAAMAAQABQABAAMAAAALAAQABQABAAMAAAAKAAQABQABAAMAAAAJAAQABQABAAMAAAAIAAQABQABAAMAAAAHAAQABQAAAAIAAAAHAAMABQADAAAAAAAEAAgABQAAAAEAAAAEAAcABQADAAAAAAAGAAgABQABAAMAAAAFAAgABQABAAMAAAAHAAgABQABAAMAAAAIAAgABQABAAMAAAAJAAgABQABAAMAAAAKAAgABQABAAMAAAALAAgABQABAAMAAAAMAAgABQABAAMAAAANAAgABQABAAMAAAAOAAMABQADAAAAAAAMAAIABQADAAIAAAAMAAEABQABAAAAAAALAAEABQAAAAMAAAANAAEABQACAAMAAAAQAAIABQADAAAAAAAQAAMABQADAAIAAAAEAAkABQADAAEAAAAEAAoABQAAAAIAAAAFAAoABQACAAAAAAAFAAsABQAAAAIAAAAGAAsABQACAAAAAAAIAAsABQADAAMAAAAKAAoABQADAAAAAAAKAAsABQAAAAEAAAALAAsABQABAAAAAAALAAwABQACAAIAAAAKAAwABQAAAAIAAAAMAAsABQACAAMAAAAGAAwABQADAAIAAAA=")
+tile_map_data = PackedByteArray("AAAVAAsABQACAAIAAAAVAAoABQACAAAAAAAUAAsABQABAAIAAAAUAAoABQABAAAAAAATAAsABQABAAIAAAATAAoABQABAAAAAAASAAsABQAAAAIAAAASAAoABQABAAAAAAARAAoABQABAAMAAAAQAAoABQABAAMAAAAPAAoABQABAAMAAAAOAAoABQAAAAIAAAAOAAkABQADAAEAAAAOAAgABQACAAEAAAAOAAcABQADAAEAAAAOAAYABQADAAEAAAAOAAUABQADAAEAAAANAAQABQABAAMAAAAOAAQABQACAAEAAAAMAAQABQABAAMAAAALAAQABQABAAMAAAAKAAQABQABAAMAAAAJAAQABQABAAMAAAAIAAQABQABAAMAAAAHAAQABQAAAAIAAAAHAAMABQADAAAAAAAEAAgABQABAAEAAAAEAAcABQADAAAAAAAGAAgABQABAAMAAAAFAAgABQABAAMAAAAHAAgABQABAAMAAAAIAAgABQABAAMAAAAJAAgABQABAAMAAAAKAAgABQABAAMAAAALAAgABQABAAMAAAAMAAgABQABAAMAAAANAAgABQABAAMAAAAOAAMABQADAAAAAAAMAAIABQADAAIAAAAMAAEABQABAAAAAAALAAEABQAAAAMAAAANAAEABQACAAMAAAAQAAIABQADAAAAAAAQAAMABQADAAIAAAAEAAkABQADAAEAAAAEAAoABQAAAAIAAAAFAAoABQACAAAAAAAFAAsABQAAAAIAAAAGAAsABQACAAAAAAAIAAsABQADAAMAAAAKAAoABQADAAAAAAAKAAsABQAAAAEAAAALAAsABQABAAAAAAALAAwABQACAAIAAAAKAAwABQAAAAIAAAAMAAsABQACAAMAAAAGAAwABQADAAIAAAD1/wgABQAAAAMAAAD2/wgABQABAAMAAAD3/wgABQABAAMAAAD4/wgABQABAAMAAAD5/wgABQABAAMAAAD6/wgABQABAAMAAAD7/wgABQABAAMAAAD8/wgABQABAAMAAAD9/wgABQABAAMAAAD+/wgABQABAAMAAAD//wgABQABAAMAAAAAAAgABQABAAMAAAABAAgABQABAAMAAAACAAgABQABAAMAAAADAAgABQABAAMAAAA=")
 tile_set = ExtResource("1_6wkkr")
 
 [node name="Paths2" type="TileMapLayer" parent="TileMapLayers" unique_id=1400951136]
@@ -92,7 +81,7 @@ tile_set = ExtResource("1_6wkkr")
 y_sort_enabled = true
 
 [node name="Player" parent="OnTheGround" unique_id=296354958 instance=ExtResource("3_7dntp")]
-position = Vector2(1216, 720)
+position = Vector2(622, 429)
 player_name = "StoryWeaver"
 sprite_frames = ExtResource("4_ltemt")
 
@@ -158,10 +147,51 @@ debug_color = Color(0.600391, 0.54335, 0, 0.42)
 [node name="Marker" type="Marker2D" parent="OnTheGround/Sigurd/InteractArea" unique_id=2031504100]
 position = Vector2(0, -100)
 
-[node name="Sign" parent="OnTheGround" unique_id=1579530966 instance=ExtResource("6_eitnf")]
+[node name="FraysEndPath" type="Node2D" parent="OnTheGround" unique_id=1315134038]
+y_sort_enabled = true
+
+[node name="Teleporter" parent="OnTheGround/FraysEndPath" unique_id=1779636661 instance=ExtResource("1_ovokv")]
+position = Vector2(1349, 705)
+next_scene = "uid://cufkthb25mpxy"
+spawn_point_path = NodePath("OnTheGround/WestPath/SpawnPointWestPath")
+enter_transition = 1
+exit_transition = 1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/FraysEndPath/Teleporter" unique_id=1496141142]
+shape = SubResource("RectangleShape2D_8hv4q")
+
+[node name="SpawnPoint" type="Marker2D" parent="OnTheGround/FraysEndPath" unique_id=1903956882 groups=["spawn_point"]]
+position = Vector2(1223, 706)
+script = ExtResource("7_q3i8o")
+look_at_side_on_spawn = -1
+metadata/_custom_type_script = "uid://0enyu5v4ra34"
+
+[node name="Sign" parent="OnTheGround/FraysEndPath" unique_id=1579530966 instance=ExtResource("6_eitnf")]
 position = Vector2(1171, 621)
 direction = 1
 text = "Eternal Loom"
+
+[node name="MythicalMeadowsPath" type="Node2D" parent="OnTheGround" unique_id=1092443977]
+y_sort_enabled = true
+position = Vector2(-280, 563)
+
+[node name="Sign" parent="OnTheGround/MythicalMeadowsPath" unique_id=20492704 instance=ExtResource("6_eitnf")]
+position = Vector2(186, -62)
+text = "Mythical Meadows"
+
+[node name="SpawnPoint" type="Marker2D" parent="OnTheGround/MythicalMeadowsPath" unique_id=634037126 groups=["spawn_point"]]
+position = Vector2(296, -19)
+script = ExtResource("7_q3i8o")
+look_at_side_on_spawn = 1
+metadata/_custom_type_script = "uid://0enyu5v4ra34"
+
+[node name="QuestTeleporter" parent="OnTheGround/MythicalMeadowsPath" unique_id=960490707 node_paths=PackedStringArray("abandon_point") instance=ExtResource("17_kxo1k")]
+quest = ExtResource("18_k2nu1")
+abandon_point = NodePath("../SpawnPoint")
+enter_transition = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/MythicalMeadowsPath/QuestTeleporter" unique_id=1742306982]
+shape = SubResource("RectangleShape2D_jbkpe")
 
 [node name="Houses" type="Node2D" parent="OnTheGround" unique_id=1443466890]
 y_sort_enabled = true
@@ -217,6 +247,8 @@ scale = Vector2(1.0253335, 1.0274945)
 
 [node name="Forest" type="StaticBody2D" parent="OnTheGround" unique_id=2126418376]
 y_sort_enabled = true
+collision_layer = 16
+collision_mask = 0
 
 [node name="AreaFiller" type="Node" parent="OnTheGround/Forest" unique_id=940815448]
 script = ExtResource("7_ltemt")
@@ -225,12 +257,11 @@ sprite_frames = Array[SpriteFrames]([ExtResource("9_htidp"), ExtResource("10_wps
 metadata/_custom_type_script = "uid://bdhjixygupit1"
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="OnTheGround/Forest" unique_id=1547085708]
-polygon = PackedVector2Array(1192, -36, 1192, -542, -688, -554, -688, 763, 82, 753, 150, 465, 241, 214, 507, -48)
+polygon = PackedVector2Array(1192, -36, 1192, -542, -688, -554, -701, 511, 99, 483, 241, 214, 507, -48)
 
-[node name="Tree" parent="OnTheGround/Forest" unique_id=778491064 instance=ExtResource("8_wf3xu")]
-position = Vector2(159.66095, 438.35275)
-scale = Vector2(0.86004066, 0.8585061)
-sprite_frames = ExtResource("9_htidp")
+[node name="CollisionPolygon2D2" type="CollisionPolygon2D" parent="OnTheGround/Forest" unique_id=1574986777]
+position = Vector2(-3, 0)
+polygon = PackedVector2Array(-689, 634, -688, 763, 83, 772, -143.73969, 629.2645)
 
 [node name="Tree2" parent="OnTheGround/Forest" unique_id=1938107775 instance=ExtResource("8_wf3xu")]
 position = Vector2(63.55966, 373.05328)
@@ -267,19 +298,9 @@ position = Vector2(200.88316, 123.31611)
 scale = Vector2(1.0491804, 1.0788546)
 sprite_frames = ExtResource("9_htidp")
 
-[node name="Tree10" parent="OnTheGround/Forest" unique_id=735177379 instance=ExtResource("8_wf3xu")]
-position = Vector2(5.2201004, 519.5328)
-scale = Vector2(1.0297824, 1.111391)
-sprite_frames = ExtResource("9_htidp")
-
 [node name="Tree11" parent="OnTheGround/Forest" unique_id=715555394 instance=ExtResource("8_wf3xu")]
 position = Vector2(-25.772491, 401.56238)
 scale = Vector2(0.9176795, 0.86824113)
-
-[node name="Tree12" parent="OnTheGround/Forest" unique_id=1185100400 instance=ExtResource("8_wf3xu")]
-position = Vector2(121.005424, 519.8536)
-scale = Vector2(0.8746478, 0.85931814)
-sprite_frames = ExtResource("9_htidp")
 
 [node name="Tree13" parent="OnTheGround/Forest" unique_id=991622759 instance=ExtResource("8_wf3xu")]
 position = Vector2(-4.3438034, 231.73775)
@@ -290,29 +311,10 @@ sprite_frames = ExtResource("9_htidp")
 position = Vector2(-106.33467, 394.45755)
 scale = Vector2(1.1203755, 1.1090813)
 
-[node name="Tree15" parent="OnTheGround/Forest" unique_id=562926490 instance=ExtResource("8_wf3xu")]
-position = Vector2(60.95576, 569.45557)
-scale = Vector2(0.9682841, 1.0287123)
-sprite_frames = ExtResource("9_htidp")
-
 [node name="Tree16" parent="OnTheGround/Forest" unique_id=1013473017 instance=ExtResource("8_wf3xu")]
 position = Vector2(-56.364113, 295.68915)
 scale = Vector2(0.98004043, 1.0875492)
 sprite_frames = ExtResource("9_htidp")
-
-[node name="Tree17" parent="OnTheGround/Forest" unique_id=1283098914 instance=ExtResource("8_wf3xu")]
-position = Vector2(177.71082, 376.40372)
-scale = Vector2(0.8049863, 0.8435616)
-sprite_frames = ExtResource("9_htidp")
-
-[node name="Tree18" parent="OnTheGround/Forest" unique_id=1299769062 instance=ExtResource("8_wf3xu")]
-position = Vector2(-2.5057487, 660.71783)
-scale = Vector2(1.1869736, 1.1872046)
-sprite_frames = ExtResource("9_htidp")
-
-[node name="Tree19" parent="OnTheGround/Forest" unique_id=1107992244 instance=ExtResource("8_wf3xu")]
-position = Vector2(113.17438, 611.66583)
-scale = Vector2(1.0590259, 0.9668085)
 
 [node name="Tree20" parent="OnTheGround/Forest" unique_id=1207124401 instance=ExtResource("8_wf3xu")]
 position = Vector2(262.2728, 88.045944)
@@ -332,11 +334,6 @@ scale = Vector2(1.1271391, 1.1321772)
 position = Vector2(67.78522, 134.8357)
 scale = Vector2(0.81823385, 0.83547723)
 
-[node name="Tree24" parent="OnTheGround/Forest" unique_id=730022136 instance=ExtResource("8_wf3xu")]
-position = Vector2(74.708595, 688.29376)
-scale = Vector2(1.1668999, 1.1999096)
-sprite_frames = ExtResource("9_htidp")
-
 [node name="Tree25" parent="OnTheGround/Forest" unique_id=1189821976 instance=ExtResource("8_wf3xu")]
 position = Vector2(-79.49761, 226.4905)
 scale = Vector2(0.9658169, 0.961374)
@@ -353,10 +350,6 @@ scale = Vector2(0.9012564, 0.9869385)
 [node name="Tree28" parent="OnTheGround/Forest" unique_id=1538345739 instance=ExtResource("8_wf3xu")]
 position = Vector2(-181.0192, 283.941)
 scale = Vector2(0.95756996, 0.88214576)
-
-[node name="Tree29" parent="OnTheGround/Forest" unique_id=891701431 instance=ExtResource("8_wf3xu")]
-position = Vector2(-90.43895, 574.3589)
-scale = Vector2(0.9726088, 1.0570283)
 
 [node name="Tree30" parent="OnTheGround/Forest" unique_id=2047740994 instance=ExtResource("8_wf3xu")]
 position = Vector2(-185.50992, 155.80466)
@@ -376,18 +369,9 @@ sprite_frames = ExtResource("9_htidp")
 position = Vector2(214.44485, 188.53206)
 scale = Vector2(0.9207478, 0.8952641)
 
-[node name="Tree34" parent="OnTheGround/Forest" unique_id=821865987 instance=ExtResource("8_wf3xu")]
-position = Vector2(-27.159573, 591.47754)
-scale = Vector2(0.96917874, 0.9369299)
-
 [node name="Tree35" parent="OnTheGround/Forest" unique_id=1275780068 instance=ExtResource("8_wf3xu")]
 position = Vector2(-270.43466, 248.71716)
 scale = Vector2(0.9640548, 1.0460645)
-sprite_frames = ExtResource("9_htidp")
-
-[node name="Tree36" parent="OnTheGround/Forest" unique_id=440892032 instance=ExtResource("8_wf3xu")]
-position = Vector2(-92.34378, 659.5833)
-scale = Vector2(0.93796676, 0.9271841)
 sprite_frames = ExtResource("9_htidp")
 
 [node name="Tree37" parent="OnTheGround/Forest" unique_id=1841828016 instance=ExtResource("8_wf3xu")]
@@ -419,7 +403,7 @@ scale = Vector2(0.927422, 0.9725865)
 sprite_frames = ExtResource("9_htidp")
 
 [node name="Tree43" parent="OnTheGround/Forest" unique_id=1975478779 instance=ExtResource("8_wf3xu")]
-position = Vector2(-195.85342, 659.556)
+position = Vector2(-237, 475.00006)
 scale = Vector2(1.1427575, 1.0466622)
 
 [node name="Tree44" parent="OnTheGround/Forest" unique_id=279827484 instance=ExtResource("8_wf3xu")]
@@ -474,19 +458,10 @@ scale = Vector2(1.0417728, 1.044542)
 position = Vector2(75.757324, -188.97379)
 scale = Vector2(1.1672541, 1.1650103)
 
-[node name="Tree56" parent="OnTheGround/Forest" unique_id=14323794 instance=ExtResource("8_wf3xu")]
-position = Vector2(-202.1153, 533.60596)
-scale = Vector2(0.9136242, 0.92887527)
-sprite_frames = ExtResource("9_htidp")
-
 [node name="Tree57" parent="OnTheGround/Forest" unique_id=1635512029 instance=ExtResource("8_wf3xu")]
 position = Vector2(-205.91428, 216.81686)
 scale = Vector2(1.0478795, 1.1543453)
 sprite_frames = ExtResource("9_htidp")
-
-[node name="Tree58" parent="OnTheGround/Forest" unique_id=366609224 instance=ExtResource("8_wf3xu")]
-position = Vector2(-292.8856, 568.73285)
-scale = Vector2(1.1434621, 1.1572684)
 
 [node name="Tree59" parent="OnTheGround/Forest" unique_id=55067559 instance=ExtResource("8_wf3xu")]
 position = Vector2(-322.3988, 148.60309)
@@ -543,16 +518,12 @@ position = Vector2(-461.54102, 339.81036)
 scale = Vector2(1.1469421, 1.1706853)
 sprite_frames = ExtResource("9_htidp")
 
-[node name="Tree71" parent="OnTheGround/Forest" unique_id=138570486 instance=ExtResource("8_wf3xu")]
-position = Vector2(-160.01115, 583.8489)
-scale = Vector2(0.91745675, 0.85779595)
-
 [node name="Tree72" parent="OnTheGround/Forest" unique_id=954196433 instance=ExtResource("8_wf3xu")]
 position = Vector2(247.73032, -166.29639)
 scale = Vector2(0.81203824, 0.89562)
 
 [node name="Tree73" parent="OnTheGround/Forest" unique_id=596357014 instance=ExtResource("8_wf3xu")]
-position = Vector2(-278.59, 662.2422)
+position = Vector2(-278.99997, 662)
 scale = Vector2(0.9450697, 1.0143555)
 sprite_frames = ExtResource("9_htidp")
 
@@ -608,10 +579,6 @@ scale = Vector2(0.8261287, 0.8644027)
 [node name="Tree85" parent="OnTheGround/Forest" unique_id=386394853 instance=ExtResource("8_wf3xu")]
 position = Vector2(59.94814, -252.675)
 scale = Vector2(1.0823563, 0.9916571)
-
-[node name="Tree86" parent="OnTheGround/Forest" unique_id=2147367693 instance=ExtResource("8_wf3xu")]
-position = Vector2(-389.206, 508.98914)
-scale = Vector2(0.90620834, 0.99545646)
 
 [node name="Tree87" parent="OnTheGround/Forest" unique_id=1146670212 instance=ExtResource("8_wf3xu")]
 position = Vector2(-534.2535, 412.56204)
@@ -775,10 +742,6 @@ position = Vector2(294.22266, -468.33685)
 scale = Vector2(1.019808, 1.1055074)
 sprite_frames = ExtResource("9_htidp")
 
-[node name="Tree123" parent="OnTheGround/Forest" unique_id=1295176787 instance=ExtResource("8_wf3xu")]
-position = Vector2(-389.76965, 619.55023)
-scale = Vector2(1.1142632, 1.1170062)
-
 [node name="Tree124" parent="OnTheGround/Forest" unique_id=1337864966 instance=ExtResource("8_wf3xu")]
 position = Vector2(651.5775, -131.62259)
 scale = Vector2(0.863071, 0.8595984)
@@ -819,11 +782,6 @@ sprite_frames = ExtResource("9_htidp")
 position = Vector2(202.7413, -357.45203)
 scale = Vector2(0.9685279, 1.0547076)
 
-[node name="Tree133" parent="OnTheGround/Forest" unique_id=975836812 instance=ExtResource("8_wf3xu")]
-position = Vector2(-487.37463, 558.6925)
-scale = Vector2(0.88220054, 0.9762977)
-sprite_frames = ExtResource("9_htidp")
-
 [node name="Tree134" parent="OnTheGround/Forest" unique_id=682232896 instance=ExtResource("8_wf3xu")]
 position = Vector2(603.9319, -344.06586)
 scale = Vector2(1.0129429, 0.99818194)
@@ -841,11 +799,6 @@ sprite_frames = ExtResource("9_htidp")
 position = Vector2(620.1231, -189.00049)
 scale = Vector2(1.1427251, 1.1419003)
 
-[node name="Tree138" parent="OnTheGround/Forest" unique_id=2086202020 instance=ExtResource("8_wf3xu")]
-position = Vector2(-595.51434, 552.19385)
-scale = Vector2(0.7385148, 0.80113375)
-sprite_frames = ExtResource("9_htidp")
-
 [node name="Tree139" parent="OnTheGround/Forest" unique_id=2075789172 instance=ExtResource("8_wf3xu")]
 position = Vector2(-412.5889, -68.88965)
 scale = Vector2(0.8093304, 0.85747534)
@@ -854,10 +807,6 @@ scale = Vector2(0.8093304, 0.85747534)
 position = Vector2(468.95737, -278.5318)
 scale = Vector2(0.76800364, 0.80820346)
 sprite_frames = ExtResource("9_htidp")
-
-[node name="Tree141" parent="OnTheGround/Forest" unique_id=742426867 instance=ExtResource("8_wf3xu")]
-position = Vector2(-552.4863, 619.2237)
-scale = Vector2(1.0980862, 1.0047947)
 
 [node name="Tree142" parent="OnTheGround/Forest" unique_id=214794748 instance=ExtResource("8_wf3xu")]
 position = Vector2(461.70886, -397.9583)
@@ -884,11 +833,6 @@ scale = Vector2(0.902344, 0.84449595)
 [node name="Tree147" parent="OnTheGround/Forest" unique_id=1992823677 instance=ExtResource("8_wf3xu")]
 position = Vector2(-461.91858, 108.52306)
 scale = Vector2(1.0462632, 1.0540217)
-sprite_frames = ExtResource("9_htidp")
-
-[node name="Tree148" parent="OnTheGround/Forest" unique_id=513534376 instance=ExtResource("8_wf3xu")]
-position = Vector2(-631.00024, 621.80365)
-scale = Vector2(0.83060926, 0.85345364)
 sprite_frames = ExtResource("9_htidp")
 
 [node name="Tree149" parent="OnTheGround/Forest" unique_id=1316426674 instance=ExtResource("8_wf3xu")]
@@ -979,10 +923,6 @@ sprite_frames = ExtResource("9_htidp")
 [node name="Tree168" parent="OnTheGround/Forest" unique_id=295699534 instance=ExtResource("8_wf3xu")]
 position = Vector2(-226.40677, -323.12476)
 scale = Vector2(1.1661963, 1.1495479)
-
-[node name="Tree169" parent="OnTheGround/Forest" unique_id=1113283464 instance=ExtResource("8_wf3xu")]
-position = Vector2(-671.32794, 561.1299)
-scale = Vector2(0.88806766, 0.9821287)
 
 [node name="Tree170" parent="OnTheGround/Forest" unique_id=1441880985 instance=ExtResource("8_wf3xu")]
 position = Vector2(-299.95956, -317.12558)
@@ -1460,6 +1400,15 @@ scale = Vector2(1.0555549, 1.0745053)
 position = Vector2(-687.12573, -241.89369)
 scale = Vector2(0.9058032, 0.91305906)
 sprite_frames = ExtResource("9_htidp")
+
+[node name="Tree17" parent="OnTheGround/Forest" unique_id=1283098914 instance=ExtResource("8_wf3xu")]
+position = Vector2(177.71082, 376.40372)
+scale = Vector2(0.8049863, 0.8435616)
+sprite_frames = ExtResource("9_htidp")
+
+[node name="Tree86" parent="OnTheGround/Forest" unique_id=2147367693 instance=ExtResource("8_wf3xu")]
+position = Vector2(-382, 481)
+scale = Vector2(0.90620834, 0.99545646)
 
 [node name="Fauna" type="Node2D" parent="OnTheGround" unique_id=785049589]
 y_sort_enabled = true


### PR DESCRIPTION
Move the Mythical Meadows quest teleporter into Fray's End West, on a
new path through the forest further west. The path from Fray's End to
Fray's End West is already blocked by the same conditions (both Void and
Musician quests completed). Adjust the elder's dialogue accordingly.

Repurpose the bridge on the beach as the route to Dev Archipelago.
Adjust Dolores' dialogue so that talking to her locks and unlocks the
path. Implement this by setting a global fact. (I discovered that there
is no change notification for facts, which I decided to work around
rather than fixing here.)

Block the player from reaching the beach if they're at the end of a
quest and need to go to the loom.

Remove the Template Elder from Fray's End, since he's in Dev
Archipelago.

Resolves https://github.com/endlessm/threadbare/issues/2265

