### PR TITLE
Debug Settings: Add button to open current scene in editor

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -19,6 +19,7 @@ path = [
 	"addons/sprite_frames_exported_textures/plugin.cfg",
 	"addons/storyquest_bootstrap/plugin.cfg",
 	"addons/storyquest_bootstrap/*.tscn",
+	"addons/threadbare_editor/plugin.cfg",
 	"addons/threadbare_project_settings/plugin.cfg",
 	"assets/**/*.tres",
 	"locale/*.po",

--- a/addons/threadbare_editor/plugin.cfg
+++ b/addons/threadbare_editor/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="ThreadbareEditor"
+description="Adds an editor debugger."
+author="The Threadbare Authors"
+version=""
+script="plugin.gd"

--- a/addons/threadbare_editor/plugin.gd
+++ b/addons/threadbare_editor/plugin.gd
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name ThreadbareEditorPlugin
+extends EditorPlugin
+
+const ThreadbareDebugger := preload("res://addons/threadbare_editor/threadbare_debugger.gd")
+
+var threadbare_debugger: EditorDebuggerPlugin
+
+
+func _enter_tree() -> void:
+	threadbare_debugger = ThreadbareDebugger.new()
+	add_debugger_plugin(threadbare_debugger)
+
+
+func _exit_tree() -> void:
+	if threadbare_debugger:
+		remove_debugger_plugin(threadbare_debugger)
+		threadbare_debugger = null

--- a/addons/threadbare_editor/plugin.gd.uid
+++ b/addons/threadbare_editor/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://nk1e02agjxs1

--- a/addons/threadbare_editor/threadbare_debugger.gd
+++ b/addons/threadbare_editor/threadbare_debugger.gd
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+extends EditorDebuggerPlugin
+## Handles Threadbare specific messages sent by the running game through [EngineDebugger].
+
+## Prefix of the messages handled by this plugin.
+const CAPTURE_PREFIX := "threadbare_debugger"
+
+
+func _has_capture(capture: String) -> bool:
+	return capture == CAPTURE_PREFIX
+
+
+func _capture(message: String, data: Array, _session_id: int) -> bool:
+	# The messages arrive with the prefix.
+	match message.trim_prefix(CAPTURE_PREFIX + ":"):
+		"open_scene_file":
+			if data.is_empty():
+				push_error("open_scene_file: expected a scene path as first argument.")
+				return true
+			var file_path := data[0] as String
+			if file_path and file_path.ends_with(".tscn"):
+				EditorInterface.open_scene_from_path(file_path)
+			return true
+	return false

--- a/addons/threadbare_editor/threadbare_debugger.gd
+++ b/addons/threadbare_editor/threadbare_debugger.gd
@@ -22,5 +22,6 @@ func _capture(message: String, data: Array, _session_id: int) -> bool:
 			var file_path := data[0] as String
 			if file_path and file_path.ends_with(".tscn"):
 				EditorInterface.open_scene_from_path(file_path)
+				EditorInterface.set_main_screen_editor("2D")
 			return true
 	return false

--- a/addons/threadbare_editor/threadbare_debugger.gd.uid
+++ b/addons/threadbare_editor/threadbare_debugger.gd.uid
@@ -1,0 +1,1 @@
+uid://devrxp170k4f1

--- a/project.godot
+++ b/project.godot
@@ -73,7 +73,7 @@ movie_writer/movie_file="user://recording.ogv"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/dialogue_manager/plugin.cfg", "res://addons/git_lfs_checker/plugin.cfg", "res://addons/input_helper/plugin.cfg", "res://addons/phantom_camera/plugin.cfg", "res://addons/sprite_frames_exported_textures/plugin.cfg", "res://addons/storyquest_bootstrap/plugin.cfg", "res://addons/threadbare_credits/plugin.cfg", "res://addons/threadbare_git_describe/plugin.cfg", "res://addons/threadbare_project_settings/plugin.cfg")
+enabled=PackedStringArray("res://addons/dialogue_manager/plugin.cfg", "res://addons/git_lfs_checker/plugin.cfg", "res://addons/input_helper/plugin.cfg", "res://addons/phantom_camera/plugin.cfg", "res://addons/sprite_frames_exported_textures/plugin.cfg", "res://addons/storyquest_bootstrap/plugin.cfg", "res://addons/threadbare_credits/plugin.cfg", "res://addons/threadbare_editor/plugin.cfg", "res://addons/threadbare_git_describe/plugin.cfg", "res://addons/threadbare_project_settings/plugin.cfg")
 
 [file_customization]
 

--- a/scenes/menus/debug/components/open_in_editor_button.gd
+++ b/scenes/menus/debug/components/open_in_editor_button.gd
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+extends Button
+
+
+func _ready() -> void:
+	# This button only makes sense if the game is ran from the editor.
+	visible = OS.has_feature("editor")
+	if not visible:
+		queue_free()
+
+
+func _on_pressed() -> void:
+	var file_path := get_tree().current_scene.scene_file_path
+	if EngineDebugger.is_active():
+		EngineDebugger.send_message("threadbare_debugger:open_scene_file", [file_path])

--- a/scenes/menus/debug/components/open_in_editor_button.gd.uid
+++ b/scenes/menus/debug/components/open_in_editor_button.gd.uid
@@ -1,0 +1,1 @@
+uid://c4hqcgr7o8p36

--- a/scenes/menus/debug/debug_settings.tscn
+++ b/scenes/menus/debug/debug_settings.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="2_back"]
 [ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="3_arrow"]
+[ext_resource type="Script" uid="uid://c4hqcgr7o8p36" path="res://scenes/menus/debug/components/open_in_editor_button.gd" id="3_rg3mx"]
 [ext_resource type="Shortcut" uid="uid://c5pwgp1w8p3y1" path="res://scenes/ui_elements/shortcuts/back_shortcut.tres" id="3_xtet4"]
 [ext_resource type="PackedScene" uid="uid://bdbgcqsts7sk2" path="res://scenes/menus/debug/components/debug_completed_quests.tscn" id="4_cq"]
 [ext_resource type="PackedScene" uid="uid://bdbgpa6vsm70w" path="res://scenes/menus/debug/components/debug_player_abilities.tscn" id="5_pa"]
@@ -62,6 +63,15 @@ size_flags_horizontal = 4
 theme_type_variation = &"FlatButton"
 text = "Player Abilities"
 
+[node name="OpenInEditorButton" type="Button" parent="TabContainer/DebugMenu/VBoxContainer" unique_id=2103419214]
+layout_mode = 2
+size_flags_horizontal = 4
+theme_type_variation = &"FlatButton"
+shortcut = ExtResource("3_xtet4")
+text = "Open Current Scene In Editor"
+flat = true
+script = ExtResource("3_rg3mx")
+
 [node name="BackButton" type="Button" parent="TabContainer/DebugMenu/VBoxContainer" unique_id=1100040008]
 unique_name_in_owner = true
 layout_mode = 2
@@ -86,6 +96,7 @@ metadata/_tab_index = 2
 
 [connection signal="pressed" from="TabContainer/DebugMenu/VBoxContainer/CompletedQuestsButton" to="TabContainer/CompletedQuests" method="show"]
 [connection signal="pressed" from="TabContainer/DebugMenu/VBoxContainer/PlayerAbilitiesButton" to="TabContainer/PlayerAbilities" method="show"]
+[connection signal="pressed" from="TabContainer/DebugMenu/VBoxContainer/OpenInEditorButton" to="TabContainer/DebugMenu/VBoxContainer/OpenInEditorButton" method="_on_pressed"]
 [connection signal="back" from="TabContainer/CompletedQuests" to="TabContainer/DebugMenu" method="show"]
 [connection signal="back" from="TabContainer/CompletedQuests" to="TabContainer/DebugMenu/VBoxContainer/BackButton" method="grab_focus"]
 [connection signal="back" from="TabContainer/PlayerAbilities" to="TabContainer/DebugMenu" method="show"]


### PR DESCRIPTION
And for that, add and register a new plugin that contains an editor debugger plugin. Use the "threadbare_debugger:open_scene_file" message for passing it.

Resolve https://github.com/endlessm/threadbare/issues/2633