### PR TITLE
Store InventoryItems as separate resource files

### DIFF
--- a/scenes/game_elements/props/collectible_item/components/collectible_item.gd
+++ b/scenes/game_elements/props/collectible_item/components/collectible_item.gd
@@ -17,6 +17,7 @@ extends SceneLink
 
 ## [InventoryItem] provided by this collectible when interacted with.
 @export var item: InventoryItem:
+	get = _get_item,
 	set = _set_item
 
 @export_category("Dialogue")
@@ -52,11 +53,19 @@ func _get_configuration_warnings() -> PackedStringArray:
 	return warnings
 
 
+func _get_item() -> InventoryItem:
+	# Replace anonymous resource stored in scene file with separately-stored resource.
+	# Can be removed when we don't expect to have to rewrite any new quests being merged.
+	if item and item.is_built_in():
+		item = InventoryItem.with_type(item.type)
+	return item
+
+
 func _set_item(new_value: InventoryItem) -> void:
 	item = new_value
 
 	if sprite_2d:
-		sprite_2d.texture = item.get_world_texture() if item else null
+		sprite_2d.texture = item.world_texture if item else null
 
 	if interact_area:
 		interact_area.action = "Collect " + item.type_name() if item else "Collect"

--- a/scenes/globals/game_state/inventory/imagination.tres
+++ b/scenes/globals/game_state/inventory/imagination.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" script_class="InventoryItem" format=3 uid="uid://cchnv5pn6fa8e"]
+
+[ext_resource type="Texture2D" uid="uid://wyiamtqmp4gk" path="res://assets/first_party/collectibles/imagination.png" id="1_f7k4n"]
+[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="2_mhd08"]
+[ext_resource type="Texture2D" uid="uid://6bf8rum68wq3" path="res://assets/first_party/collectibles/world_imagination.png" id="3_vln5c"]
+
+[resource]
+script = ExtResource("2_mhd08")
+type = 1
+color = Color(0.969, 0.792, 0, 1)
+hud_texture = ExtResource("1_f7k4n")
+world_texture = ExtResource("3_vln5c")
+metadata/_custom_type_script = "uid://bgmwplmj3bfls"

--- a/scenes/globals/game_state/inventory/inventory_item.gd
+++ b/scenes/globals/game_state/inventory/inventory_item.gd
@@ -8,42 +8,26 @@ enum ItemType {
 	MEMORY,
 	IMAGINATION,
 	SPIRIT,
-	NONE,
-}
-
-const COLORS_PER_TYPE: Dictionary[ItemType, Color] = {
-	ItemType.MEMORY: Color(0.459, 0.867, 0.0, 1.0),
-	ItemType.IMAGINATION: Color(0.969, 0.792, 0.0, 1.0),
-	ItemType.SPIRIT: Color(0.929, 0.0, 0.0, 1.0)
-}
-
-const HUD_TEXTURES: Dictionary[ItemType, Texture2D] = {
-	ItemType.MEMORY: preload("uid://brspc1u02oawt"),
-	ItemType.IMAGINATION: preload("uid://wyiamtqmp4gk"),
-	ItemType.SPIRIT: preload("uid://c4fefrg0tfkpl")
-}
-
-const WORLD_TEXTURES: Dictionary[ItemType, Texture2D] = {
-	ItemType.MEMORY: preload("uid://5wscjc8yqqts"),
-	ItemType.IMAGINATION: preload("uid://6bf8rum68wq3"),
-	ItemType.SPIRIT: preload("uid://cepg1o3ihp055")
 }
 
 @export var type: ItemType
+@export var color: Color
+@export var hud_texture: Texture2D
+@export var world_texture: Texture2D
 
 
-func get_hud_texture() -> Texture2D:
-	return HUD_TEXTURES[type]
-
-
-func get_world_texture() -> Texture2D:
-	return WORLD_TEXTURES[type]
-
-
+# TODO: can we eliminate this?
 static func with_type(a_type: ItemType) -> InventoryItem:
-	var item := new()
-	item.type = a_type
-	return item
+	match a_type:
+		ItemType.MEMORY:
+			return load("res://scenes/globals/game_state/inventory/memory.tres")
+		ItemType.IMAGINATION:
+			return load("res://scenes/globals/game_state/inventory/imagination.tres")
+		ItemType.SPIRIT:
+			return load("res://scenes/globals/game_state/inventory/spirit.tres")
+		_:
+			push_error("Unknown ItemType %d" % a_type)
+			return null
 
 
 func type_name() -> String:

--- a/scenes/globals/game_state/inventory/memory.tres
+++ b/scenes/globals/game_state/inventory/memory.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="InventoryItem" format=3 uid="uid://ck0wbckgm5un8"]
+
+[ext_resource type="Texture2D" uid="uid://brspc1u02oawt" path="res://assets/first_party/collectibles/memory.png" id="1_kqroc"]
+[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="2_5x7xc"]
+[ext_resource type="Texture2D" uid="uid://5wscjc8yqqts" path="res://assets/first_party/collectibles/world_memory.png" id="3_t6yoc"]
+
+[resource]
+script = ExtResource("2_5x7xc")
+color = Color(0.459, 0.867, 0, 1)
+hud_texture = ExtResource("1_kqroc")
+world_texture = ExtResource("3_t6yoc")
+metadata/_custom_type_script = "uid://bgmwplmj3bfls"

--- a/scenes/globals/game_state/inventory/spirit.tres
+++ b/scenes/globals/game_state/inventory/spirit.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" script_class="InventoryItem" format=3 uid="uid://c44l6x4e7sfx3"]
+
+[ext_resource type="Texture2D" uid="uid://c4fefrg0tfkpl" path="res://assets/first_party/collectibles/spirit.png" id="1_puqvu"]
+[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="2_glbdd"]
+[ext_resource type="Texture2D" uid="uid://cepg1o3ihp055" path="res://assets/first_party/collectibles/world_spirit.png" id="3_45k8j"]
+
+[resource]
+script = ExtResource("2_glbdd")
+type = 2
+color = Color(0.929, 0, 0, 1)
+hud_texture = ExtResource("1_puqvu")
+world_texture = ExtResource("3_45k8j")
+metadata/_custom_type_script = "uid://bgmwplmj3bfls"

--- a/scenes/globals/game_state/inventory_state.gd
+++ b/scenes/globals/game_state/inventory_state.gd
@@ -15,23 +15,6 @@ signal item_consumed(item: InventoryItem)
 ## [member clear_inventory].
 @export var items: Array[InventoryItem]
 
-## Types of items in [member inventory], for storage. Use [member inventory]
-## in game code.
-@export_storage var item_types: Array[String]:
-	get():
-		var types: Array[String]
-		for item: InventoryItem in items:
-			types.append(InventoryItem.ItemType.keys()[item.type])
-		return types
-	set(new_value):
-		items = []
-		for type_name: String in new_value:
-			if InventoryItem.ItemType.has(type_name):
-				items.append(InventoryItem.with_type(InventoryItem.ItemType[type_name]))
-			else:
-				push_warning("Ignoring unknown inventory item type: %s" % type_name)
-		emit_changed()
-
 
 ## Add the [InventoryItem] to [member items].
 func add_collected_item(item: InventoryItem) -> void:
@@ -46,9 +29,3 @@ func clear_inventory() -> void:
 		items.erase(item)
 		item_consumed.emit(item)
 	emit_changed()
-
-
-func _validate_property(property: Dictionary) -> void:
-	match property.name:
-		"inventory":
-			property.usage &= ~PROPERTY_USAGE_STORAGE

--- a/scenes/quests/lore_quests/quest_000/2_stealth/tutorial_stealth.tscn
+++ b/scenes/quests/lore_quests/quest_000/2_stealth/tutorial_stealth.tscn
@@ -17,7 +17,6 @@
 [ext_resource type="PackedScene" uid="uid://b2mj4jggli0ci" path="res://scenes/quests/lore_quests/quest_000/tutorial_npc/tutorial_npc.tscn" id="9_be8bo"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="10_pbknt"]
 [ext_resource type="Resource" uid="uid://bvxfbfjv2oleg" path="res://scenes/quests/lore_quests/quest_000/2_stealth/components/tutorial_stealth.dialogue" id="11_hiptn"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="11_nil71"]
 [ext_resource type="PackedScene" uid="uid://dv4f232y8w8dv" path="res://scenes/game_elements/props/decoration/water_rock/water_rock.tscn" id="12_es244"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="13_qj7hh"]
 [ext_resource type="SpriteFrames" uid="uid://c5q1t8qd1h1pl" path="res://scenes/game_elements/props/decoration/water_rock/components/water_rock_02.tres" id="13_thfh2"]
@@ -29,6 +28,7 @@
 [ext_resource type="SpriteFrames" uid="uid://tchths61dylv" path="res://scenes/game_elements/characters/enemies/guard/components/storyvoretorch_frames_green.tres" id="22_ym6ys"]
 [ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="25_qj7hh"]
 [ext_resource type="AudioStream" uid="uid://qnqpd21qyfnc" path="res://assets/first_party/music/Threadbare_Stealth.ogg" id="26_m6viv"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="27_bh43r"]
 [ext_resource type="SpriteFrames" uid="uid://d000bjl2xdg0g" path="res://scenes/game_elements/props/checkpoint/components/knitwitch_frames_green.tres" id="28_06hgc"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="30_06hgc"]
 [ext_resource type="SpriteFrames" uid="uid://2ek86nvw6y28" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_yellow.tres" id="31_thfh2"]
@@ -54,10 +54,6 @@ size = Vector2(168.25, 122)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_thfh2"]
 size = Vector2(168.25, 122)
-
-[sub_resource type="Resource" id="Resource_rl5ft"]
-script = ExtResource("11_nil71")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_es244"]
 size = Vector2(1216, 1473)
@@ -259,7 +255,7 @@ debug_color = Color(0, 0, 0, 0.42)
 unique_name_in_owner = true
 position = Vector2(2881, 254)
 revealed = false
-item = SubResource("Resource_rl5ft")
+item = ExtResource("27_bh43r")
 next_scene = "uid://c2cdgfy31u86r"
 exit_transition = 5
 

--- a/scenes/quests/lore_quests/quest_000/5_void_runner/tutorial_void_runner.tscn
+++ b/scenes/quests/lore_quests/quest_000/5_void_runner/tutorial_void_runner.tscn
@@ -12,8 +12,8 @@
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="9_41blb"]
 [ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/components/sprite_frames/storyweaver_blue.tres" id="10_pxyem"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="11_wdt4i"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="12_rogtb"]
 [ext_resource type="PackedScene" uid="uid://cokul8w425pja" path="res://scenes/game_elements/characters/enemies/void_spreading_enemy/void_spreading_enemy.tscn" id="13_app83"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="13_tjonm"]
 [ext_resource type="Script" uid="uid://bdhjixygupit1" path="res://scenes/game_elements/props/area_filler/area_filler.gd" id="14_2lxhj"]
 [ext_resource type="PackedScene" uid="uid://b2mj4jggli0ci" path="res://scenes/quests/lore_quests/quest_000/tutorial_npc/tutorial_npc.tscn" id="14_sdmwi"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="15_m0rx6"]
@@ -26,11 +26,6 @@
 [ext_resource type="Script" uid="uid://c2lx7gvkonxaa" path="res://scenes/game_elements/props/background_music/components/clip_switcher.gd" id="24_tjonm"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="25_xfbr2"]
 [ext_resource type="PackedScene" uid="uid://dv4f232y8w8dv" path="res://scenes/game_elements/props/decoration/water_rock/water_rock.tscn" id="28_af6h4"]
-
-[sub_resource type="Resource" id="Resource_6rywr"]
-script = ExtResource("12_rogtb")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_fwbcl"]
 size = Vector2(337.5, 826)
@@ -130,7 +125,7 @@ editor_draw_limits = true
 unique_name_in_owner = true
 position = Vector2(2943, -135)
 revealed = false
-item = SubResource("Resource_6rywr")
+item = ExtResource("13_tjonm")
 next_scene = "uid://dmoxtp65y3r2w"
 
 [node name="VoidSpreadingEnemy" parent="OnTheGround" unique_id=1007896559 node_paths=PackedStringArray("void_layer", "idle_patrol_path") instance=ExtResource("13_app83")]

--- a/scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn
+++ b/scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn
@@ -16,7 +16,6 @@
 [ext_resource type="PackedScene" uid="uid://1vunygl4wpj6" path="res://scenes/game_elements/props/button_item/button_item.tscn" id="11_umhh8"]
 [ext_resource type="Script" uid="uid://bd046eokvcnu2" path="res://addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd" id="12_512nx"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="12_s8bcj"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="13_qywun"]
 [ext_resource type="Script" uid="uid://bhexx6mj1xv3q" path="res://addons/phantom_camera/scripts/phantom_camera/phantom_camera_2d.gd" id="13_r0dvx"]
 [ext_resource type="Script" uid="uid://8umksf8e80fw" path="res://addons/phantom_camera/scripts/resources/tween_resource.gd" id="14_d5yvg"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="14_o5vgf"]
@@ -25,6 +24,7 @@
 [ext_resource type="SpriteFrames" uid="uid://cfgahyntmtfgu" path="res://scenes/game_elements/props/powerup/components/powerup_thread.tres" id="17_k7scg"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="18_ifd06"]
 [ext_resource type="PackedScene" uid="uid://b2mj4jggli0ci" path="res://scenes/quests/lore_quests/quest_000/tutorial_npc/tutorial_npc.tscn" id="18_x2ecx"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="19_512nx"]
 [ext_resource type="Resource" uid="uid://ci8ll31uofkiw" path="res://scenes/quests/lore_quests/quest_000/6_grappling/components/tutorial_grappling.dialogue" id="21_x2ecx"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="24_fhcwk"]
 [ext_resource type="PackedScene" uid="uid://dv4f232y8w8dv" path="res://scenes/game_elements/props/decoration/water_rock/water_rock.tscn" id="26_3gauf"]
@@ -38,11 +38,6 @@
 
 [sub_resource type="Resource" id="Resource_atjeb"]
 script = ExtResource("14_d5yvg")
-
-[sub_resource type="Resource" id="Resource_u8qfb"]
-script = ExtResource("13_qywun")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="TutorialGrappling" type="Node2D" unique_id=217609538]
 script = ExtResource("1_512nx")
@@ -239,7 +234,7 @@ position = Vector2(-865, 781)
 
 [node name="ImaginationThread" parent="OnTheGround" unique_id=1678374994 instance=ExtResource("12_s8bcj")]
 position = Vector2(-575, 315)
-item = SubResource("Resource_u8qfb")
+item = ExtResource("19_512nx")
 collected_dialogue = ExtResource("21_x2ecx")
 dialogue_title = &"thread_collected"
 spawn_point_path = NodePath("SpawnPointAfterIntro")

--- a/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
+++ b/scenes/quests/lore_quests/quest_001/1_music_puzzle/music_puzzle.tscn
@@ -17,7 +17,6 @@
 [ext_resource type="PackedScene" uid="uid://be4o3ythda4cu" path="res://scenes/game_elements/props/sequence_puzzle_hint_sign/sequence_puzzle_hint_sign.tscn" id="9_evicy"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="13_inhg4"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="14_src2c"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="15_rxyid"]
 [ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/components/sprite_frames/storyweaver_blue.tres" id="15_s3slv"]
 [ext_resource type="SpriteFrames" uid="uid://djwymcffy83" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_red.tres" id="16_8nm0x"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="16_ytxvq"]
@@ -45,6 +44,7 @@
 [ext_resource type="AudioStream" uid="uid://c7om8kdork2rx" path="res://assets/third_party/sounds/characters/enemies/guard/Torch.ogg" id="31_ink4c"]
 [ext_resource type="SpriteFrames" uid="uid://cefk7kf0bpm3q" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/bonfire_sign/bonfire_sign_backward.tres" id="32_0wfv2"]
 [ext_resource type="AudioStream" uid="uid://xuqj6b5qqs3w" path="res://assets/third_party/sounds/ambient/459405__pfannkuchn__small-river-1-fast-semi-close.ogg" id="35_l8fgn"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="41_icnj0"]
 [ext_resource type="PackedScene" uid="uid://dgrrudegturnw" path="res://scenes/game_elements/characters/npcs/townie.tscn" id="42_ps6xw"]
 [ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="43_icnj0"]
 [ext_resource type="Resource" uid="uid://jf1tng8jxd3o" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/dialogues/music_lore_helper.dialogue" id="44_pgedt"]
@@ -52,10 +52,6 @@
 [ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="45_ps6xw"]
 [ext_resource type="Script" uid="uid://diskln3jup064" path="res://scenes/game_elements/characters/npcs/components/helper_character.gd" id="46_jaqfj"]
 [ext_resource type="AudioStream" uid="uid://wkn0u0npcijf" path="res://scenes/quests/lore_quests/quest_001/1_music_puzzle/components/song_sanctuary_music.tres" id="47_orlow"]
-
-[sub_resource type="Resource" id="Resource_dp3eg"]
-script = ExtResource("15_rxyid")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vigmf"]
 size = Vector2(52, 61)
@@ -1477,7 +1473,7 @@ hint_sign = NodePath("../../Bonfires/BonfireSign4")
 unique_name_in_owner = true
 position = Vector2(-726, 43)
 revealed = false
-item = SubResource("Resource_dp3eg")
+item = ExtResource("41_icnj0")
 collected_dialogue = ExtResource("6_l4i5r")
 dialogue_title = &"well_done"
 next_scene = "uid://cgemeabsewy1f"

--- a/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
+++ b/scenes/quests/lore_quests/quest_001/2_ink_combat/ink_combat_round_3.tscn
@@ -17,12 +17,12 @@
 [ext_resource type="TileSet" uid="uid://dfp36ffpanjq2" path="res://tiles/elevation.tres" id="7_vstxf"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="8_hyj3v"]
 [ext_resource type="SpriteFrames" uid="uid://3ujiuhj7wpm2" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_red.tres" id="8_k5uk8"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="9_rww0x"]
 [ext_resource type="SpriteFrames" uid="uid://dxbt7cgoq3dg5" path="res://scenes/game_elements/characters/enemies/throwing_enemy/components/ink_drinker_frames_blue.tres" id="9_te0v3"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="10_i5hhc"]
 [ext_resource type="AudioStream" uid="uid://qf2d38rabx8o" path="res://assets/third_party/sounds/characters/enemies/throwing_enemy/Wings.ogg" id="10_uyhkg"]
 [ext_resource type="AudioStream" uid="uid://bbnj2fog3rdy8" path="res://assets/first_party/sounds/throwing_enemy/Spray.wav" id="11_7kldn"]
 [ext_resource type="PackedScene" uid="uid://c5jedlvvnnbi0" path="res://scenes/game_elements/props/projectile/ink_blob_projectile.tscn" id="12_ms350"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="21_2anko"]
 [ext_resource type="PackedScene" uid="uid://dgrrudegturnw" path="res://scenes/game_elements/characters/npcs/townie.tscn" id="23_2anko"]
 [ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="24_7ypla"]
 [ext_resource type="Resource" uid="uid://cm0wl5emmorln" path="res://scenes/quests/lore_quests/quest_001/2_ink_combat/components/dialogues/ink_helper.dialogue" id="25_tlsag"]
@@ -51,11 +51,6 @@ tracks/0/keys = {
 _data = {
 &"goal_completed": SubResource("Animation_k5uk8")
 }
-
-[sub_resource type="Resource" id="Resource_na0be"]
-script = ExtResource("9_rww0x")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_0kgrx"]
 size = Vector2(52, 61)
@@ -172,7 +167,7 @@ color = Color(1, 1, 0, 1)
 unique_name_in_owner = true
 position = Vector2(542, 510)
 revealed = false
-item = SubResource("Resource_na0be")
+item = ExtResource("21_2anko")
 collected_dialogue = ExtResource("2_fgs83")
 dialogue_title = &"well_done"
 next_scene = "uid://db6vhi7s2f37c"

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -6,7 +6,6 @@
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="2_1b8xw"]
 [ext_resource type="AudioStream" uid="uid://qnqpd21qyfnc" path="res://assets/first_party/music/Threadbare_Stealth.ogg" id="2_p2u32"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="3_1b8xw"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="3_idy4y"]
 [ext_resource type="TileSet" uid="uid://oynx002hv8tl" path="res://tiles/water.tres" id="4_xuyoh"]
 [ext_resource type="TileSet" uid="uid://bjx3gvah0ycl1" path="res://tiles/foam_2.tres" id="5_86cpf"]
 [ext_resource type="SpriteFrames" uid="uid://bapks76u4hipj" path="res://scenes/game_elements/props/decoration/bush/components/bush_spriteframes_green_small.tres" id="7_p2u32"]
@@ -56,6 +55,7 @@
 [ext_resource type="SpriteFrames" uid="uid://qwlhm21ndgn2" path="res://scenes/game_elements/characters/enemies/guard/components/storyvore_frames_orange.tres" id="33_pld6d"]
 [ext_resource type="PackedScene" uid="uid://dgrrudegturnw" path="res://scenes/game_elements/characters/npcs/townie.tscn" id="51_c2gs0"]
 [ext_resource type="Script" uid="uid://edcifob4jc4s" path="res://scenes/game_logic/talk_behavior.gd" id="52_4qmxg"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="53_54yji"]
 [ext_resource type="Resource" uid="uid://vlfqwpiuf0i2" path="res://scenes/quests/lore_quests/quest_001/3_stealth_level/components/bridge_helper.dialogue" id="53_c2gs0"]
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/interact_area.gd" id="54_llwyy"]
 [ext_resource type="Script" uid="uid://diskln3jup064" path="res://scenes/game_elements/characters/npcs/components/helper_character.gd" id="55_vnfb8"]
@@ -153,11 +153,6 @@ size = Vector2(137, 126)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_n0bwe"]
 size = Vector2(212, 254)
-
-[sub_resource type="Resource" id="Resource_idy4y"]
-script = ExtResource("3_idy4y")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="Curve2D" id="Curve2D_86cpf"]
 _data = {
@@ -1040,7 +1035,7 @@ debug_color = Color(0, 0, 0, 0.42)
 
 [node name="CollectibleItem" parent="." unique_id=1252493919 instance=ExtResource("2_1b8xw")]
 position = Vector2(7199, 888)
-item = SubResource("Resource_idy4y")
+item = ExtResource("53_54yji")
 next_scene = "uid://cd2p2udmkif80"
 
 [node name="Door" parent="." unique_id=1358622977 instance=ExtResource("25_ulxtw")]

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/void_runner.tscn
@@ -35,7 +35,6 @@
 [ext_resource type="SpriteFrames" uid="uid://brspwu70qbdaf" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_blue.tres" id="21_xqo3t"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="22_auh5r"]
 [ext_resource type="Resource" uid="uid://cy6q1djsmma1f" path="res://scenes/quests/lore_quests/quest_002/1_void_runner/components/townie.dialogue" id="22_tsnue"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="23_amu0w"]
 [ext_resource type="PackedScene" uid="uid://dgrrudegturnw" path="res://scenes/game_elements/characters/npcs/townie.tscn" id="23_kfcfu"]
 [ext_resource type="PackedScene" uid="uid://dme77bdscoo1o" path="res://scenes/quests/lore_quests/quest_002/1_void_runner/components/monk.tscn" id="23_swnl7"]
 [ext_resource type="SpriteFrames" uid="uid://2ek86nvw6y28" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_yellow.tres" id="23_wtoj6"]
@@ -49,6 +48,7 @@
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="29_gbo6l"]
 [ext_resource type="Resource" uid="uid://cki0neredlfou" path="res://scenes/quests/lore_quests/quest_002/1_void_runner/components/runner_lore_helper.dialogue" id="29_tsnue"]
 [ext_resource type="PackedScene" uid="uid://cf3cbl12wt6vr" path="res://scenes/game_elements/props/buildings/temple/temple.tscn" id="37_kgem8"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="43_auh5r"]
 [ext_resource type="PackedScene" uid="uid://dua6mynlw2ptw" path="res://scenes/game_elements/props/checkpoint/checkpoint.tscn" id="48_auh5r"]
 
 [sub_resource type="NavigationPolygon" id="NavigationPolygon_05yrb"]
@@ -76,10 +76,6 @@ point_count = 17
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_rrp37"]
 size = Vector2(52, 61)
-
-[sub_resource type="Resource" id="Resource_8l6e1"]
-script = ExtResource("23_amu0w")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_amu0w"]
 size = Vector2(64, 64)
@@ -1228,7 +1224,7 @@ polygon = PackedVector2Array(-221.5, 55.5, -226.5, 102.5, -174.5, 105.5, -158.5,
 [node name="CollectibleItem" parent="OnTheGround" unique_id=1898669578 instance=ExtResource("22_auh5r")]
 position = Vector2(474, 1058)
 revealed = false
-item = SubResource("Resource_8l6e1")
+item = ExtResource("43_auh5r")
 collected_dialogue = ExtResource("27_g2rto")
 next_scene = "uid://b8mfigsd8y5qs"
 

--- a/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_start.tscn
+++ b/scenes/quests/lore_quests/quest_002/2_grappling_hook/grappling_hook_start.tscn
@@ -15,13 +15,13 @@
 [ext_resource type="PackedScene" uid="uid://dvj15pnuqr2ua" path="res://scenes/game_elements/props/hookable_button_item/hookable_button_item.tscn" id="6_3g3x4"]
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="6_ngr1v"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="7_upilw"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="8_jqq45"]
 [ext_resource type="PackedScene" uid="uid://cokul8w425pja" path="res://scenes/game_elements/characters/enemies/void_spreading_enemy/void_spreading_enemy.tscn" id="9_3g3x4"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="9_vdhd3"]
 [ext_resource type="Script" uid="uid://csev4hv57utxv" path="res://scenes/game_logic/walk_behaviors/character_speeds.gd" id="10_upilw"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="11_p44d7"]
 [ext_resource type="Script" uid="uid://0enyu5v4ra34" path="res://scenes/game_elements/props/spawn_point/components/spawn_point.gd" id="14_jqq45"]
 [ext_resource type="PackedScene" uid="uid://1vunygl4wpj6" path="res://scenes/game_elements/props/button_item/button_item.tscn" id="15_wv4km"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="17_wv4km"]
 [ext_resource type="PackedScene" uid="uid://crqjcicx0vdu" path="res://scenes/game_elements/props/decoration/bush/bush.tscn" id="18_wv4km"]
 [ext_resource type="SpriteFrames" uid="uid://bapks76u4hipj" path="res://scenes/game_elements/props/decoration/bush/components/bush_spriteframes_green_small.tres" id="19_6n4qp"]
 [ext_resource type="PackedScene" uid="uid://0ull24fvmhwk" path="res://scenes/game_elements/props/teleporter/teleporter.tscn" id="23_wv4km"]
@@ -62,11 +62,6 @@ _data = {
 &"RESET": SubResource("Animation_w67qe"),
 &"eat_floor": SubResource("Animation_aiq76")
 }
-
-[sub_resource type="Resource" id="Resource_kr8u1"]
-script = ExtResource("8_jqq45")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="Resource" id="Resource_jqq45"]
 script = ExtResource("10_upilw")
@@ -227,7 +222,7 @@ position = Vector2(1132, 1079)
 
 [node name="CollectibleItem" parent="OnTheGround" unique_id=317578047 instance=ExtResource("7_upilw")]
 position = Vector2(1434, 520)
-item = SubResource("Resource_kr8u1")
+item = ExtResource("17_wv4km")
 next_scene = "uid://ce7nk8qmi64d2"
 exit_transition = 1
 

--- a/scenes/quests/lore_quests/quest_004/mythical_meadows.tscn
+++ b/scenes/quests/lore_quests/quest_004/mythical_meadows.tscn
@@ -13,14 +13,9 @@
 [ext_resource type="TileSet" uid="uid://ciq5guijvlyb0" path="res://tiles/void_chromakey.tres" id="9_q603x"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="10_1wq77"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="12_q0isu"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="13_33k3i"]
 [ext_resource type="SpriteFrames" uid="uid://dtoylirwywk0j" path="res://scenes/game_elements/characters/components/sprite_frames/storyweaver_blue.tres" id="13_ag7vv"]
 [ext_resource type="PackedScene" uid="uid://dv4f232y8w8dv" path="res://scenes/game_elements/props/decoration/water_rock/water_rock.tscn" id="14_brig6"]
-
-[sub_resource type="Resource" id="Resource_g27r7"]
-script = ExtResource("13_33k3i")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="15_ag7vv"]
 
 [node name="MythicalMeadows" type="Node2D" unique_id=78806229]
 
@@ -89,7 +84,7 @@ editor_draw_limits = true
 
 [node name="CollectibleItem" parent="OnTheGround" unique_id=327991066 instance=ExtResource("12_q0isu")]
 position = Vector2(1945, 338)
-item = SubResource("Resource_g27r7")
+item = ExtResource("15_ag7vv")
 target = 1
 
 [node name="InTheWater" type="Node2D" parent="." unique_id=2028481663]

--- a/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.tscn
+++ b/scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/stealth_sequence_combo.tscn
@@ -15,7 +15,6 @@
 [ext_resource type="AudioStream" uid="uid://4ec6e2alns71" path="res://assets/third_party/sounds/characters/enemies/guard/GrassFoot.ogg" id="8_bc7ib"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="8_u3d8g"]
 [ext_resource type="AudioStream" uid="uid://c7om8kdork2rx" path="res://assets/third_party/sounds/characters/enemies/guard/Torch.ogg" id="9_00lb2"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="9_1l5nh"]
 [ext_resource type="AudioStream" uid="uid://bwif2oo6ymiu2" path="res://assets/third_party/sounds/characters/enemies/guard/TorchHit.ogg" id="10_f0rs2"]
 [ext_resource type="SpriteFrames" uid="uid://d1k25io0tiiij" path="res://scenes/game_elements/characters/enemies/guard/components/storyvoretorch_frames_blue.tres" id="11_bc7ib"]
 [ext_resource type="Script" uid="uid://c68oh8dtr21ti" path="res://scenes/game_logic/sequence_puzzle.gd" id="14_qhjva"]
@@ -30,6 +29,7 @@
 [ext_resource type="AudioStream" uid="uid://shckj7dsimyt" path="res://assets/third_party/nepalese_hand_bells/handBells-g#4.ogg" id="20_lxyj7"]
 [ext_resource type="PackedScene" uid="uid://be4o3ythda4cu" path="res://scenes/game_elements/props/sequence_puzzle_hint_sign/sequence_puzzle_hint_sign.tscn" id="22_4t55h"]
 [ext_resource type="PackedScene" uid="uid://dv4f232y8w8dv" path="res://scenes/game_elements/props/decoration/water_rock/water_rock.tscn" id="25_bc7ib"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="28_w608l"]
 [ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="30_togfe"]
 [ext_resource type="AudioStream" uid="uid://c831gmm3rlklr" path="res://scenes/quests/lore_quests/song_sanctuary_2/1_stealth_sequence_combo/music/stealth_sequence_combo_music.tres" id="31_w608l"]
 
@@ -44,11 +44,6 @@ _data = {
 "points": PackedVector2Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1111, -13, 0, 0, 0, 0, 1109, -380, 0, 0, 0, 0, 1416, -392)
 }
 point_count = 4
-
-[sub_resource type="Resource" id="Resource_idy4y"]
-script = ExtResource("9_1l5nh")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="StealthSequenceCombo" type="Node2D" unique_id=1761996320]
 y_sort_enabled = true
@@ -212,7 +207,7 @@ curve = SubResource("Curve2D_qhjva")
 unique_name_in_owner = true
 position = Vector2(2429, 1936)
 revealed = false
-item = SubResource("Resource_idy4y")
+item = ExtResource("28_w608l")
 collected_dialogue = ExtResource("19_gwj3x")
 dialogue_title = &"collected"
 target = 1

--- a/scenes/quests/lore_quests/song_sanctuary_3/1_ink_drinker_levels/ink_combat_round_6.tscn
+++ b/scenes/quests/lore_quests/song_sanctuary_3/1_ink_drinker_levels/ink_combat_round_6.tscn
@@ -27,7 +27,7 @@
 [ext_resource type="PackedScene" uid="uid://crqjcicx0vdu" path="res://scenes/game_elements/props/decoration/bush/bush.tscn" id="23_0oabu"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="27_4co4a"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="27_7y6db"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="28_ihx08"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="29_t7x86"]
 [ext_resource type="PackedScene" uid="uid://dy8ohrl7j24qy" path="res://scenes/game_elements/characters/enemies/mothsache/Mothsache.tscn" id="30_4co4a"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="30_t7x86"]
 [ext_resource type="Resource" uid="uid://1q4ntvf11y4l" path="res://scenes/quests/lore_quests/song_sanctuary_3/1_ink_drinker_levels/components/musician.dialogue" id="31_n0ti8"]
@@ -53,11 +53,6 @@ tracks/0/keys = {
 _data = {
 &"goal_completed": SubResource("Animation_k5uk8")
 }
-
-[sub_resource type="Resource" id="Resource_rlfef"]
-script = ExtResource("28_ihx08")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="InkCombatRound6" type="Node2D" unique_id=559694113]
 
@@ -235,7 +230,7 @@ scale = Vector2(0.8, 0.8)
 unique_name_in_owner = true
 position = Vector2(593, 356)
 revealed = false
-item = SubResource("Resource_rlfef")
+item = ExtResource("29_t7x86")
 dialogue_title = &"well_done"
 target = 1
 

--- a/scenes/quests/story_quests/after_the_tremor/2_colegiojuego/after_the_tremor_colegiojuego.tscn
+++ b/scenes/quests/story_quests/after_the_tremor/2_colegiojuego/after_the_tremor_colegiojuego.tscn
@@ -4,11 +4,11 @@
 [ext_resource type="Script" uid="uid://dnp0tjloec2d7" path="res://scenes/game_logic/stealth_game_logic.gd" id="1_wwgeh"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="3_hg8ka"]
 [ext_resource type="SpriteFrames" uid="uid://dbe6l18tss360" path="res://scenes/quests/story_quests/after_the_tremor/charlie_components/after_the_tremor_charlie.tres" id="3_uy1rd"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="7_dm3hp"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="9_xqa6r"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="10_2ikh1"]
 [ext_resource type="TileSet" uid="uid://4ewcvb1sibsf" path="res://scenes/quests/story_quests/after_the_tremor/3_combat/2_cinematicacombate/tile/tilestaller.tres" id="10_dm3hp"]
 [ext_resource type="Texture2D" uid="uid://dma605ym4kwoi" path="res://scenes/quests/story_quests/after_the_tremor/2_colegiojuego/stealth_components/Captura de pantalla 2025-11-13 182221.png" id="11_dskj3"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="11_etnks"]
 [ext_resource type="Texture2D" uid="uid://bkjnj3xgy4qnn" path="res://scenes/quests/story_quests/after_the_tremor/cables.png" id="11_lsxbb"]
 [ext_resource type="Resource" uid="uid://ckjcd1twpgfcw" path="res://scenes/quests/story_quests/after_the_tremor/2_colegiojuego/stealth_components/after_the_tremor_collected.dialogue" id="12_6cc12"]
 [ext_resource type="Script" uid="uid://cujdidbq78hl7" path="res://scenes/quests/story_quests/after_the_tremor/2_colegiojuego/zone_focus_1.gd" id="12_h8y0j"]
@@ -30,10 +30,6 @@
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_pr13y"]
 radius = 21.333328
 height = 74.666626
-
-[sub_resource type="Resource" id="Resource_ltp2f"]
-script = ExtResource("11_etnks")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_dskj3"]
 size = Vector2(166.65625, 124.5)
@@ -89,7 +85,7 @@ horizontal_alignment = 1
 modulate = Color(1, 1, 1, 0)
 position = Vector2(447, 531)
 revealed = false
-item = SubResource("Resource_ltp2f")
+item = ExtResource("7_dm3hp")
 collected_dialogue = ExtResource("12_6cc12")
 next_scene = "uid://byqluh4f76sqn"
 

--- a/scenes/quests/story_quests/after_the_tremor/2_sequence_puzzle/2_tallerjuego/minijuego2.tscn
+++ b/scenes/quests/story_quests/after_the_tremor/2_sequence_puzzle/2_tallerjuego/minijuego2.tscn
@@ -12,8 +12,8 @@
 [ext_resource type="SpriteFrames" uid="uid://dkcv15as5d6gw" path="res://scenes/quests/story_quests/after_the_tremor/bryan_components/after_the_tremor_bryan.tres" id="9_cbqvq"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="10_8cyi3"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="11_gek8f"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="12_321x3"]
 [ext_resource type="Resource" uid="uid://dtqascp25vdgx" path="res://scenes/quests/story_quests/after_the_tremor/2_sequence_puzzle/2_tallerjuego/dialogofinal.dialogue" id="13_ea4l7"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="13_fikee"]
 [ext_resource type="Script" uid="uid://c68oh8dtr21ti" path="res://scenes/game_logic/sequence_puzzle.gd" id="14_0n12u"]
 [ext_resource type="PackedScene" uid="uid://b8sok264erfoc" path="res://scenes/game_elements/props/sequence_puzzle_object/sequence_puzzle_object.tscn" id="15_ea4l7"]
 [ext_resource type="SpriteFrames" uid="uid://bosdk18pjhyo0" path="res://scenes/quests/story_quests/after_the_tremor/2_sequence_puzzle/botonfuente.tres" id="16_8drhf"]
@@ -45,10 +45,6 @@ size = Vector2(80, 162.66667)
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_p26tb"]
 radius = 21.333328
 height = 74.666626
-
-[sub_resource type="Resource" id="Resource_cbqvq"]
-script = ExtResource("12_321x3")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="Minijuego2" type="Node2D" unique_id=1172299557]
 y_sort_enabled = true
@@ -130,7 +126,7 @@ shape = SubResource("CapsuleShape2D_p26tb")
 modulate = Color(1, 1, 1, 0)
 position = Vector2(452, -41)
 revealed = false
-item = SubResource("Resource_cbqvq")
+item = ExtResource("13_fikee")
 collected_dialogue = ExtResource("13_ea4l7")
 next_scene = "uid://iywmch2pilxk"
 

--- a/scenes/quests/story_quests/after_the_tremor/3_combat/after_the_tremor_combat.tscn
+++ b/scenes/quests/story_quests/after_the_tremor/3_combat/after_the_tremor_combat.tscn
@@ -18,8 +18,8 @@
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="13_3lgw8"]
 [ext_resource type="Resource" uid="uid://dkuosu241la84" path="res://scenes/quests/story_quests/after_the_tremor/3_combat/componentes/dialogofinal.dialogue" id="13_ilkny"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="15_25fjq"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="15_hh6bx"]
 [ext_resource type="Script" uid="uid://72qfdsx7ftfu" path="res://scenes/quests/story_quests/after_the_tremor/3_combat/scripts/throwing_enemytremor.gd" id="15_omu5o"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="16_epny2"]
 [ext_resource type="SpriteFrames" uid="uid://k5tiiho1vva0" path="res://scenes/quests/story_quests/after_the_tremor/3_combat/componentes/bryanpalo.tres" id="16_ilkny"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="18_epny2"]
 [ext_resource type="Script" uid="uid://chpgq8d41toca" path="res://scenes/quests/story_quests/after_the_tremor/3_combat/scripts/scriptsthreadbare/bosshealth.gd" id="18_fq20r"]
@@ -312,10 +312,6 @@ _data = {
 script = ExtResource("5_aisso")
 metadata/_custom_type_script = "uid://csev4hv57utxv"
 
-[sub_resource type="Resource" id="Resource_ilkny"]
-script = ExtResource("16_epny2")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
-
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fq20r"]
 bg_color = Color(0, 0, 0, 1)
 border_width_left = 2
@@ -464,7 +460,7 @@ metadata/_custom_type_script = "uid://x1mxt6bmei2o"
 modulate = Color(1, 1, 1, 0)
 position = Vector2(794, 309)
 revealed = false
-item = SubResource("Resource_ilkny")
+item = ExtResource("15_hh6bx")
 collected_dialogue = ExtResource("13_ilkny")
 next_scene = "uid://c0rr6ow3dhecj"
 

--- a/scenes/quests/story_quests/champ/1_combat/champ_combat.tscn
+++ b/scenes/quests/story_quests/champ/1_combat/champ_combat.tscn
@@ -18,7 +18,6 @@
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="13_45tp4"]
 [ext_resource type="PackedScene" uid="uid://driu5llb873ns" path="res://scenes/quests/story_quests/champ/1_combat/combat_components/champ_projectile_3.tscn" id="13_418m7"]
 [ext_resource type="Texture2D" uid="uid://dyyu8w3qtm6q5" path="res://scenes/quests/story_quests/champ/1_combat/combat_components/champ_combat_bait_sign.png" id="14_1o4lf"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="14_bn425"]
 [ext_resource type="Texture2D" uid="uid://ckjior4vavgpy" path="res://scenes/quests/story_quests/champ/1_combat/combat_components/champ_bait_projectile_1.png" id="15_nn4ti"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="15_qewm5"]
 [ext_resource type="PackedScene" uid="uid://cd24crxnn6c3n" path="res://scenes/quests/story_quests/champ/1_combat/combat_components/buoy.tscn" id="15_sm7tj"]
@@ -26,11 +25,7 @@
 [ext_resource type="Texture2D" uid="uid://ct7ux8rnh0gyo" path="res://scenes/quests/story_quests/champ/1_combat/combat_components/champ_bait_projectile_3.png" id="17_j60m7"]
 [ext_resource type="Texture2D" uid="uid://b8bo7js8fgtvq" path="res://scenes/quests/story_quests/champ/1_combat/combat_components/circular_ripples.png" id="21_yidpm"]
 [ext_resource type="Texture2D" uid="uid://bopnrtenvp4sm" path="res://scenes/quests/story_quests/champ/tiles/assets/water_ripples.png" id="22_hv7kx"]
-
-[sub_resource type="Resource" id="Resource_no6r0"]
-script = ExtResource("14_bn425")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="23_8ja4x"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_p0sed"]
 atlas = ExtResource("21_yidpm")
@@ -344,7 +339,7 @@ offset = Vector2(-1, -10)
 unique_name_in_owner = true
 position = Vector2(1155, 900)
 revealed = false
-item = SubResource("Resource_no6r0")
+item = ExtResource("23_8ja4x")
 collected_dialogue = ExtResource("2_sm7tj")
 dialogue_title = &"well_done"
 next_scene = "uid://gr7ykelwh6u1"

--- a/scenes/quests/story_quests/champ/2_sequence_puzzle/champ_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/champ/2_sequence_puzzle/champ_sequence_puzzle.tscn
@@ -12,9 +12,9 @@
 [ext_resource type="PackedScene" uid="uid://be4o3ythda4cu" path="res://scenes/game_elements/props/sequence_puzzle_hint_sign/sequence_puzzle_hint_sign.tscn" id="13_jn76l"]
 [ext_resource type="SpriteFrames" uid="uid://cbu01r36cmdrh" path="res://scenes/quests/story_quests/champ/2_sequence_puzzle/champ_sign.tres" id="14_wt3t3"]
 [ext_resource type="SpriteFrames" uid="uid://c40qep1qluqlm" path="res://scenes/quests/story_quests/champ/2_sequence_puzzle/champ_sign_2.tres" id="15_daq40"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="15_fiojq"]
 [ext_resource type="Script" uid="uid://ccc78coj2b1li" path="res://scenes/game_logic/sequence_puzzle_step.gd" id="16_sgian"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="17_hjeem"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="18_34sng"]
 [ext_resource type="PackedScene" uid="uid://ipvcfv2g0oi1" path="res://scenes/game_elements/characters/npcs/talker/talker.tscn" id="18_f2rba"]
 [ext_resource type="Resource" uid="uid://btfqnw51oyy81" path="res://scenes/quests/story_quests/champ/2_sequence_puzzle/champ_sequence_puzzle.dialogue" id="19_00tvj"]
 [ext_resource type="Resource" uid="uid://c4eaioxcrhg07" path="res://scenes/quests/story_quests/champ/2_sequence_puzzle/learner_edits/champ_sequence_puzzle_lore.dialogue" id="19_27hsp"]
@@ -22,11 +22,6 @@
 [ext_resource type="SpriteFrames" uid="uid://h85time5ateg" path="res://scenes/quests/story_quests/champ/2_sequence_puzzle/learner_edits/champ_default_npc.tres" id="20_ey61o"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="21_wpffp"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="22_hebqh"]
-
-[sub_resource type="Resource" id="Resource_qrg6i"]
-script = ExtResource("18_34sng")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="SequencePuzzleTemplate" type="Node2D" unique_id=489705438]
 
@@ -235,7 +230,7 @@ hint_sign = NodePath("../../Signs/HintSign2")
 [node name="CollectibleItem" parent="OnTheGround" unique_id=205185299 instance=ExtResource("17_hjeem")]
 position = Vector2(1807, -927)
 revealed = false
-item = SubResource("Resource_qrg6i")
+item = ExtResource("15_fiojq")
 collected_dialogue = ExtResource("19_00tvj")
 dialogue_title = &"well_done"
 next_scene = "uid://d0hvx8x3o7q4f"

--- a/scenes/quests/story_quests/champ/3_stealth/champ_stealth.tscn
+++ b/scenes/quests/story_quests/champ/3_stealth/champ_stealth.tscn
@@ -21,7 +21,6 @@
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="10_saf7v"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="11_680ig"]
 [ext_resource type="Texture2D" uid="uid://bwqo8f7jg5df6" path="res://scenes/quests/story_quests/champ/tiles/assets/wood_floor_tiles.png" id="11_b83kw"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="12_epx14"]
 [ext_resource type="Texture2D" uid="uid://cn8v0dfqm3f1h" path="res://scenes/quests/story_quests/champ/tiles/assets/evan_room_tiles.png" id="12_rlxqi"]
 [ext_resource type="Texture2D" uid="uid://cx0o1blte7xjj" path="res://scenes/quests/story_quests/champ/tiles/assets/shore_tiles.png" id="13_nk1ag"]
 [ext_resource type="Resource" uid="uid://c51ad5akpk8j8" path="res://scenes/quests/story_quests/champ/3_stealth/stealth_components/champ_collected.dialogue" id="13_oswsn"]
@@ -56,6 +55,7 @@
 [ext_resource type="Script" uid="uid://cbj0406q05dly" path="res://scenes/game_elements/props/hint/input_key/interact_input.gd" id="30_nyycj"]
 [ext_resource type="Texture2D" uid="uid://bbvedlx2ahdxk" path="res://assets/third_party/kenney_input_prompts/keyboard-&-mouse_sheet_default.png" id="31_y8c8x"]
 [ext_resource type="Resource" uid="uid://bmharix12w26t" path="res://scenes/quests/story_quests/champ/3_stealth/stealth_components/champ_blink.dialogue" id="34_g76pt"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="35_y8c8x"]
 [ext_resource type="Texture2D" uid="uid://h606ovawbm0x" path="res://scenes/quests/story_quests/champ/3_stealth/stealth_components/BlinkMarker.png" id="44_onp74"]
 [ext_resource type="PackedScene" uid="uid://0ull24fvmhwk" path="res://scenes/game_elements/props/teleporter/teleporter.tscn" id="46_8k5n0"]
 [ext_resource type="Resource" uid="uid://cxjgjjb44ssnm" path="res://scenes/quests/story_quests/champ/3_stealth/stealth_components/champ_walking_on_water.dialogue" id="55_rosy4"]
@@ -1632,10 +1632,6 @@ region = Rect2(192, 704, 64, 64)
 atlas = ExtResource("31_y8c8x")
 region = Rect2(64, 576, 64, 64)
 
-[sub_resource type="Resource" id="Resource_x1dad"]
-script = ExtResource("12_epx14")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
-
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_fw64s"]
 radius = 24.0
 height = 50.0
@@ -1788,13 +1784,13 @@ text = "Walk on water"
 
 [node name="CollectibleItem" parent="." unique_id=1250372978 instance=ExtResource("11_680ig")]
 position = Vector2(892, -2934)
-item = SubResource("Resource_x1dad")
+item = ExtResource("35_y8c8x")
 collected_dialogue = ExtResource("13_oswsn")
 next_scene = "uid://bbjh0yoqbchuo"
 
 [node name="CollectibleItem2" parent="." unique_id=327991066 instance=ExtResource("11_680ig")]
 position = Vector2(2510, 513)
-item = SubResource("Resource_x1dad")
+item = ExtResource("35_y8c8x")
 collected_dialogue = ExtResource("13_oswsn")
 next_scene = "uid://bbjh0yoqbchuo"
 

--- a/scenes/quests/story_quests/el_abrigo/1_el_abrigo_sequence_puzzle/el_abrigo_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/el_abrigo/1_el_abrigo_sequence_puzzle/el_abrigo_sequence_puzzle.tscn
@@ -18,16 +18,11 @@
 [ext_resource type="SpriteFrames" uid="uid://dcs82hf75j3mp" path="res://scenes/quests/story_quests/el_abrigo/1_el_abrigo_sequence_puzzle/el_abrigo_sign_2.tres" id="15_auted"]
 [ext_resource type="Script" uid="uid://ccc78coj2b1li" path="res://scenes/game_logic/sequence_puzzle_step.gd" id="16_nbjmb"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="17_qilgh"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="18_13w3u"]
 [ext_resource type="Resource" uid="uid://ctq1rlb53bsr7" path="res://scenes/quests/story_quests/el_abrigo/1_el_abrigo_sequence_puzzle/el_abrigo_sequence_puzzle.dialogue" id="19_et0ln"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="19_q4xxt"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="20_5lqbj"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="21_ls5ve"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="22_k8jmo"]
-
-[sub_resource type="Resource" id="Resource_wsnfe"]
-script = ExtResource("18_13w3u")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="SequencePuzzleTemplate" type="Node2D" unique_id=341518395]
 position = Vector2(0, 47)
@@ -283,7 +278,7 @@ hint_sign = NodePath("../../Signs/HintSign3")
 [node name="CollectibleItem" parent="OnTheGround" unique_id=975173069 instance=ExtResource("17_qilgh")]
 position = Vector2(386, 914)
 revealed = false
-item = SubResource("Resource_wsnfe")
+item = ExtResource("19_q4xxt")
 collected_dialogue = ExtResource("19_et0ln")
 dialogue_title = &"well_done"
 next_scene = "uid://dfwpehorj34mx"

--- a/scenes/quests/story_quests/el_abrigo/2_el_abrigo_stealth/el_abrigo_stealth1.tscn
+++ b/scenes/quests/story_quests/el_abrigo/2_el_abrigo_stealth/el_abrigo_stealth1.tscn
@@ -10,7 +10,7 @@
 [ext_resource type="SpriteFrames" uid="uid://c828jcbsnsvkr" path="res://scenes/quests/story_quests/el_abrigo/2_el_abrigo_stealth/el_abrigo_stealth1components/champ_guard_enemy.tres" id="7_nkr5o"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="8_0402c"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="9_pjl46"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="10_3pb1g"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="11_gaxyh"]
 [ext_resource type="Resource" uid="uid://bx25bjdfjux36" path="res://scenes/quests/story_quests/el_abrigo/2_el_abrigo_stealth/el_abrigo_stealth1components/champ_collected.dialogue" id="11_ih7cc"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="12_cflgt"]
 [ext_resource type="Resource" uid="uid://ci5vw13idgxl4" path="res://scenes/quests/story_quests/el_abrigo/2_el_abrigo_stealth/el_abrigo_stealth1components/champ_stealth.dialogue" id="13_eh4r8"]
@@ -27,10 +27,6 @@ _data = {
 "points": PackedVector2Array(0, 0, 0, 0, 488, -91, 0, 0, 0, 0, 480, 106, 0, 0, 0, 0, 356, 208, 0, 0, 0, 0, 246, 126, 0, 0, 0, 0, 166, 26, 0, 0, 0, 0, 169, -97, 0, 0, 0, 0, 354, -101, 0, 0, 0, 0, 488, -91)
 }
 point_count = 8
-
-[sub_resource type="Resource" id="Resource_x1dad"]
-script = ExtResource("10_3pb1g")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="StealthTemplateLevel" type="Node2D" unique_id=1915503757]
 y_sort_enabled = true
@@ -150,7 +146,7 @@ curve = SubResource("Curve2D_2hewv")
 
 [node name="CollectibleItem" parent="." unique_id=1299879609 instance=ExtResource("9_pjl46")]
 position = Vector2(5787, 1348)
-item = SubResource("Resource_x1dad")
+item = ExtResource("11_gaxyh")
 collected_dialogue = ExtResource("11_ih7cc")
 next_scene = "uid://ikqwy7kpa5ly"
 

--- a/scenes/quests/story_quests/el_abrigo/3_el_abrigo_runner/el_abrigo_runner.tscn
+++ b/scenes/quests/story_quests/el_abrigo/3_el_abrigo_runner/el_abrigo_runner.tscn
@@ -17,7 +17,6 @@
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="10_4rp0h"]
 [ext_resource type="Script" uid="uid://bx30ncvhcbprn" path="res://scenes/quests/story_quests/el_abrigo/3_el_abrigo_runner/el_abrigo_runner_components/farmer_trap.gd" id="10_m0dfd"]
 [ext_resource type="PackedScene" uid="uid://bp20cjimwi8l0" path="res://scenes/game_elements/props/buildings/house/house_2.tscn" id="10_udqck"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="11_1pd1l"]
 [ext_resource type="SpriteFrames" uid="uid://cpm5o35ede3qs" path="res://scenes/game_elements/characters/npcs/npc_prop/sprite_frames/fray_idle_purple.tres" id="11_6hci7"]
 [ext_resource type="Resource" uid="uid://cv3cmfe06hf57" path="res://scenes/quests/story_quests/el_abrigo/3_el_abrigo_runner/el_abrigo_runner_components/el_abrigo_collected.dialogue" id="12_fsmso"]
 [ext_resource type="Texture2D" uid="uid://ol20om7xc1o7" path="res://scenes/game_elements/props/buildings/house/components/House_Wool_Red_Stage1.png" id="13_c45fb"]
@@ -30,6 +29,7 @@
 [ext_resource type="Script" uid="uid://b4ga88hhtoqd5" path="res://scenes/quests/story_quests/el_abrigo/3_el_abrigo_runner/path_follow_2d.gd" id="21_hjkle"]
 [ext_resource type="Script" uid="uid://c6gowmuxoxlg7" path="res://scenes/quests/story_quests/el_abrigo/3_el_abrigo_runner/area_2d.gd" id="21_r7i8v"]
 [ext_resource type="PackedScene" uid="uid://c78fj5em5tpm5" path="res://scenes/game_elements/props/decoration/crops/carrot.tscn" id="23_udqck"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="26_301yh"]
 [ext_resource type="Script" uid="uid://cj5gw0bqwm326" path="res://scenes/quests/story_quests/el_abrigo/3_el_abrigo_runner/el_abrigo_runner_components/carrot_trap.gd" id="26_c45fb"]
 [ext_resource type="AudioStream" uid="uid://kc657macgib4" path="res://assets/first_party/music/Threadbare_Main_Loud.ogg" id="31_0ldiv"]
 
@@ -154,10 +154,6 @@ animations = [{
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_6hci7"]
 size = Vector2(359.75, 452.75)
-
-[sub_resource type="Resource" id="Resource_jyt4x"]
-script = ExtResource("11_1pd1l")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="StealthTemplateLevel" type="Node2D" unique_id=1958537541]
 y_sort_enabled = true
@@ -1892,7 +1888,7 @@ shape = SubResource("RectangleShape2D_6hci7")
 
 [node name="CollectibleItem" parent="." unique_id=120029080 instance=ExtResource("10_4rp0h")]
 position = Vector2(6703, 2210)
-item = SubResource("Resource_jyt4x")
+item = ExtResource("26_301yh")
 collected_dialogue = ExtResource("12_fsmso")
 next_scene = "uid://c5mblxkgfxr8r"
 

--- a/scenes/quests/story_quests/el_juguete_perdido/1_stealth/stealth.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/1_stealth/stealth.tscn
@@ -15,8 +15,8 @@
 [ext_resource type="SpriteFrames" uid="uid://dbdys7gewepba" path="res://scenes/quests/story_quests/el_juguete_perdido/1_stealth/components/guard_enemy.tres" id="11_otj14"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="12_15dag"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="13_6cv6u"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="14_d1ucx"]
 [ext_resource type="Resource" uid="uid://cn16ax75gxewu" path="res://scenes/quests/story_quests/el_juguete_perdido/1_stealth/components/collected.dialogue" id="15_bfns3"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="16_u77sa"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="16_xanj6"]
 [ext_resource type="Resource" uid="uid://dekuveqofa52e" path="res://scenes/quests/story_quests/el_juguete_perdido/1_stealth/components/stealth.dialogue" id="17_rcrkg"]
 
@@ -62,10 +62,6 @@ _data = {
 "points": PackedVector2Array(0, 0, 0, 0, 952, 1056, 0, 0, 0, 0, 1472, 1056, 0, 0, 0, 0, 1472, 1120, 0, 0, 0, 0, 1704, 1120)
 }
 point_count = 4
-
-[sub_resource type="Resource" id="Resource_idy4y"]
-script = ExtResource("14_d1ucx")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="StealthTemplateLevel" type="Node2D" unique_id=1461105729]
 y_sort_enabled = true
@@ -278,7 +274,7 @@ metadata/_edit_lock_ = true
 
 [node name="CollectibleItem" parent="." unique_id=416302336 instance=ExtResource("13_6cv6u")]
 position = Vector2(2089, 2144)
-item = SubResource("Resource_idy4y")
+item = ExtResource("16_u77sa")
 collected_dialogue = ExtResource("15_bfns3")
 next_scene = "uid://be2gr1lptrhxu"
 

--- a/scenes/quests/story_quests/el_juguete_perdido/2_combat/combat.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/2_combat/combat.tscn
@@ -14,7 +14,6 @@
 [ext_resource type="Texture2D" uid="uid://bdhfcs6igu6di" path="res://assets/third_party/tiny-swords/Deco/14.png" id="8_x8tfn"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="8_xvhfb"]
 [ext_resource type="Texture2D" uid="uid://b8t4t3n4syqli" path="res://assets/third_party/tiny-swords/Deco/15.png" id="9_7xnls"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="9_w3dy0"]
 [ext_resource type="Texture2D" uid="uid://8ujtwgp8fb1v" path="res://scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_stealth_fire.png" id="10_0konm"]
 [ext_resource type="Texture2D" uid="uid://cw330muutqql7" path="res://assets/third_party/tiny-swords/Deco/05.png" id="10_adm0l"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="10_obsym"]
@@ -26,6 +25,7 @@
 [ext_resource type="SpriteFrames" uid="uid://dygrlyqhiy6j0" path="res://scenes/quests/story_quests/el_juguete_perdido/2_combat/components/target_spriteframes.tres" id="17_f8rx3"]
 [ext_resource type="PackedScene" uid="uid://nve5vecg5q5q" path="res://scenes/quests/story_quests/el_juguete_perdido/2_combat/components/projectile.tscn" id="18_v0l6r"]
 [ext_resource type="PackedScene" uid="uid://lmh7sal3fkyl" path="res://scenes/quests/story_quests/el_juguete_perdido/objects_components/barrel.tscn" id="20_adm0l"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="22_ouleg"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0ownb"]
 atlas = ExtResource("10_0konm")
@@ -83,11 +83,6 @@ animations = [{
 "name": &"default",
 "speed": 13.0
 }]
-
-[sub_resource type="Resource" id="Resource_a51xm"]
-script = ExtResource("9_w3dy0")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="Combat" type="Node2D" unique_id=1428810130]
 y_sort_enabled = true
@@ -444,7 +439,7 @@ projectile_duration = 2.0
 unique_name_in_owner = true
 position = Vector2(1156, 1882)
 revealed = false
-item = SubResource("Resource_a51xm")
+item = ExtResource("22_ouleg")
 collected_dialogue = ExtResource("2_j6s2f")
 dialogue_title = &"well_done"
 next_scene = "uid://7hehs33no2j3"

--- a/scenes/quests/story_quests/el_juguete_perdido/3_sequence_puzzle/sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/el_juguete_perdido/3_sequence_puzzle/sequence_puzzle.tscn
@@ -6,18 +6,13 @@
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="2_io7px"]
 [ext_resource type="PackedScene" uid="uid://boc4ibh8o13d2" path="res://scenes/quests/story_quests/el_juguete_perdido/0_intro/components/trees1.tscn" id="2_yiahn"]
 [ext_resource type="SpriteFrames" uid="uid://b7oxscw47ykwj" path="res://scenes/quests/story_quests/el_juguete_perdido/player_components/player_with_apolo_components/storyweaver_apolo.tres" id="3_yiahn"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="8_acxkl"]
 [ext_resource type="PackedScene" uid="uid://c4vbokn408f2c" path="res://scenes/game_elements/props/decoration/sheep/sheep.tscn" id="10_acxkl"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="14_y2gkn"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="15_i80sc"]
 [ext_resource type="Resource" uid="uid://b6umdn3fee6tf" path="res://scenes/quests/story_quests/el_juguete_perdido/3_sequence_puzzle/components/sequence_puzzle.dialogue" id="16_6jc5p"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="17_64xko"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="18_hstlp"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="19_my15m"]
-
-[sub_resource type="Resource" id="Resource_u8qfb"]
-script = ExtResource("15_i80sc")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="SequencePuzzleTemplate" type="Node2D" unique_id=1912634357]
 
@@ -77,7 +72,7 @@ editor_draw_limits = true
 
 [node name="CollectibleItem" parent="OnTheGround" unique_id=548589429 instance=ExtResource("14_y2gkn")]
 position = Vector2(1407, 384)
-item = SubResource("Resource_u8qfb")
+item = ExtResource("8_acxkl")
 collected_dialogue = ExtResource("16_6jc5p")
 dialogue_title = &"well_done"
 next_scene = "uid://da7akt4pqtvpk"

--- a/scenes/quests/story_quests/el_ojo_revelador/1_stealth/el_ojo_revelador_stealth.tscn
+++ b/scenes/quests/story_quests/el_ojo_revelador/1_stealth/el_ojo_revelador_stealth.tscn
@@ -13,11 +13,11 @@
 [ext_resource type="AudioStream" uid="uid://dfhy5ea7edbxf" path="res://scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/Suspenso.wav" id="9_o0bil"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="9_rli1d"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="10_cb2x4"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="11_gja4x"]
 [ext_resource type="Resource" uid="uid://n546p2kle1fv" path="res://scenes/quests/story_quests/el_ojo_revelador/1_stealth/stealth_components/el_ojo_revelador_collected.dialogue" id="12_udwbx"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="13_5gpbs"]
 [ext_resource type="Resource" uid="uid://4jyo5vuumh23" path="res://scenes/quests/story_quests/el_ojo_revelador/1_stealth/stealth_components/el_ojo_revelador_stealth.dialogue" id="14_0rw02"]
 [ext_resource type="Texture2D" uid="uid://daf2ilk2ingia" path="res://scenes/quests/story_quests/el_ojo_revelador/0_intro/intro_components/luz.png" id="15_jkgkj"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="15_yd3qj"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="16_xvtq7"]
 
 [sub_resource type="Curve2D" id="Curve2D_sqg5n"]
@@ -58,10 +58,6 @@ point_count = 5
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_4i8s0"]
 size = Vector2(175.0625, 55)
-
-[sub_resource type="Resource" id="Resource_rx2mx"]
-script = ExtResource("11_gja4x")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="StealthTemplateLevel" type="Node2D" unique_id=1974814176]
 y_sort_enabled = true
@@ -226,7 +222,7 @@ debug_color = Color(0, 0, 0, 0.42)
 
 [node name="CollectibleItem" parent="." unique_id=756034815 instance=ExtResource("10_cb2x4")]
 position = Vector2(2681, 2246)
-item = SubResource("Resource_rx2mx")
+item = ExtResource("15_yd3qj")
 collected_dialogue = ExtResource("12_udwbx")
 next_scene = "uid://oos7ity34uiy"
 

--- a/scenes/quests/story_quests/el_ojo_revelador/2_combat/el_ojo_revelador_combat.tscn
+++ b/scenes/quests/story_quests/el_ojo_revelador/2_combat/el_ojo_revelador_combat.tscn
@@ -13,17 +13,12 @@
 [ext_resource type="SpriteFrames" uid="uid://b0t6gxuhl8feg" path="res://scenes/quests/story_quests/el_ojo_revelador/2_combat/combat_components/el_ojo_revelador_target_spriteframes.tres" id="10_pcbux"]
 [ext_resource type="AudioStream" uid="uid://bparraclv55l6" path="res://scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/Efecto_fireball.ogg" id="10_t1ovd"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="11_bqjni"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="12_01dyg"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="13_7t6f5"]
 [ext_resource type="Texture2D" uid="uid://daf2ilk2ingia" path="res://scenes/quests/story_quests/el_ojo_revelador/0_intro/intro_components/luz.png" id="14_7k2ib"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="14_u1uqs"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="15_3otej"]
 [ext_resource type="AudioStream" uid="uid://b44mmo4fh5s60" path="res://scenes/quests/story_quests/el_ojo_revelador/el_ojo_revelador_audios/Ambiente2_01.ogg" id="17_63hqo"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="18_63hqo"]
-
-[sub_resource type="Resource" id="Resource_dkfwt"]
-script = ExtResource("12_01dyg")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="Combat" type="Node2D" unique_id=1120252753]
 y_sort_enabled = true
@@ -271,7 +266,7 @@ color = Color(1, 1, 1, 1)
 unique_name_in_owner = true
 position = Vector2(3265, 259)
 revealed = false
-item = SubResource("Resource_dkfwt")
+item = ExtResource("14_u1uqs")
 collected_dialogue = ExtResource("2_7k2ib")
 dialogue_title = &"well_done"
 next_scene = "uid://dd12p8od2ec3w"

--- a/scenes/quests/story_quests/eldrune/1_stealth/eldrune_stealth.tscn
+++ b/scenes/quests/story_quests/eldrune/1_stealth/eldrune_stealth.tscn
@@ -21,13 +21,13 @@
 [ext_resource type="Resource" uid="uid://bbfxjku2ka16q" path="res://scenes/quests/story_quests/eldrune/1_stealth/stealth_components/eldrune_checkpoint2.dialogue" id="10_p0b5d"]
 [ext_resource type="SpriteFrames" uid="uid://cal8squrkef" path="res://scenes/quests/story_quests/eldrune/eldrune_checkpoint/eldrune_knitwitch_frames_purple.tres" id="11_8bwwe"]
 [ext_resource type="Resource" uid="uid://dwx8skx5dms6a" path="res://scenes/quests/story_quests/eldrune/1_stealth/stealth_components/eldrune_checkpoint4.dialogue" id="11_gksxr"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="11_ycvx8"]
 [ext_resource type="Resource" uid="uid://b8l6wf0v8qui6" path="res://scenes/quests/story_quests/eldrune/1_stealth/stealth_components/eldrune_collected.dialogue" id="12_dojuq"]
 [ext_resource type="Resource" uid="uid://batfvm4hnf05w" path="res://scenes/quests/story_quests/eldrune/1_stealth/stealth_components/eldrune_checkpoint3.dialogue" id="12_p6mhu"]
 [ext_resource type="Resource" uid="uid://ddu51fy1a7xow" path="res://scenes/quests/story_quests/eldrune/1_stealth/stealth_components/eldrune_checkpoint5.dialogue" id="13_8bwwe"]
 [ext_resource type="AudioStream" uid="uid://da0ptap0tsujw" path="res://scenes/quests/story_quests/eldrune/Musica/Construction.mp3" id="13_dq3if"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="13_hsvk0"]
 [ext_resource type="Resource" uid="uid://de765vp54x228" path="res://scenes/quests/story_quests/eldrune/1_stealth/stealth_components/eldrune_stealth.dialogue" id="14_dq3if"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="25_66jkx"]
 
 [sub_resource type="Curve2D" id="Curve2D_v71t3"]
 _data = {
@@ -133,10 +133,6 @@ point_count = 8
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_4yknk"]
 size = Vector2(148, 158)
-
-[sub_resource type="Resource" id="Resource_ieb5r"]
-script = ExtResource("11_ycvx8")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="StealthTemplateLevel" type="Node2D" unique_id=936922053]
 y_sort_enabled = true
@@ -567,7 +563,7 @@ debug_color = Color(0, 0, 0, 0.42)
 
 [node name="CollectibleItem" parent="." unique_id=1827110448 instance=ExtResource("10_8bwwe")]
 position = Vector2(478, 2155)
-item = SubResource("Resource_ieb5r")
+item = ExtResource("25_66jkx")
 collected_dialogue = ExtResource("12_dojuq")
 next_scene = "uid://cakexw1g553y1"
 

--- a/scenes/quests/story_quests/eldrune/2_combat/eldrune_combat.tscn
+++ b/scenes/quests/story_quests/eldrune/2_combat/eldrune_combat.tscn
@@ -13,15 +13,10 @@
 [ext_resource type="SpriteFrames" uid="uid://lrhngrxfpq7i" path="res://scenes/quests/story_quests/eldrune/2_combat/combat_components/eldrune_target_spriteframes.tres" id="10_51j36"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="11_1wb1m"]
 [ext_resource type="Script" uid="uid://cjt2u8fd0b2hp" path="res://scenes/quests/story_quests/eldrune/2_combat/combat_components/eldrune_filling_barrel.gd" id="12_flf2v"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="12_t7msw"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="13_1o1pe"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="14_prm6u"]
 [ext_resource type="PackedScene" uid="uid://2rbpl811wlv1" path="res://scenes/game_elements/props/background_music/background_music.tscn" id="16_as4dr"]
 [ext_resource type="AudioStream" uid="uid://b5d1eexymi57m" path="res://scenes/quests/story_quests/eldrune/Musica/Fantasy Choir 3.mp3" id="17_as4dr"]
-
-[sub_resource type="Resource" id="Resource_3tuwf"]
-script = ExtResource("12_t7msw")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="Combat" type="Node2D" unique_id=65657651]
 y_sort_enabled = true
@@ -74,9 +69,6 @@ position = Vector2(464, 152)
 distance = 30.0
 projectile_scene = ExtResource("8_dsveo")
 projectile_duration = 7.0
-walking_time = 0.0
-walking_range = 300.0
-walking_speed = 0.0
 
 [node name="Target" parent="OnTheGround" unique_id=480602029 instance=ExtResource("9_525xp")]
 position = Vector2(341, 419)
@@ -110,7 +102,7 @@ color = Color(1, 1, 1, 1)
 unique_name_in_owner = true
 position = Vector2(443, 200)
 revealed = false
-item = SubResource("Resource_3tuwf")
+item = ExtResource("14_prm6u")
 collected_dialogue = ExtResource("2_evre0")
 dialogue_title = &"well_done"
 next_scene = "uid://d2ao3ikovpb26"

--- a/scenes/quests/story_quests/eldrune/3_sequence_puzzle/eldrune_puzzle_2.tscn
+++ b/scenes/quests/story_quests/eldrune/3_sequence_puzzle/eldrune_puzzle_2.tscn
@@ -29,18 +29,13 @@
 [ext_resource type="SpriteFrames" uid="uid://cs30ce3ijcp2e" path="res://scenes/quests/story_quests/eldrune/3_sequence_puzzle/eldrune_sign.tres" id="14_uvao7"]
 [ext_resource type="SpriteFrames" uid="uid://m1prpwp3v5nb" path="res://scenes/quests/story_quests/eldrune/3_sequence_puzzle/eldrune_sign_2.tres" id="16_wwgta"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="19_qse1j"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="20_j4pla"]
 [ext_resource type="Resource" uid="uid://t8ki7hxqccco" path="res://scenes/quests/story_quests/eldrune/3_sequence_puzzle/eldrune_sequence_puzzle.dialogue" id="21_eovs1"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="21_vel5v"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="22_vwra0"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="33_h8wpy"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="34_urqxy"]
 [ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="35_vel5v"]
 [ext_resource type="AudioStream" uid="uid://ddhhyo7lojhuu" path="res://scenes/quests/story_quests/eldrune/Musica/TownTheme.ogg" id="36_vel5v"]
-
-[sub_resource type="Resource" id="Resource_lyrk4"]
-script = ExtResource("20_j4pla")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_oefbf"]
 animations = [{
@@ -206,7 +201,7 @@ hint_sign = NodePath("../../Signs/HintSign4")
 [node name="CollectibleItem" parent="OnTheGround" unique_id=1199875283 instance=ExtResource("19_qse1j")]
 position = Vector2(624, 558)
 revealed = false
-item = SubResource("Resource_lyrk4")
+item = ExtResource("21_vel5v")
 collected_dialogue = ExtResource("21_eovs1")
 dialogue_title = &"well_done"
 next_scene = "uid://cfi1hvtuesjjk"

--- a/scenes/quests/story_quests/renya_beyond_sorrow/1_combat/renya_combat_round_3.tscn
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/1_combat/renya_combat_round_3.tscn
@@ -17,8 +17,8 @@
 [ext_resource type="SpriteFrames" uid="uid://ci6o3o7ti17l0" path="res://scenes/quests/story_quests/renya_beyond_sorrow/1_combat/enemies_components/negacion_enemy_spriteframes.tres" id="14_ip8a5"]
 [ext_resource type="SpriteFrames" uid="uid://lt1fwrvd4a5h" path="res://scenes/quests/story_quests/renya_beyond_sorrow/1_combat/relleno/filling_spriteframes.tres" id="16_fmb00"]
 [ext_resource type="PackedScene" uid="uid://y8ha8abfyap2" path="res://scenes/game_elements/props/filling_barrel/filling_barrel.tscn" id="18_nj7sv"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="19_djale"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="19_g15s0"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="20_oa8k8"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="22_i4pom"]
 [ext_resource type="Resource" uid="uid://ctmbv8jkb5j48" path="res://scenes/quests/story_quests/renya_beyond_sorrow/1_combat/components/dialogues/renya_combat.dialogue" id="24_886ht"]
 
@@ -43,11 +43,6 @@ tracks/0/keys = {
 _data = {
 &"goal_completed": SubResource("Animation_k5uk8")
 }
-
-[sub_resource type="Resource" id="Resource_na0be"]
-script = ExtResource("20_oa8k8")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="InkCombat" type="Node2D" unique_id=441167742]
 
@@ -236,7 +231,7 @@ color = Color(0.17254902, 0.7254902, 0.011764706, 1)
 unique_name_in_owner = true
 position = Vector2(137, 175)
 revealed = false
-item = SubResource("Resource_na0be")
+item = ExtResource("19_djale")
 collected_dialogue = ExtResource("24_886ht")
 dialogue_title = &"well_done"
 next_scene = "uid://bkri3sutwl4uq"

--- a/scenes/quests/story_quests/renya_beyond_sorrow/2_sequence_puzzle/renya_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/2_sequence_puzzle/renya_sequence_puzzle.tscn
@@ -21,16 +21,11 @@
 [ext_resource type="SpriteFrames" uid="uid://b4swsfng58ikl" path="res://scenes/quests/story_quests/renya_beyond_sorrow/2_sequence_puzzle/components/renya_beyond_sorrow_sign_2.tres" id="15_tr7dq"]
 [ext_resource type="Script" uid="uid://ccc78coj2b1li" path="res://scenes/game_logic/sequence_puzzle_step.gd" id="16_jj8cg"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="17_5myqv"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="18_xxhkl"]
 [ext_resource type="Resource" uid="uid://kh4o027dgo6k" path="res://scenes/quests/story_quests/renya_beyond_sorrow/2_sequence_puzzle/components/dialogue/renya_beyond_sorrow_sequence_puzzle.dialogue" id="19_j7r3o"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="20_68hfe"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="21_vm8rx"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="22_jppep"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="22_l45x2"]
-
-[sub_resource type="Resource" id="Resource_344oq"]
-script = ExtResource("18_xxhkl")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="SequencePuzzleTemplate" type="Node2D" unique_id=130441569]
 
@@ -148,7 +143,7 @@ hint_sign = NodePath("../../Signs/HintSign2")
 [node name="CollectibleItem" parent="OnTheGround" unique_id=456727147 instance=ExtResource("17_5myqv")]
 position = Vector2(524, 1288)
 revealed = false
-item = SubResource("Resource_344oq")
+item = ExtResource("22_jppep")
 collected_dialogue = ExtResource("19_j7r3o")
 dialogue_title = &"well_done"
 next_scene = "uid://bnrkqt6j6ph7u"

--- a/scenes/quests/story_quests/renya_beyond_sorrow/3_stealth/renya_beyond_sorrow_stealth.tscn
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/3_stealth/renya_beyond_sorrow_stealth.tscn
@@ -13,10 +13,10 @@
 [ext_resource type="Resource" uid="uid://by6kjm8sh7sx8" path="res://scenes/quests/story_quests/renya_beyond_sorrow/3_stealth/stealth_components/dialogue/renya_beyond_sorrow_checkpoint.dialogue" id="8_1mg1v"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="9_pnswv"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="10_k330u"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="11_x3apo"]
 [ext_resource type="Resource" uid="uid://c1gowkhyn68ih" path="res://scenes/quests/story_quests/renya_beyond_sorrow/3_stealth/stealth_components/dialogue/renya_beyond_sorrow_collected.dialogue" id="12_1cfkr"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="13_m7vwu"]
 [ext_resource type="Resource" uid="uid://c3ljyi2iw3duc" path="res://scenes/quests/story_quests/renya_beyond_sorrow/3_stealth/stealth_components/dialogue/renya_beyond_sorrow_stealth.dialogue" id="14_ooi2f"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="14_tc2kh"]
 
 [sub_resource type="Curve2D" id="Curve2D_r7y04"]
 _data = {
@@ -80,10 +80,6 @@ point_count = 12
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ilxtq"]
 size = Vector2(168.25, 122)
-
-[sub_resource type="Resource" id="Resource_el81k"]
-script = ExtResource("11_x3apo")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_v54vi"]
 size = Vector2(133, 87)
@@ -325,7 +321,7 @@ debug_color = Color(0, 0, 0, 0.42)
 
 [node name="CollectibleItem" parent="." unique_id=892574903 instance=ExtResource("10_k330u")]
 position = Vector2(3644, 1324)
-item = SubResource("Resource_el81k")
+item = ExtResource("14_tc2kh")
 collected_dialogue = ExtResource("12_1cfkr")
 next_scene = "uid://cqs18blj5pvx7"
 

--- a/scenes/quests/story_quests/shjourney/4_Laberinto/Laberinto.tscn
+++ b/scenes/quests/story_quests/shjourney/4_Laberinto/Laberinto.tscn
@@ -15,7 +15,6 @@
 [ext_resource type="PackedScene" uid="uid://bkbyhmwv0v78v" path="res://scenes/quests/story_quests/shjourney/4_Laberinto/personajes/arbol_11.tscn" id="8_f2sr3"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="8_w3xtx"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="9_q6p3d"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="10_r8s28"]
 [ext_resource type="SpriteFrames" uid="uid://vrthlt7kah8w" path="res://scenes/quests/story_quests/shjourney/Otros_componentes/tim_sprite_frames.tres" id="11_38eo7"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="12_37aoh"]
 [ext_resource type="SpriteFrames" uid="uid://bjfl1ii3am8ll" path="res://scenes/quests/story_quests/shjourney/Otros_componentes/guardia_sprite_frames.tres" id="13_656p3"]
@@ -33,6 +32,7 @@
 [ext_resource type="Resource" uid="uid://crc4ayn4316ly" path="res://scenes/quests/story_quests/shjourney/Angel/components/dialogo-angel-puerta.dialogue" id="19_lna1e"]
 [ext_resource type="Script" uid="uid://b46ce6fs3hjco" path="res://scenes/quests/story_quests/shjourney/4_Laberinto/llave.gd" id="22_r751j"]
 [ext_resource type="Texture2D" uid="uid://d0yyk0dikkltr" path="res://scenes/quests/story_quests/shjourney/4_Laberinto/personajes/estructuras(decoracion)/puertagrande2.png" id="23_r751j"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="26_37sn7"]
 [ext_resource type="AudioStream" uid="uid://dbwjolg3xlntq" path="res://scenes/quests/story_quests/shjourney/2_shjourney_intro/template_intro_components/EffectSounds/amazon-rainforest.ogg" id="32_jg4bf"]
 [ext_resource type="AudioStream" uid="uid://beoi7axeloxrk" path="res://scenes/quests/story_quests/shjourney/2_shjourney_intro/template_intro_components/EffectSounds/male-scream.wav" id="34_3ri7t"]
 [ext_resource type="PackedScene" uid="uid://due8sqsrtdke1" path="res://scenes/quests/story_quests/shjourney/Otros_componentes/fire_fly.tscn" id="35_lldb0"]
@@ -81,10 +81,6 @@ point_count = 25
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_idy4y"]
 size = Vector2(168.25, 122)
-
-[sub_resource type="Resource" id="Resource_idy4y"]
-script = ExtResource("10_r8s28")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_t5n4b"]
 radius = 45.6777
@@ -1500,7 +1496,7 @@ follow_viewport_enabled = true
 [node name="CollectibleItem" parent="." unique_id=1822326188 instance=ExtResource("9_q6p3d")]
 show_behind_parent = true
 position = Vector2(2710, 188)
-item = SubResource("Resource_idy4y")
+item = ExtResource("26_37sn7")
 collected_dialogue = ExtResource("17_c1lxt")
 next_scene = "uid://b2e7wpdr7ebsp"
 

--- a/scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_puzzle.tscn
@@ -20,7 +20,6 @@
 [ext_resource type="SpriteFrames" uid="uid://cauuocuqonixc" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_sign.tres" id="14_50kek"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="14_fmuso"]
 [ext_resource type="AudioStream" uid="uid://b83x8h0ob5mpq" path="res://assets/third_party/nepalese_hand_bells/handBells-d4.ogg" id="14_it68j"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="15_daurq"]
 [ext_resource type="AudioStream" uid="uid://5dtwojx17yy3" path="res://assets/third_party/nepalese_hand_bells/handBells-d#4.ogg" id="16_at0ry"]
 [ext_resource type="SpriteFrames" uid="uid://b57jvrpdva2lg" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_Eye6.tres" id="16_hvqie"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="17_w086l"]
@@ -33,6 +32,7 @@
 [ext_resource type="PackedScene" uid="uid://ipvcfv2g0oi1" path="res://scenes/game_elements/characters/npcs/talker/talker.tscn" id="27_m0770"]
 [ext_resource type="Resource" uid="uid://de4oyrbo2yvok" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_guardian.dialogue" id="28_vpkld"]
 [ext_resource type="SpriteFrames" uid="uid://bkg2yqajvfipw" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_guardian.tres" id="29_hvqie"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="30_it68j"]
 [ext_resource type="Resource" uid="uid://m3wugmcg8r6m" path="res://scenes/quests/story_quests/shjourney/5_shjourney_sequence_puzzle/shjourney_sequence_components/shjourney_sequence_puzzle.dialogue" id="32_1fi4m"]
 [ext_resource type="AudioStream" uid="uid://wh36l3rfb7xa" path="res://scenes/quests/story_quests/shjourney/Otros_componentes/musicas/Minds Eye Full.ogg" id="33_at0ry"]
 [ext_resource type="PackedScene" uid="uid://dpbsi065gmh8a" path="res://scenes/game_elements/fx/fog/fog.tscn" id="35_at0ry"]
@@ -42,11 +42,6 @@ script = ExtResource("9_it68j")
 walk_speed = 190.0
 run_speed = 200.0
 metadata/_custom_type_script = "uid://csev4hv57utxv"
-
-[sub_resource type="Resource" id="Resource_u8qfb"]
-script = ExtResource("15_daurq")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="SequencePuzzleTemplate" type="Node2D" unique_id=1909753078]
 
@@ -328,7 +323,7 @@ hint_sign = NodePath("../../Signs/HintSign2")
 [node name="CollectibleItem" parent="OnTheGround" unique_id=1303420710 instance=ExtResource("14_fmuso")]
 position = Vector2(993, 491)
 revealed = false
-item = SubResource("Resource_u8qfb")
+item = ExtResource("30_it68j")
 next_scene = "uid://bc7mh0pmjqcmw"
 
 [node name="Sign" parent="OnTheGround" unique_id=1343996570 instance=ExtResource("17_w086l")]

--- a/scenes/quests/story_quests/shjourney/7_shjourney_combate/Combate.tscn
+++ b/scenes/quests/story_quests/shjourney/7_shjourney_combate/Combate.tscn
@@ -11,7 +11,6 @@
 [ext_resource type="PackedScene" uid="uid://b82nsrh332syj" path="res://scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn" id="5_xtx35"]
 [ext_resource type="PackedScene" uid="uid://y8ha8abfyap2" path="res://scenes/game_elements/props/filling_barrel/filling_barrel.tscn" id="6_t000m"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="8_0st60"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="9_14l1t"]
 [ext_resource type="SpriteFrames" uid="uid://dnuphrwcns6p" path="res://scenes/quests/story_quests/shjourney/7_shjourney_combate/template_combat_components/template_throwing_enemy.tres" id="9_lpt11"]
 [ext_resource type="AudioStream" uid="uid://cspabpdyggh4c" path="res://scenes/quests/story_quests/shjourney/2_shjourney_intro/template_intro_components/EffectSounds/fireball-woosh-pass-fast.wav" id="10_4ji03"]
 [ext_resource type="Texture2D" uid="uid://wftkywqu7g0k" path="res://scenes/quests/story_quests/shjourney/7_shjourney_combate/assets/heart_pixelart_64x64_clean_transparent-Sheet.png" id="10_l82d5"]
@@ -21,6 +20,7 @@
 [ext_resource type="PackedScene" uid="uid://duetu3j6jpxqx" path="res://scenes/quests/story_quests/shjourney/7_shjourney_combate/template_combat_components/fireball1.tscn" id="11_mtgbq"]
 [ext_resource type="PackedScene" uid="uid://gnqum6w7qe4a" path="res://scenes/quests/story_quests/shjourney/7_shjourney_combate/template_combat_components/fireball2.tscn" id="12_lpt11"]
 [ext_resource type="PackedScene" uid="uid://dkx3dgc1br3b4" path="res://scenes/ui_elements/input_hints/repel_input_hint.tscn" id="19_mtgbq"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="19_r2vdt"]
 [ext_resource type="AudioStream" uid="uid://dxoui232ly161" path="res://scenes/quests/story_quests/shjourney/Otros_componentes/musicas/Hunting in the Reeds.ogg" id="22_r2vdt"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_jqvha"]
@@ -82,10 +82,6 @@ animations = [{
 "name": &"filling",
 "speed": 10.0
 }]
-
-[sub_resource type="Resource" id="Resource_inexp"]
-script = ExtResource("9_14l1t")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="Combat" type="Node2D" unique_id=1753395573]
 y_sort_enabled = true
@@ -196,7 +192,7 @@ color = Color(1, 1, 1, 1)
 unique_name_in_owner = true
 position = Vector2(1152, 120)
 revealed = false
-item = SubResource("Resource_inexp")
+item = ExtResource("19_r2vdt")
 dialogue_title = &"well_done"
 next_scene = "uid://b4dotq384vljq"
 

--- a/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
+++ b/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth.tscn
@@ -14,7 +14,6 @@
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="7_n4o8u"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="8_jobnx"]
 [ext_resource type="Resource" uid="uid://c025q6p1owbcu" path="res://scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_checkpoint.dialogue" id="8_wgqmn"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="9_h858g"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="11_mehsu"]
 [ext_resource type="Resource" uid="uid://d3gr543f34pwh" path="res://scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_collected.dialogue" id="12_rlkm0"]
 [ext_resource type="Texture2D" uid="uid://8ujtwgp8fb1v" path="res://scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_stealth_fire.png" id="13_rlkm0"]
@@ -24,6 +23,7 @@
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="16_0ownb"]
 [ext_resource type="Resource" uid="uid://fgepu5pdp6wu" path="res://scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_firekeeper.dialogue" id="16_rlkm0"]
 [ext_resource type="SpriteFrames" uid="uid://dktcbyom7px88" path="res://scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_firekeeper.tres" id="17_0ownb"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="17_l3kdm"]
 
 [sub_resource type="Curve2D" id="Curve2D_vnsq3"]
 _data = {
@@ -111,10 +111,6 @@ point_count = 9
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_idy4y"]
 size = Vector2(264, 74.25)
-
-[sub_resource type="Resource" id="Resource_idy4y"]
-script = ExtResource("9_h858g")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0ownb"]
 atlas = ExtResource("13_rlkm0")
@@ -500,7 +496,7 @@ debug_color = Color(0, 0, 0, 0.42)
 
 [node name="CollectibleItem" parent="OnTheGround" unique_id=1494033634 instance=ExtResource("8_jobnx")]
 position = Vector2(451, 775)
-item = SubResource("Resource_idy4y")
+item = ExtResource("17_l3kdm")
 collected_dialogue = ExtResource("12_rlkm0")
 next_scene = "uid://bfr7svwx5hqkf"
 

--- a/scenes/quests/story_quests/stella/2_stella_combat/stella_combat.tscn
+++ b/scenes/quests/story_quests/stella/2_stella_combat/stella_combat.tscn
@@ -15,12 +15,12 @@
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="7_fttab"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="8_2svos"]
 [ext_resource type="TileSet" uid="uid://dfp36ffpanjq2" path="res://tiles/elevation.tres" id="8_gsim2"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="9_chxci"]
 [ext_resource type="TileSet" uid="uid://do0ffypatd77h" path="res://tiles/bridges.tres" id="9_ky4po"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="10_xeai8"]
 [ext_resource type="Texture2D" uid="uid://cpqvaoatvjc2d" path="res://scenes/quests/story_quests/stella/2_stella_combat/stella_combat_components/stella_target.png" id="13_ndyje"]
 [ext_resource type="PackedScene" uid="uid://ipvcfv2g0oi1" path="res://scenes/game_elements/characters/npcs/talker/talker.tscn" id="14_asncp"]
 [ext_resource type="SpriteFrames" uid="uid://b8ib21ye5xvwb" path="res://scenes/quests/story_quests/stella/2_stella_combat/stella_combat_components/stella_fisherman.tres" id="14_e46so"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="20_17ppw"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_btmjw"]
 atlas = ExtResource("13_ndyje")
@@ -60,11 +60,6 @@ animations = [{
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ndyje"]
 size = Vector2(101, 91.5)
-
-[sub_resource type="Resource" id="Resource_a51xm"]
-script = ExtResource("9_chxci")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="StellaCombat" type="Node2D" unique_id=1263390013]
 script = ExtResource("1_17ppw")
@@ -172,7 +167,7 @@ shape = SubResource("RectangleShape2D_ndyje")
 unique_name_in_owner = true
 position = Vector2(139, 254)
 revealed = false
-item = SubResource("Resource_a51xm")
+item = ExtResource("20_17ppw")
 collected_dialogue = ExtResource("2_awu4o")
 dialogue_title = &"well_done"
 next_scene = "uid://b7j5em2h1m2j7"

--- a/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_puzzle.tscn
@@ -7,9 +7,9 @@
 [ext_resource type="Script" uid="uid://c68oh8dtr21ti" path="res://scenes/game_logic/sequence_puzzle.gd" id="3_an7xq"]
 [ext_resource type="SpriteFrames" uid="uid://dn0ivusgamrg3" path="res://scenes/quests/story_quests/stella/stella_player_components/stella_player.tres" id="3_r0gok"]
 [ext_resource type="PackedScene" uid="uid://be4o3ythda4cu" path="res://scenes/game_elements/props/sequence_puzzle_hint_sign/sequence_puzzle_hint_sign.tscn" id="11_c8urv"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="12_moe01"]
 [ext_resource type="Script" uid="uid://ccc78coj2b1li" path="res://scenes/game_logic/sequence_puzzle_step.gd" id="13_cyoxr"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="14_edmpl"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="15_2p35u"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="18_w255e"]
 [ext_resource type="PackedScene" uid="uid://ipvcfv2g0oi1" path="res://scenes/game_elements/characters/npcs/talker/talker.tscn" id="19_iwkby"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="19_mt5a1"]
@@ -20,11 +20,6 @@
 [ext_resource type="SpriteFrames" uid="uid://2ek86nvw6y28" path="res://scenes/game_elements/props/tree/components/tree_spriteframes_yellow.tres" id="31_xd6u5"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="32_7w21t"]
 [ext_resource type="Resource" uid="uid://wpifv4dfofm2" path="res://scenes/quests/story_quests/stella/3_stella_sequence_puzzle/stella_sequence_components/stella_sequence_puzzle.dialogue" id="33_g4uwj"]
-
-[sub_resource type="Resource" id="Resource_u8qfb"]
-script = ExtResource("15_2p35u")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="StellaSequencePuzzle" type="Node2D" unique_id=1076373484]
 
@@ -100,7 +95,7 @@ hint_sign = NodePath("../../Signs/HintSign3")
 [node name="CollectibleItem" parent="OnTheGround" unique_id=838740229 instance=ExtResource("14_edmpl")]
 position = Vector2(831, 462)
 revealed = false
-item = SubResource("Resource_u8qfb")
+item = ExtResource("12_moe01")
 collected_dialogue = ExtResource("33_g4uwj")
 dialogue_title = &"well_done"
 next_scene = "uid://dd8wip76jpadr"

--- a/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat.tscn
+++ b/scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat.tscn
@@ -17,11 +17,11 @@
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="8_weewi"]
 [ext_resource type="Texture2D" uid="uid://jh8ohi4wxxid" path="res://scenes/quests/story_quests/verso/assets/Scribbled_Stack_Papers_Tiles.png" id="9_7yave"]
 [ext_resource type="Texture2D" uid="uid://dcq6v7mx3h1fl" path="res://assets/first_party/tiles/Dirt_Tiles.png" id="9_d4ogx"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="9_ml8ui"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="10_ntgxy"]
 [ext_resource type="Texture2D" uid="uid://bvanws8kq1xde" path="res://scenes/quests/story_quests/verso/assets/Eraser_Tiles.png" id="13_qh7o3"]
 [ext_resource type="SpriteFrames" uid="uid://dy4hi40ctxeno" path="res://scenes/quests/story_quests/verso/verso_player_components/verso_player.tres" id="18_2bah4"]
 [ext_resource type="PackedScene" uid="uid://bwqrh7clivubq" path="res://scenes/quests/story_quests/verso/assets/sharpener/pencil_sharpener.tscn" id="22_gbl6x"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="22_qh7o3"]
 [ext_resource type="PackedScene" uid="uid://dcoas3imo10p5" path="res://scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/ThrowingEnemyHealth.tscn" id="26_d6umq"]
 [ext_resource type="Resource" uid="uid://dbjm7schpu1dk" path="res://scenes/quests/story_quests/verso/1_verso_combat_anger/verso_combat_components/verso_combat.dialogue" id="26_m5ihe"]
 
@@ -311,11 +311,6 @@ sources/4 = SubResource("TileSetAtlasSource_dn5jo")
 sources/0 = SubResource("TileSetAtlasSource_m5ihe")
 sources/5 = SubResource("TileSetAtlasSource_yxv4n")
 
-[sub_resource type="Resource" id="Resource_a51xm"]
-script = ExtResource("9_ml8ui")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
-
 [node name="Combat" type="Node2D" unique_id=139364543]
 y_sort_enabled = true
 
@@ -361,7 +356,7 @@ position = Vector2(1450, 606)
 unique_name_in_owner = true
 position = Vector2(868, 303)
 revealed = false
-item = SubResource("Resource_a51xm")
+item = ExtResource("22_qh7o3")
 collected_dialogue = ExtResource("26_m5ihe")
 dialogue_title = &"well_done"
 next_scene = "uid://runaj1nwk77c"

--- a/scenes/quests/story_quests/verso/2_verso_stealth_sadness/verso_stealth.tscn
+++ b/scenes/quests/story_quests/verso/2_verso_stealth_sadness/verso_stealth.tscn
@@ -16,13 +16,13 @@
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="8_12nev"]
 [ext_resource type="Texture2D" uid="uid://cophwiv5rmm1" path="res://scenes/quests/story_quests/verso/assets/Hallway_Tiles.png" id="8_nsaju"]
 [ext_resource type="Texture2D" uid="uid://dqcacyxq3xdcx" path="res://scenes/quests/story_quests/verso/assets/Teacher_Desk_Prop.png" id="9_6m3nq"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="9_fn542"]
 [ext_resource type="Texture2D" uid="uid://c7oht7wudd8wa" path="res://assets/first_party/tiles/Cliff_Tiles.png" id="9_lsgvj"]
 [ext_resource type="TileSet" uid="uid://b8qnr0owsbhhn" path="res://tiles/exterior_floors.tres" id="10_e83wv"]
 [ext_resource type="Resource" uid="uid://de2hf2j6lfmcj" path="res://scenes/quests/story_quests/verso/2_verso_stealth_sadness/verso_stealth_components/verso_collected.dialogue" id="10_gidvg"]
 [ext_resource type="PackedScene" uid="uid://b2gi1i8mpyp6x" path="res://scenes/quests/story_quests/verso/assets/teacher_desk/teacher_desk.tscn" id="10_wdmba"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="11_0lwn1"]
 [ext_resource type="SpriteFrames" uid="uid://dy4hi40ctxeno" path="res://scenes/quests/story_quests/verso/verso_player_components/verso_player.tres" id="13_4e5pa"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="21_e83wv"]
 [ext_resource type="Resource" uid="uid://de1u8st6lbktc" path="res://scenes/quests/story_quests/verso/2_verso_stealth_sadness/verso_stealth_components/verso_stealth.dialogue" id="21_lsgvj"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_lib0f"]
@@ -564,10 +564,6 @@ point_count = 12
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_idy4y"]
 size = Vector2(107.5, 95)
 
-[sub_resource type="Resource" id="Resource_idy4y"]
-script = ExtResource("9_fn542")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
-
 [node name="StealthTemplateLevel2" type="Node2D" unique_id=884215565]
 y_sort_enabled = true
 
@@ -954,7 +950,7 @@ debug_color = Color(0, 0, 0, 0.42)
 
 [node name="CollectibleItem" parent="." unique_id=1327166988 instance=ExtResource("8_12nev")]
 position = Vector2(3424, 2833)
-item = SubResource("Resource_idy4y")
+item = ExtResource("21_e83wv")
 collected_dialogue = ExtResource("10_gidvg")
 next_scene = "uid://c0a4bblbj21b7"
 

--- a/scenes/quests/story_quests/verso/3_verso_sequence_puzzle_happiness/verso_sequence_puzzle.tscn
+++ b/scenes/quests/story_quests/verso/3_verso_sequence_puzzle_happiness/verso_sequence_puzzle.tscn
@@ -16,7 +16,7 @@
 [ext_resource type="SpriteFrames" uid="uid://kl603uwmtosm" path="res://scenes/quests/story_quests/verso/3_verso_sequence_puzzle_happiness/verso_hint_book.tres" id="12_dbfhi"]
 [ext_resource type="Script" uid="uid://ccc78coj2b1li" path="res://scenes/game_logic/sequence_puzzle_step.gd" id="13_c1wqg"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="14_y31ij"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="15_5k7sg"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="17_x86hm"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="18_g781g"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="19_w3ler"]
 [ext_resource type="Resource" uid="uid://buibv2w6d1mjg" path="res://scenes/quests/story_quests/verso/3_verso_sequence_puzzle_happiness/verso_sequence_puzzle.dialogue" id="20_x86hm"]
@@ -88,11 +88,6 @@ texture_region_size = Vector2i(64, 64)
 tile_size = Vector2i(64, 64)
 physics_layer_0/collision_layer = 1
 sources/2 = SubResource("TileSetAtlasSource_wnk0x")
-
-[sub_resource type="Resource" id="Resource_u8qfb"]
-script = ExtResource("15_5k7sg")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="SequencePuzzleTemplate" type="Node2D" unique_id=1071676546]
 
@@ -318,7 +313,7 @@ hint_sign = NodePath("../../Signs/HintSign2")
 [node name="CollectibleItem" parent="OnTheGround" unique_id=1302492123 instance=ExtResource("14_y31ij")]
 position = Vector2(1045, 958)
 revealed = false
-item = SubResource("Resource_u8qfb")
+item = ExtResource("17_x86hm")
 collected_dialogue = ExtResource("20_x86hm")
 dialogue_title = &"well_done"
 next_scene = "uid://daokn3huj1lsy"

--- a/scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth.tscn
@@ -10,7 +10,7 @@
 [ext_resource type="Resource" uid="uid://cppk2qynt485b" path="res://scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth_components/NO_EDIT_checkpoint.dialogue" id="7_eujsg"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="8_gxd2f"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="9_v0n5i"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="10_tbnoi"]
+[ext_resource type="Resource" uid="uid://ck0wbckgm5un8" path="res://scenes/globals/game_state/inventory/memory.tres" id="10_axd4p"]
 [ext_resource type="Resource" uid="uid://dpv4wurvaamhb" path="res://scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth_components/NO_EDIT_collected.dialogue" id="11_f7iof"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="12_bs0vj"]
 [ext_resource type="Resource" uid="uid://cggywn8t6s4le" path="res://scenes/quests/template_quests/NO_EDIT/1_NO_EDIT_stealth/NO_EDIT_stealth_components/NO_EDIT_stealth.dialogue" id="13_y0fxw"]
@@ -31,10 +31,6 @@ point_count = 8
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_idy4y"]
 size = Vector2(168.25, 122)
-
-[sub_resource type="Resource" id="Resource_idy4y"]
-script = ExtResource("10_tbnoi")
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="NoEditStealth" type="Node2D" unique_id=528815133]
 
@@ -114,7 +110,7 @@ debug_color = Color(0, 0, 0, 0.42)
 
 [node name="CollectibleItem" parent="OnTheGround" unique_id=1779229490 instance=ExtResource("9_v0n5i")]
 position = Vector2(2335, 955)
-item = SubResource("Resource_idy4y")
+item = ExtResource("10_axd4p")
 collected_dialogue = ExtResource("11_f7iof")
 next_scene = "uid://thwcu5akkqp5"
 

--- a/scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat.tscn
@@ -10,20 +10,15 @@
 [ext_resource type="SpriteFrames" uid="uid://c50725q5ey5j5" path="res://scenes/quests/template_quests/NO_EDIT/2_NO_EDIT_combat/NO_EDIT_combat_components/NO_EDIT_target_spriteframes.tres" id="7_sdnn7"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="10_a6ony"]
 [ext_resource type="PackedScene" uid="uid://iu2q66clupc6" path="res://scenes/game_elements/characters/player/player.tscn" id="10_rcv3t"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="11_4lmqk"]
 [ext_resource type="PackedScene" uid="uid://b82nsrh332syj" path="res://scenes/game_elements/characters/enemies/throwing_enemy/throwing_enemy.tscn" id="11_64btt"]
 [ext_resource type="PackedScene" uid="uid://y8ha8abfyap2" path="res://scenes/game_elements/props/filling_barrel/filling_barrel.tscn" id="12_2eyq6"]
+[ext_resource type="Resource" uid="uid://cchnv5pn6fa8e" path="res://scenes/globals/game_state/inventory/imagination.tres" id="13_ku1na"]
 [ext_resource type="PackedScene" uid="uid://dmevaymmt6wco" path="res://scenes/game_elements/props/powerup/powerup.tscn" id="14_6xf5p"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="14_ttfgd"]
 [ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="16_t2kes"]
 [ext_resource type="AudioStream" uid="uid://dgwihwibc8ah6" path="res://assets/first_party/music/Threadbare_Combat.ogg" id="17_ku1na"]
 [ext_resource type="AudioStream" uid="uid://bbamdm6wtjjcn" path="res://assets/first_party/music/Threadbare_Bed.ogg" id="18_bxavx"]
 [ext_resource type="Script" uid="uid://c2lx7gvkonxaa" path="res://scenes/game_elements/props/background_music/components/clip_switcher.gd" id="18_ku1na"]
-
-[sub_resource type="Resource" id="Resource_a51xm"]
-script = ExtResource("11_4lmqk")
-type = 1
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [sub_resource type="AudioStreamInteractive" id="AudioStreamInteractive_niajk"]
 clip_count = 2
@@ -121,7 +116,7 @@ color = Color(1, 1, 1, 1)
 unique_name_in_owner = true
 position = Vector2(868, 303)
 revealed = false
-item = SubResource("Resource_a51xm")
+item = ExtResource("13_ku1na")
 collected_dialogue = ExtResource("2_3qn31")
 dialogue_title = &"well_done"
 next_scene = "uid://x3wm2ce0ax8i"

--- a/scenes/quests/template_quests/NO_EDIT/3_NO_EDIT_sequence_puzzle/NO_EDIT_sequence_puzzle.tscn
+++ b/scenes/quests/template_quests/NO_EDIT/3_NO_EDIT_sequence_puzzle/NO_EDIT_sequence_puzzle.tscn
@@ -17,17 +17,12 @@
 [ext_resource type="SpriteFrames" uid="uid://bhcgkxhy4cqf4" path="res://scenes/quests/template_quests/NO_EDIT/3_NO_EDIT_sequence_puzzle/NO_EDIT_sign_2.tres" id="12_8jbpq"]
 [ext_resource type="Script" uid="uid://ccc78coj2b1li" path="res://scenes/game_logic/sequence_puzzle_step.gd" id="13_ewc4v"]
 [ext_resource type="PackedScene" uid="uid://fuhl3l6gxq5k" path="res://scenes/game_elements/props/collectible_item/collectible_item.tscn" id="14_opnjc"]
-[ext_resource type="Script" uid="uid://bgmwplmj3bfls" path="res://scenes/globals/game_state/inventory/inventory_item.gd" id="15_5fyey"]
 [ext_resource type="Resource" uid="uid://bb1g8ftnxjhvh" path="res://scenes/quests/template_quests/NO_EDIT/3_NO_EDIT_sequence_puzzle/NO_EDIT_sequence_puzzle.dialogue" id="16_bt1lb"]
 [ext_resource type="PackedScene" uid="uid://covsdqqsd6rsy" path="res://scenes/game_elements/props/sign/sign.tscn" id="17_757eh"]
+[ext_resource type="Resource" uid="uid://c44l6x4e7sfx3" path="res://scenes/globals/game_state/inventory/spirit.tres" id="18_e434m"]
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="18_fip7f"]
 [ext_resource type="Script" uid="uid://x1mxt6bmei2o" path="res://scenes/ui_elements/cinematic/cinematic.gd" id="19_7si2r"]
 [ext_resource type="Script" uid="uid://c8405c212rbn6" path="res://scenes/game_elements/props/background_music/components/background_music.gd" id="23_42ab1"]
-
-[sub_resource type="Resource" id="Resource_u8qfb"]
-script = ExtResource("15_5fyey")
-type = 2
-metadata/_custom_type_script = "uid://bgmwplmj3bfls"
 
 [node name="NoEditSequencePuzzle" type="Node2D" unique_id=217609538]
 
@@ -128,7 +123,7 @@ hint_sign = NodePath("../../Signs/HintSign2")
 [node name="CollectibleItem" parent="OnTheGround" unique_id=1678374994 instance=ExtResource("14_opnjc")]
 position = Vector2(861, 282)
 revealed = false
-item = SubResource("Resource_u8qfb")
+item = ExtResource("18_e434m")
 collected_dialogue = ExtResource("16_bt1lb")
 dialogue_title = &"well_done"
 next_scene = "uid://cqjdjcwwfg0xi"

--- a/scenes/ui_elements/dialogue/components/response_button.gd
+++ b/scenes/ui_elements/dialogue/components/response_button.gd
@@ -13,6 +13,7 @@ func set_response(value: DialogueResponse) -> void:
 
 	var thread_type := response.get_tag_value("thread")
 	if thread_type and thread_type.to_upper() in InventoryItem.ItemType:
-		icon = InventoryItem.HUD_TEXTURES[InventoryItem.ItemType[thread_type.to_upper()]]
+		var item_type: InventoryItem.ItemType = InventoryItem.ItemType[thread_type.to_upper()]
+		icon = InventoryItem.with_type(item_type).hud_texture
 	else:
 		icon = null

--- a/scenes/ui_elements/story_quest_progress/components/item_slot/components/item_slot.gd
+++ b/scenes/ui_elements/story_quest_progress/components/item_slot/components/item_slot.gd
@@ -8,7 +8,7 @@ var filled_with_item: InventoryItem = null:
 	set(new_item):
 		filled_with_item = new_item
 		if filled_with_item:
-			texture = filled_with_item.get_hud_texture()
+			texture = filled_with_item.hud_texture
 
 @onready var animation_player: AnimationPlayer = $AnimationPlayer
 
@@ -32,7 +32,7 @@ func fill(inventory_item: InventoryItem) -> void:
 		return
 
 	filled_with_item = inventory_item
-	texture = inventory_item.get_hud_texture()
+	texture = inventory_item.hud_texture
 	pivot_offset = size / 2.0
 	animation_player.play(&"item_collected")
 	await animation_player.animation_finished

--- a/scenes/ui_elements/story_quest_progress/components/story_quest_progress.gd
+++ b/scenes/ui_elements/story_quest_progress/components/story_quest_progress.gd
@@ -51,7 +51,9 @@ func _on_helper_state_changed() -> void:
 		head.reparent(helper_container)
 		head.process_mode = Node.PROCESS_MODE_DISABLED
 		remove_child(helper_character)
-		helper_color.color = InventoryItem.COLORS_PER_TYPE[GameState.global.helper.helper_type]
+		# TODO: store item in game state instead?
+		var item := InventoryItem.with_type(GameState.global.helper.helper_type)
+		helper_color.color = item.color
 
 
 func _on_item_collected(item: InventoryItem) -> void:


### PR DESCRIPTION
Previously we defined InventoryItem resources inline in every scene that
uses them; and we hardcoded the world texture, HUD texture, and colour
for each in the script.

Turn these into properties of the resource. Create 3 on-disk resources
for the memory, imagination, and spirit threads. Add migration code to
collectible_item.gd which updates the property so that loading & saving
a scene using this script does the migration. Leave the migration code
in-place so that as out-of-tree quests are merged we can easily update
them.

Change the inventory storage to refer to those, rather than saving just
the item type name and reconstructing resources on load.

I think this will make it easier to add collectibles which are not
threads in future, and also to remember which threads have been
collected when loading or replaying a quest, though I haven't attempted
to do that here.