### PR TITLE
Storybook: Correctly focus first button after changing page

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -58,9 +58,9 @@ func _ready() -> void:
 func _populate_quest_lists() -> void:
 	#Clear out any existing buttons from previous views
 	for child in left_quest_list.get_children():
-		child.queue_free()
+		child.free()
 	for child in right_quest_list.get_children():
-		child.queue_free()
+		child.free()
 
 	#Calculate the quest slices for this specific book spread
 	var left_start: int = _current_list_page * quests_per_page * 2

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -54,13 +54,16 @@ func _ready() -> void:
 	_populate_quest_lists()
 
 
-## Clears and regenerates the quest buttons based on the current page view
+func _clear_list(quest_list: Node) -> void:
+	for child: Node in quest_list.get_children():
+		quest_list.remove_child(child)
+		child.queue_free()
+
+
+# Clears and regenerates the quest buttons based on the current page view
 func _populate_quest_lists() -> void:
-	#Clear out any existing buttons from previous views
-	for child in left_quest_list.get_children():
-		child.free()
-	for child in right_quest_list.get_children():
-		child.free()
+	_clear_list(left_quest_list)
+	_clear_list(right_quest_list)
 
 	#Calculate the quest slices for this specific book spread
 	var left_start: int = _current_list_page * quests_per_page * 2


### PR DESCRIPTION
After `_populate_quest_lists()` rebuilds the quest lists, `_update_page_visibility()` picks the first child of the left list and assigns focus to it. However, previously `_populate_quest_lists()` did not remove the old children from the left (and right) lists before adding new ones; it merely queued them to be freed at the end of the current frame. This meant that at the point where `_update_page_visibility()` gave focus to the 0th child of the left list, it was still the old button, which was freed shortly afterwards.

Fix this by explicitly removing each button from each list before `queue_free()`ing it, so that when `_update_page_visibility()` gets the first child, it finds the first of the new buttons.

Resolves #2616 