### PR TITLE
Tweak quest ending in StoryQuest Kit

### DIFF
--- a/scenes/dev/components/dev_archipelago.gd
+++ b/scenes/dev/components/dev_archipelago.gd
@@ -19,9 +19,10 @@ func _ready() -> void:
 	bridge_to_frays_end.set_toggled(is_storyquest_kit)
 	bridge_to_frays_end_broken.set_toggled(not is_storyquest_kit)
 
-	if is_storyquest_kit and GameState.quest:
-		# The player has returned here after completing a quest. Silently mark
-		# it as completed.
+	if GameState.quest:
+		# The player has returned here after completing a quest. There is no
+		# loom to interact with: just have an elder congratulate the player.
+		await story_quest_elder.congratulate_player()
 		GameState.mark_quest_completed()
 		GameState.save()
 

--- a/scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro_components/NO_EDIT_outro.dialogue
+++ b/scenes/quests/template_quests/NO_EDIT/4_NO_EDIT_outro/NO_EDIT_outro_components/NO_EDIT_outro.dialogue
@@ -3,5 +3,5 @@
 ~ start
 You've made it to the closing scene!
 This is where you will tie up the loose ends of your story.
-Let's go back to Fray's End so you can return these threads to the Eternal Loom...
+Now, let's take these threads back home...
 => END


### PR DESCRIPTION
Remove the reference to "Fray's End" and "Eternal Loom" in the last line
of NO_EDIT_outro's dialogue. Those entities are not in the StoryQuest
kit. Just speak more generically about taking the threads home.

We don't have a loom in Dev Archipelago, so we don't run the whole
end-of-quest sequence. Instead of silently marking it as finished, play
the normal "thank you, StoryWeaver!" dialogue. Have the StoryQuest Elder
say it because we have a reference to him! Do this even in the normal
project, rather than only if we detect we are in a StoryQuest Kit. I
don't think this will happen in practise right now, but you could
imagine that some of the dev "quests" will deliberately take you back to
Dev Archipelago rather than having no way out except to abandon the
quest.

Helps https://github.com/endlessm/threadbare/issues/2662
