### PR TITLE
Update hint sign for spawnpoints in teleporter test

### DIFF
--- a/scenes/dev/basics/teleporter/teleporter_test_2.tscn
+++ b/scenes/dev/basics/teleporter/teleporter_test_2.tscn
@@ -119,14 +119,15 @@ two points in the same scene!"
 
 [node name="Sign3" parent="OnTheGround" unique_id=284069038 instance=ExtResource("10_x52rp")]
 position = Vector2(968, -351)
-text = "Speaking of transitions...
-We only use them if the spawn point is
-not visible from the teleporter."
+text = "We only give a teleporter a transition if
+ the spawn point is not visible when using it."
 
 [node name="Sign4" parent="OnTheGround" unique_id=408891707 instance=ExtResource("10_x52rp")]
 position = Vector2(1489, 356)
 text = "Each teleporter has a SpawnPoint
-that it moves the Player to."
+that it moves the Player to.
+Add a spawn_point.tscn to your scene and then select it
+from the teleporter's \"Spawn Point Path\" dropdown in the inspector."
 
 [node name="Sign5" parent="OnTheGround" unique_id=2091669521 instance=ExtResource("10_x52rp")]
 position = Vector2(458, 42)

--- a/scenes/dev/basics/teleporter/teleporter_test_2.tscn
+++ b/scenes/dev/basics/teleporter/teleporter_test_2.tscn
@@ -124,8 +124,8 @@ text = "We only give a teleporter a transition if
 
 [node name="Sign4" parent="OnTheGround" unique_id=408891707 instance=ExtResource("10_x52rp")]
 position = Vector2(1489, 356)
-text = "Each teleporter has a SpawnPoint
-that it moves the Player to.
+text = "Each teleporter can reference a SpawnPoint
+as a target to move the Player to.
 Add a spawn_point.tscn to your scene and then select it
 from the teleporter's \"Spawn Point Path\" dropdown in the inspector."
 


### PR DESCRIPTION
Explain that a `spawn_point.tscn` scene must be added to your scene separately and then pointed to by the teleporter. Based on feedback from Justin, it was unclear that spawn points are not part of the teleporter logic and exist as their own scene/script.

Also, reword the hint sign regarding transitions for teleporters with spawn points out of visible range.