### PR TITLE
sqckck: Don't put version number into zip file name

### DIFF
--- a/tools/sqckck.sh
+++ b/tools/sqckck.sh
@@ -42,7 +42,7 @@ echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
 echo "::endgroup::"
 
 echo "::group::Creating zip file"
-git archive --format=zip --prefix=threadbare-storyquest/ --output="threadbare-storyquest-$VERSION.zip" @
+git archive --format=zip --prefix=threadbare-storyquest/ --output="threadbare-storyquest-kit.zip" @
 echo "::endgroup::"
 
-echo "zip_file=threadbare-storyquest-$VERSION.zip" >> "$GITHUB_OUTPUT"
+echo "zip_file=threadbare-storyquest-kit.zip" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
sqckck: Don't put version number into zip file name

By using a predictable filename for every release, we can link to the
kit for the latest release:

https://github.com/endlessm/threadbare/releases/latest/download/threadbare-storyquest-kit.zip

Resolves https://github.com/endlessm/threadbare/issues/2661
