### PR TITLE
InteractArea: Set debug color on shapes

### DIFF
--- a/scenes/dev/level_design/area_filler/interactive_area_filler_test.tscn
+++ b/scenes/dev/level_design/area_filler/interactive_area_filler_test.tscn
@@ -63,6 +63,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/FabricRock/InteractArea" unique_id=1977446241]
 shape = SubResource("CircleShape2D_pp1gq")
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="FabricRock2" parent="OnTheGround" unique_id=345844557 instance=ExtResource("5_s5eon")]
 position = Vector2(672, -214)
@@ -75,6 +76,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/FabricRock2/InteractAreaDecrease" unique_id=876564450]
 shape = SubResource("CircleShape2D_cdbf2")
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="FabricRock3" parent="OnTheGround" unique_id=1534237650 instance=ExtResource("5_s5eon")]
 position = Vector2(931, -214)
@@ -87,6 +89,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/FabricRock3/InteractAreaIncrease" unique_id=1688650151]
 shape = SubResource("CircleShape2D_5l5sl")
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Player" parent="OnTheGround" unique_id=296354958 instance=ExtResource("7_yosnh")]
 position = Vector2(154, 614)

--- a/scenes/game_elements/characters/npcs/elder/template_elder.tscn
+++ b/scenes/game_elements/characters/npcs/elder/template_elder.tscn
@@ -59,7 +59,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=123091838]
 position = Vector2(7.5, -40)
 shape = SubResource("RectangleShape2D_3eksq")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker2D" type="Marker2D" parent="InteractArea" unique_id=487749907]
 position = Vector2(0, -96)

--- a/scenes/game_elements/props/interact_area/interact_area.gd
+++ b/scenes/game_elements/props/interact_area/interact_area.gd
@@ -20,6 +20,7 @@ signal interaction_ended
 ## Emitted when characters start or stop seeing this area for interaction.
 signal observers_changed
 
+const SHAPE_DEBUG_COLOR := Color(0.6, 0.545, 0.0, 0.42)
 const INDICATOR_SCENE := preload("uid://d252j2mhya0kq")
 
 ## Position at which to show an arrow when this area is being observed. This
@@ -74,6 +75,18 @@ func remove_observer(character_sight: CharacterSight) -> void:
 
 func _get_is_being_observed() -> bool:
 	return bool(_observers.size())
+
+
+func _recolor_shapes() -> void:
+	for child: Node in get_children():
+		if child is CollisionShape2D:
+			child.debug_color = SHAPE_DEBUG_COLOR
+
+
+func _notification(what: int) -> void:
+	match what:
+		NOTIFICATION_CHILD_ORDER_CHANGED when Engine.is_editor_hint():
+			_recolor_shapes()
 
 
 func _ready() -> void:

--- a/scenes/quests/lore_quests/quest_000/tutorial_npc/tutorial_npc.tscn
+++ b/scenes/quests/lore_quests/quest_000/tutorial_npc/tutorial_npc.tscn
@@ -144,7 +144,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 visible = false
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_tx2gm")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker2D" type="Marker2D" parent="InteractArea" unique_id=728279640]
 position = Vector2(0, -88)

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/components/musical_rock.tscn
@@ -38,7 +38,7 @@ action = "Tap"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=1665980500]
 position = Vector2(0, -16)
 shape = SubResource("RectangleShape2D_kw7av")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="InteractArea" unique_id=87544084]
 position = Vector2(0, -64)

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -1505,7 +1505,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Helper/InteractArea" unique_id=317299534]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_vigmf")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="HelperCharacter" type="Node" parent="OnTheGround/Helper" unique_id=2049853056]
 script = ExtResource("46_jaqfj")

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
@@ -203,7 +203,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Helper/InteractArea" unique_id=498179141]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_0kgrx")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="HelperCharacter" type="Node" parent="OnTheGround/Helper" unique_id=660836413]
 script = ExtResource("27_6bwsk")

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -1112,7 +1112,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Helper/InteractArea" unique_id=1242432926]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_54yji")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="HelperCharacter" type="Node" parent="Helper" unique_id=271753697]
 script = ExtResource("55_vnfb8")

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.tscn
@@ -39,7 +39,7 @@ marker = NodePath("Marker")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=98094106]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_bqjp5")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="InteractArea" unique_id=1186921933]
 position = Vector2(0, -100)

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
@@ -346,7 +346,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 visible = false
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_rrp37")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="TalkBehavior" type="Node" parent="OnTheGround/StartingIsland/Townie" unique_id=526014934 node_paths=PackedStringArray("interact_area")]
 script = ExtResource("24_tsnue")
@@ -410,7 +410,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/StartingIsland/Helper/InteractArea" unique_id=1933907753]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_rrp37")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="HelperCharacter" type="Node" parent="OnTheGround/StartingIsland/Helper" unique_id=52968944]
 script = ExtResource("27_twlcp")
@@ -445,7 +445,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/StartingIsland/Helper2/InteractArea" unique_id=789086224]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_rrp37")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="HelperCharacter" type="Node" parent="OnTheGround/StartingIsland/Helper2" unique_id=291121416]
 script = ExtResource("27_twlcp")

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/buttons_collector.tscn
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/components/buttons_collector.tscn
@@ -34,7 +34,7 @@ marker = NodePath("Marker")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=1253932590]
 position = Vector2(0, -33)
 shape = SubResource("RectangleShape2D_vnm58")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="InteractArea" unique_id=2111856598]
 position = Vector2(0, -128)

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_needles.tscn
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_needles.tscn
@@ -450,7 +450,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Helper/InteractArea" unique_id=1731870932]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_6wsnq")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="HelperCharacter" type="Node" parent="OnTheGround/Helper" unique_id=423859809]
 script = ExtResource("31_hnwdt")

--- a/scenes/quests/lore_quests/quest_002/4_closing_transition/closing_transition.tscn
+++ b/scenes/quests/lore_quests/quest_002/4_closing_transition/closing_transition.tscn
@@ -478,7 +478,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/InteractArea" unique_id=153059657]
 position = Vector2(-19, -11)
 shape = SubResource("RectangleShape2D_e2p5u")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="OnTheGround/InteractArea" unique_id=1764721366]
 position = Vector2(0, -100)

--- a/scenes/quests/story_quests/champ/2_sequence_puzzle/champ_sequence_puzzle_object.tscn
+++ b/scenes/quests/story_quests/champ/2_sequence_puzzle/champ_sequence_puzzle_object.tscn
@@ -39,7 +39,7 @@ action = "Tap"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="InteractArea" unique_id=1674431163]
 position = Vector2(3, -11)
 shape = SubResource("RectangleShape2D_kw7av")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="InteractArea" unique_id=626671535]
 position = Vector2(0, -30)

--- a/scenes/quests/story_quests/champ/3_stealth/champ_stealth.tscn
+++ b/scenes/quests/story_quests/champ/3_stealth/champ_stealth.tscn
@@ -2050,7 +2050,7 @@ marker = NodePath("Marker")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hints/Hint NPC/InteractArea2" unique_id=1465528784]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="Hints/Hint NPC/InteractArea2" unique_id=1321770066]
 position = Vector2(0, -100)
@@ -2069,7 +2069,7 @@ marker = NodePath("Marker")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hints/Hint NPC2/InteractArea2" unique_id=1365930728]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="Hints/Hint NPC2/InteractArea2" unique_id=749163149]
 position = Vector2(0, -100)
@@ -2088,7 +2088,7 @@ marker = NodePath("Marker")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hints/Hint NPC3/InteractArea2" unique_id=179206779]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="Hints/Hint NPC3/InteractArea2" unique_id=2011078540]
 position = Vector2(0, -100)
@@ -2107,7 +2107,7 @@ marker = NodePath("Marker")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hints/Hint NPC4 - Blink/InteractArea2" unique_id=1414287729]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="Hints/Hint NPC4 - Blink/InteractArea2" unique_id=1202881832]
 position = Vector2(0, -100)
@@ -2126,7 +2126,7 @@ marker = NodePath("Marker")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hints/Hint NPC5 - Water_walking/InteractArea2" unique_id=1379546799]
 position = Vector2(0, -29)
 shape = SubResource("RectangleShape2D_3eksq")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="Hints/Hint NPC5 - Water_walking/InteractArea2" unique_id=804980487]
 position = Vector2(0, -100)

--- a/scenes/world_map/frays_end.tscn
+++ b/scenes/world_map/frays_end.tscn
@@ -459,7 +459,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 visible = false
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_duxxr")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="FarmersPartner" parent="OnTheGround/NPCs" unique_id=1246028381 instance=ExtResource("54_duxxr")]
 position = Vector2(1638, 833)
@@ -489,7 +489,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 visible = false
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_duxxr")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="GardenerB" parent="OnTheGround/NPCs" unique_id=514890698 instance=ExtResource("54_duxxr")]
 position = Vector2(268, 886)
@@ -523,7 +523,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 visible = false
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_t7c6s")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="EternalLoom" parent="OnTheGround" unique_id=17061783 instance=ExtResource("16_ojp30")]
 unique_name_in_owner = true

--- a/scenes/world_map/frays_end_west.tscn
+++ b/scenes/world_map/frays_end_west.tscn
@@ -114,7 +114,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Oscar/InteractArea" unique_id=1380061781]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_kxo1k")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="OnTheGround/Oscar/InteractArea" unique_id=1409355159]
 position = Vector2(0, -72)
@@ -142,7 +142,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Sigurd/InteractArea" unique_id=728137002]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_kxo1k")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="Marker" type="Marker2D" parent="OnTheGround/Sigurd/InteractArea" unique_id=2031504100]
 position = Vector2(0, -100)

--- a/scenes/world_map/linenville_path.tscn
+++ b/scenes/world_map/linenville_path.tscn
@@ -660,7 +660,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 visible = false
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_v2wms")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="TalkBehavior" type="Node" parent="OnTheGround/Townie" unique_id=423059525 node_paths=PackedStringArray("interact_area")]
 script = ExtResource("20_j805n")

--- a/scenes/world_map/song_sanctuary_path.tscn
+++ b/scenes/world_map/song_sanctuary_path.tscn
@@ -211,7 +211,7 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="OnTheGround/Townie/InteractArea" unique_id=1636031978]
 position = Vector2(0, -23.5)
 shape = SubResource("RectangleShape2D_fgnem")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.545, 0, 0.42)
 
 [node name="PointLight2D" type="PointLight2D" parent="OnTheGround/Townie" unique_id=296062278 groups=["night-lights"]]
 visible = false


### PR DESCRIPTION
Use a consistent yellow color for all collision shapes that define an InteractArea (that is, their CollisionShape2D immediate children), so they are easy to identify in the editor.