### PR TITLE
Storybook: list of StoryQuests aligns properly regardless of title lengths

### DIFF
--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -23,7 +23,6 @@ atlas = ExtResource("10_p0vqm")
 region = Rect2(576, 576, 64, 64)
 
 [node name="Storybook" type="CanvasLayer" unique_id=438542807]
-layer = 10
 script = ExtResource("1_gw8hn")
 quests = Array[ExtResource("3_21r2o")]([ExtResource("5_ywp77")])
 
@@ -103,7 +102,6 @@ layout_mode = 2
 
 [node name="LeftQuestList" type="VBoxContainer" parent="VBoxContainer/CenterContainer/StoryBookContent/MarginContainer/QuestContainer/BookSpread/LeftPage/VBoxContainer" unique_id=887510218]
 unique_name_in_owner = true
-custom_maximum_size = Vector2(450, -1)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 6
@@ -119,7 +117,6 @@ layout_mode = 2
 
 [node name="RightQuestList" type="VBoxContainer" parent="VBoxContainer/CenterContainer/StoryBookContent/MarginContainer/QuestContainer/BookSpread/RightPage/VBoxContainer" unique_id=1110923687]
 unique_name_in_owner = true
-custom_maximum_size = Vector2(450, -1)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -23,6 +23,7 @@ atlas = ExtResource("10_p0vqm")
 region = Rect2(576, 576, 64, 64)
 
 [node name="Storybook" type="CanvasLayer" unique_id=438542807]
+layer = 10
 script = ExtResource("1_gw8hn")
 quests = Array[ExtResource("3_21r2o")]([ExtResource("5_ywp77")])
 
@@ -71,9 +72,9 @@ layout_mode = 1
 anchors_preset = -1
 anchor_left = 0.5
 anchor_right = 0.5
-offset_left = -105.0
+offset_left = -413.5
 offset_top = -191.0
-offset_right = 333.0
+offset_right = 641.5
 offset_bottom = 361.0
 grow_horizontal = 2
 grow_vertical = 2
@@ -88,32 +89,40 @@ horizontal_scroll_mode = 0
 [node name="BookSpread" type="HBoxContainer" parent="VBoxContainer/CenterContainer/StoryBookContent/MarginContainer/QuestContainer" unique_id=1606272031]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_constants/separation = 55
+theme_override_constants/separation = 10
 
 [node name="LeftPage" type="MarginContainer" parent="VBoxContainer/CenterContainer/StoryBookContent/MarginContainer/QuestContainer/BookSpread" unique_id=103149296]
+custom_minimum_size = Vector2(400, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/margin_left = 40
+theme_override_constants/margin_right = 0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/CenterContainer/StoryBookContent/MarginContainer/QuestContainer/BookSpread/LeftPage" unique_id=434752580]
 layout_mode = 2
 
 [node name="LeftQuestList" type="VBoxContainer" parent="VBoxContainer/CenterContainer/StoryBookContent/MarginContainer/QuestContainer/BookSpread/LeftPage/VBoxContainer" unique_id=887510218]
 unique_name_in_owner = true
+custom_maximum_size = Vector2(450, -1)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 6
 
 [node name="RightPage" type="MarginContainer" parent="VBoxContainer/CenterContainer/StoryBookContent/MarginContainer/QuestContainer/BookSpread" unique_id=1947571017]
+custom_minimum_size = Vector2(400, 0)
 layout_mode = 2
 size_flags_horizontal = 3
+theme_override_constants/margin_left = 40
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/CenterContainer/StoryBookContent/MarginContainer/QuestContainer/BookSpread/RightPage" unique_id=687423957]
 layout_mode = 2
 
 [node name="RightQuestList" type="VBoxContainer" parent="VBoxContainer/CenterContainer/StoryBookContent/MarginContainer/QuestContainer/BookSpread/RightPage/VBoxContainer" unique_id=1110923687]
 unique_name_in_owner = true
+custom_maximum_size = Vector2(450, -1)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 
 [node name="StorybookPage" parent="VBoxContainer/CenterContainer/StoryBookContent" unique_id=1375899951 instance=ExtResource("3_n2i2u")]
 unique_name_in_owner = true


### PR DESCRIPTION
I updated my previous storybook work to ensure that the proper page layout isn't dependent on the StoryQuest title lengths.

Resolves #2617