### PR TITLE
AreaFiller: Split fill() into clear() + update()

### DIFF
--- a/scenes/dev/level_design/area_filler/interactive_area_filler_test.gd
+++ b/scenes/dev/level_design/area_filler/interactive_area_filler_test.gd
@@ -7,7 +7,8 @@ extends Node2D
 
 ## Refill the FlowerBed on interaction with the FabricRock.
 func _on_interact_area_interaction_started(area: InteractArea) -> void:
-	area_filler.fill()
+	area_filler.clear()
+	area_filler.update()
 	area.end_interaction()
 
 

--- a/scenes/game_elements/props/area_filler/area_filler.gd
+++ b/scenes/game_elements/props/area_filler/area_filler.gd
@@ -14,9 +14,12 @@ extends Node
 ## [CollisionObject2D]). Define the collisions shapes as normal, either with
 ## [CollisionPolygon2D], or with [CollisionShape2D] with a [RectangleShape2D],
 ## [CircleShape2D], or [CapsuleShape2D]. Assign at least one scene to [member
-## scenes], adjust other parameters to taste, then click [b]Refill[/b] in the
-## inspector to fill the area with a new random arrangement of instances of
-## [member scenes].
+## scenes], adjust other parameters to taste, then click [b]Update[/b] in the
+## inspector to fill the area with a random arrangement of instances of
+## [member scenes]. If you don't like the arrangement, click [b]Clear[/b] then
+## [b]Update[/b] to try again. If you want to adjust the shapes, click
+## [b]Update[/b] after you do so to remove any out-of-bounds children and fill
+## any new regions.
 ## [br][br]
 ## By default, this node is only used in the editor and frees itself when the
 ## game is running. Enabling [member in_game_filler] allows you to use it
@@ -44,7 +47,10 @@ extends Node
 @export var in_game_filler: bool = false
 
 @warning_ignore("unused_private_class_variable")
-@export_tool_button("Refill") var _fill_button: Callable = fill
+@export_tool_button("Clear") var _clear_button: Callable = clear
+
+@warning_ignore("unused_private_class_variable")
+@export_tool_button("Update") var _update_button: Callable = update
 
 var _area: CollisionObject2D
 var _undoredo: Object  # EditorUndoRedoManager
@@ -158,11 +164,7 @@ func _merge_into(
 	return result
 
 
-## Generate random points that fill the shapes of [param area], at least
-## [param minimum_separation] px apart.
-func _generate_points() -> PackedVector2Array:
-	var points: PackedVector2Array
-
+func _generate_polygons() -> Array[PackedVector2Array]:
 	# Collect polygons from all shape owners, converting as needed.
 	# If the polygon has a transform we have to apply it here so that
 	# minimum_separation is interpreted in the parent's coordinate space.
@@ -186,14 +188,7 @@ func _generate_points() -> PackedVector2Array:
 	for polygon in polygons:
 		merged = _merge_into(polygon, merged)
 
-	# Sample each disjoint polygon region.
-	for polygon in merged:
-		var sampler := PoissonDiscSampler.new()
-		sampler.initialise(polygon, minimum_separation)
-		sampler.fill()
-		points.append_array(sampler.points)
-
-	return points
+	return merged
 
 
 func _prepare_child(pos: Vector2) -> Node2D:
@@ -205,27 +200,12 @@ func _prepare_child(pos: Vector2) -> Node2D:
 	return child
 
 
-## Clears [member area] (except for this node and any collision shapes),
-## generate a new set of points according to the current
-## parameters, and fill [member area] with instances of [member scenes]
-## at those points.
-func fill() -> void:
-	var old_children: Array[Node]
-	var new_children: Array[Node]
-
-	for child: Node in _area.get_children():
-		if child != self and child is not CollisionPolygon2D and child is not CollisionShape2D:
-			old_children.append(child)
-
-	var points := _generate_points()
-	for point in points:
-		new_children.append(_prepare_child(point))
-
+func _apply(action_name: String, old_children: Array[Node], new_children: Array[Node]) -> void:
 	if Engine.is_editor_hint():
 		# Filling in editor; add methods to _undoredo object
 		var scene := get_tree().edited_scene_root
 
-		_undoredo.create_action("Refill area", UndoRedo.MergeMode.MERGE_DISABLE, scene, false)
+		_undoredo.create_action(action_name, UndoRedo.MergeMode.MERGE_DISABLE, scene, false)
 
 		# When performing the action in either direction, we want to remove, then add.
 		for child in old_children:
@@ -248,3 +228,48 @@ func fill() -> void:
 
 		for child in new_children:
 			_area.add_child(child)
+
+
+func _find_existing_children() -> Array[Node]:
+	var children: Array[Node]
+
+	for child: Node in _area.get_children():
+		if child != self and child is not CollisionPolygon2D and child is not CollisionShape2D:
+			children.append(child)
+
+	return children
+
+
+## Clears [member area], except for this node and any collision shapes.
+func clear() -> void:
+	_apply("Clear area", _find_existing_children(), [])
+
+
+## Removes any nodes that are outside the current bounds of [member area], and
+## fills in new regions with instances of [member scenes].
+func update() -> void:
+	var polygons: Array[PackedVector2Array] = _generate_polygons()
+	var old_children: Array[Node]
+	var current_points: Array[Vector2]
+	var new_children: Array[Node]
+
+	for child: Node in _find_existing_children():
+		if polygons.any(
+			func(polygon: PackedVector2Array) -> bool:
+				return Geometry2D.is_point_in_polygon(child.position, polygon)
+		):
+			current_points.append(child.position)
+		else:
+			old_children.append(child)
+
+	var points: PackedVector2Array
+	var sampler := PoissonDiscSampler.new()
+	sampler.initialise(polygons, current_points, minimum_separation)
+	var i := sampler.points.size()
+	sampler.fill()
+	points.append_array(sampler.points.slice(i))
+
+	for point in points:
+		new_children.append(_prepare_child(point))
+
+	_apply("Refill area", old_children, new_children)

--- a/scenes/game_elements/props/area_filler/components/poisson_disc_sampler.gd
+++ b/scenes/game_elements/props/area_filler/components/poisson_disc_sampler.gd
@@ -13,7 +13,7 @@ const K := 30
 ## Generated points
 var points: PackedVector2Array
 
-var _polygon: PackedVector2Array
+var _polygons: Array[PackedVector2Array]
 var _bbox: Rect2
 
 ## Radius: minimum distance between generated points
@@ -43,20 +43,28 @@ var _grid_size: Vector2i
 var _active: PackedVector2Array
 
 
-static func _bounding_box(polygon: PackedVector2Array) -> Rect2:
-	if polygon.is_empty():
+static func _bounding_box(polygons: Array[PackedVector2Array]) -> Rect2:
+	var ps: PackedVector2Array
+	for polygon: PackedVector2Array in polygons:
+		ps.append_array(polygon)
+
+	if ps.is_empty():
 		return Rect2()
 
-	var bbox: Rect2 = Rect2(polygon[0], Vector2.ZERO)
-	for point: Vector2 in polygon:
+	var bbox: Rect2 = Rect2(ps[0], Vector2.ZERO)
+	for point: Vector2 in ps:
 		bbox = bbox.expand(point)
 
 	return bbox
 
 
-func initialise(polygon: PackedVector2Array, minimum_separation: float = 64) -> void:
-	_polygon = polygon
-	_bbox = _bounding_box(polygon)
+func initialise(
+	polygons: Array[PackedVector2Array],
+	initial_points: PackedVector2Array,
+	minimum_separation: float = 64,
+) -> void:
+	_polygons = polygons
+	_bbox = _bounding_box(polygons)
 
 	_r = minimum_separation
 	_r_squared = _r * _r
@@ -76,6 +84,9 @@ func initialise(polygon: PackedVector2Array, minimum_separation: float = 64) -> 
 	points.clear()
 	_active.clear()
 
+	for point: Vector2 in initial_points:
+		add_sample(point)
+
 
 ## Runs generate until no more points can be discovered
 func fill() -> void:
@@ -83,21 +94,26 @@ func fill() -> void:
 		pass
 
 
-func _generate_first_point() -> Vector2:
+func _generate_first_point(polygon: PackedVector2Array) -> Vector2:
 	# TODO: Triangulate polygon; pick triangle, weighted by area; pick random point in triangle
 	# (search keyword: barycentric).
 
 	# Simpler implementation: Pick a random point on a random edge.
-	var i := randi_range(0, _polygon.size() - 1)
-	var j := (i + 1) % _polygon.size()
-	return _polygon[i].lerp(_polygon[j], randf())
+	var i := randi_range(0, polygon.size() - 1)
+	var j := (i + 1) % polygon.size()
+	return polygon[i].lerp(polygon[j], randf())
 
 
 ## Generates a single point and appends it to [member points].
 ## Returns [code]false[/code] when no more points can be generated.
 func generate() -> bool:
 	if not points:
-		_add_sample(_generate_first_point())
+		for polygon: PackedVector2Array in _polygons:
+			var p := _generate_first_point(polygon)
+			if not _has_nearby_point(p):
+				add_sample(p)
+			# ...otherwise the two polygons must be close enough together that
+			# they can be reached in 2*minimum_separation.
 
 	while _active:
 		# While the active list is not empty, choose a random index
@@ -108,9 +124,10 @@ func generate() -> bool:
 
 		for j in range(K):
 			var q := _generate_around(p)
-			if Geometry2D.is_point_in_polygon(q, _polygon) and not _has_nearby_point(q):
-				_add_sample(q)
-				return true
+			for polygon: PackedVector2Array in _polygons:
+				if Geometry2D.is_point_in_polygon(q, polygon) and not _has_nearby_point(q):
+					add_sample(q)
+					return true
 
 		# No suitable candidate found near p; remove it from the queue
 		_active[i] = _active[n]
@@ -132,7 +149,7 @@ func _to_grid_coords(point: Vector2) -> Vector2i:
 	)
 
 
-func _add_sample(point: Vector2) -> void:
+func add_sample(point: Vector2) -> void:
 	points.push_back(point)
 	_active.push_back(point)
 


### PR DESCRIPTION
In practice I have found it annoying that, if I tweak the area to be
filled, the whole area is refilled from scratch.

Adapt PoissonDiscSampler to handle multiple polygons at once. This
addresses an undocumented issue where if you had two shapes that do not
overlap but are very close to one another, the old implementation could
place items right on the edge of each, not respecting the minimum
separation.

Rewrite fill() to update(), which preserves any existing children that
fall within the current area, removes any children that fall outside it,
and fills in any new regions. (In fact sometimes new trees will be
planted within the unchanged region, because sometimes the sampler finds
new valid unfilled points. That's how randomness works.)

Add a separate clear() function that erases the area in case you
actually want to refill it.

Factor out the code that applies the changes via UndoRedo at edit time
and directly at runtime.

Update the interactive area filler test scene to use clear() + update().
