### PR TITLE
Add Language enum to StoryQuest resources

### DIFF
--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -15,8 +15,17 @@ enum Status {
 	BROKEN = 2,
 }
 
+##The language of a quest.
+enum Language {
+	ENGLISH,
+	SPANISH,
+}
+
 ## [Quest] resources must have this filename to be found by the game.
 const FILENAME := "quest.tres"
+
+## The language of this quest.
+@export var language: Language = Language.ENGLISH
 
 ## The development status of this quest.
 @export var status: Status = Status.WORK_IN_PROGRESS

--- a/scenes/quests/story_quests/el_abrigo/quest.tres
+++ b/scenes/quests/story_quests/el_abrigo/quest.tres
@@ -4,6 +4,7 @@
 
 [resource]
 script = ExtResource("1_4uyxg")
+language = 1
 status = 1
 title = "El Abrigo"
 description = "Kaiser, un joven tejedor errante, debe ayudar a una misteriosa comerciante a conseguir los tres hilos sagrados necesarios para confeccionar un abrigo capaz de resistir el paso helado entre reinos. Para lograrlo, deberá superar tres desafíos únicos: capturar la lana cálida de la Oveja Carmesí en las colinas otoñales y recolectar la fibra de seda helada. Al ritmo del viento, en el Bosque de Hilos Helados, seguirá patrones rítmicos sin romperlos para recolectar el hilo azul de seda helada. Con la astucia de un gato, deberá inmercionarse en la profundidad del Golden Cave, para conseguir la legendaria lana dorada y por último deberá atrapar a la escurridiza oveja en los montes  otoñales para conseguir la lana cálida roja. 

--- a/scenes/quests/story_quests/el_juguete_perdido/quest.tres
+++ b/scenes/quests/story_quests/el_juguete_perdido/quest.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_bk13m")
+language = 1
 status = 1
 title = "El Juguete Perdido"
 description = "La historia se centra en la búsqueda de Apolo, un niño curioso y valiente que ha desaparecido tras perseguir a su archienemigo, Python. El anciano Elder, preocupado por la ausencia de su nieto, encomienda al viajero la tarea de encontrarlo en las cavernas del bosque en donde asechan los goblins."

--- a/scenes/quests/story_quests/el_ojo_revelador/quest.tres
+++ b/scenes/quests/story_quests/el_ojo_revelador/quest.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_nmqt7")
+language = 1
 title = "El ojo revelador"
 description = "Jeremy Jones, un explorador de élite se adentra a un templo buscando un tesoro en forma de diamante llamado “El ojo revelador”, pero para conseguirlo deberá usar su ingenio y habilidades para superar distintos obstáculos. Cuando finalmente alcanza el preciado tesoro, este le mostrará una verdad que había olvidado."
 authors = Array[String](["Robert Ignacio Vasquez Sanchez", "Jose Enrique Gonzales Amaro", "Diego Leonardo Choque Castro", "Erasmo Jesús Llanos Trujillo", "Edison Paucar Cisneros"])

--- a/scenes/quests/story_quests/eldrune/quest.tres
+++ b/scenes/quests/story_quests/eldrune/quest.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_ukbr7")
+language = 1
 title = "Eldrune"
 description = "Lyrem es un joven mago de Eldline con un don inusual: puede escuchar las runas elementales. Mientras que la mayoría de los magos dominan un solo elemento —tres en el caso de los excepcionalmente talentosos—, Lyrem puede dominar tantos como descubra. Guiado por susurros ancestrales hacia runas prohibidas ocultas en templos y ruinas, adquiere nuevos poderes y descubre una oscura verdad: el Rey Malvado está regresando."
 authors = Array[String](["Josué Carmelo Murga Guimaray", "Jhonny Denis Mamani Moreno", "Edu Sergio Lazo Armas", "Manuel Augusto Díaz Guarda"])

--- a/scenes/quests/story_quests/renya_beyond_sorrow/quest.tres
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/quest.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_kgprh")
+language = 1
 title = "Renya: Beyond Sorrow"
 description = "Renya, cansada de ver que las almas no logran avanzar a la siguiente fase, decide viajar a DemoPenthos para poner orden. Sin embargo, pronto descubrirá que las almas que habitan allí no necesitan ser forzadas, sino comprendidas. En este viaje, Renya aprenderá a reconciliar su propio caos interno y a conectar con ellas desde la empatía."
 authors = Array[String](["Daniela Nayeli Suarez Franklin", "Francisco Bush Izaguirre Sonco ", "Bianca Pierina Espejo Sandoval", "Andrea Nicole Ugarte Calero"])

--- a/scenes/quests/story_quests/shjourney/quest.tres
+++ b/scenes/quests/story_quests/shjourney/quest.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_ssubp")
+language = 1
 title = "Sueños nocturnos"
 description = "Cuando su hermana desaparece misteriosamente durante el sueño, Tim se lanza a un mundo de pesadillas vivientes donde la realidad se retuerce con sus temores más profundos. Enfrentando un laberinto que devora la memoria, una mazmorra poseída por melodías espectrales y un dios del inframundo sediento de almas, Tim deberá superar pruebas imposibles para reunir los fragmentos de luz que lo guíen hasta ella... antes de que el sueño se convierta en prisión eterna."
 authors = Array[String](["Gian Piero Daniel Cano Espejo", "Leopoldo Josue Brito Ruiz", "Joseph Montes de Oca Untiveros", "Leonardo Jesus Contreras Moriano.", "Shirley Torres"])


### PR DESCRIPTION
There is a Language enum (ENGLISH, SPANISH) added to quest.gd with an exported variable to categorize each quest by language. All of the existing quest .tres files are updated to their appropriate language setting.

Helps #2548 