### PR TITLE
Quest: Add language field

### DIFF
--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -22,7 +22,7 @@ const FILENAME := "quest.tres"
 @export var status: Status = Status.WORK_IN_PROGRESS
 
 ## The 2-letter ISO language code for the quest.
-@export var language: String = "en"
+@export_enum("en", "es") var language: String = "en"
 
 ## The quest's title. This should be short, like the title of a novel.
 @export var title: String

--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -21,7 +21,7 @@ const FILENAME := "quest.tres"
 ## The development status of this quest.
 @export var status: Status = Status.WORK_IN_PROGRESS
 
-## The 2-letter ISO language code for the quest.
+## The 2-letter ISO 639 language code for the quest.
 @export_enum("en", "es") var language: String = "en"
 
 ## The quest's title. This should be short, like the title of a novel.

--- a/scenes/menus/storybook/components/quest.gd
+++ b/scenes/menus/storybook/components/quest.gd
@@ -21,6 +21,9 @@ const FILENAME := "quest.tres"
 ## The development status of this quest.
 @export var status: Status = Status.WORK_IN_PROGRESS
 
+## The 2-letter ISO language code for the quest.
+@export var language: String = "en"
+
 ## The quest's title. This should be short, like the title of a novel.
 @export var title: String
 

--- a/scenes/quests/story_quests/after_the_tremor/quest.tres
+++ b/scenes/quests/story_quests/after_the_tremor/quest.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_dx67k")
+language = "es"
 title = "After The Tremor"
 description = "Despues de un temblor misterioso. Bryan y Charlie salen en busqueda de sus seres queridos, en una aldea con peligros en todos lados."
 authors = Array[String](["Alvaro Roldan", "Dulce Gonzales", "Andre Lagos"])

--- a/scenes/quests/story_quests/el_abrigo/quest.tres
+++ b/scenes/quests/story_quests/el_abrigo/quest.tres
@@ -5,6 +5,7 @@
 [resource]
 script = ExtResource("1_4uyxg")
 status = 1
+language = "es"
 title = "El Abrigo"
 description = "Kaiser, un joven tejedor errante, debe ayudar a una misteriosa comerciante a conseguir los tres hilos sagrados necesarios para confeccionar un abrigo capaz de resistir el paso helado entre reinos. Para lograrlo, deberá superar tres desafíos únicos: capturar la lana cálida de la Oveja Carmesí en las colinas otoñales y recolectar la fibra de seda helada. Al ritmo del viento, en el Bosque de Hilos Helados, seguirá patrones rítmicos sin romperlos para recolectar el hilo azul de seda helada. Con la astucia de un gato, deberá inmercionarse en la profundidad del Golden Cave, para conseguir la legendaria lana dorada y por último deberá atrapar a la escurridiza oveja en los montes  otoñales para conseguir la lana cálida roja. 
 "

--- a/scenes/quests/story_quests/el_juguete_perdido/quest.tres
+++ b/scenes/quests/story_quests/el_juguete_perdido/quest.tres
@@ -6,6 +6,7 @@
 [resource]
 script = ExtResource("1_bk13m")
 status = 1
+language = "es"
 title = "El Juguete Perdido"
 description = "La historia se centra en la búsqueda de Apolo, un niño curioso y valiente que ha desaparecido tras perseguir a su archienemigo, Python. El anciano Elder, preocupado por la ausencia de su nieto, encomienda al viajero la tarea de encontrarlo en las cavernas del bosque en donde asechan los goblins."
 authors = Array[String](["Miguel Navarro", "Omar Mendez"])

--- a/scenes/quests/story_quests/el_ojo_revelador/quest.tres
+++ b/scenes/quests/story_quests/el_ojo_revelador/quest.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_nmqt7")
+language = "es"
 title = "El ojo revelador"
 description = "Jeremy Jones, un explorador de élite se adentra a un templo buscando un tesoro en forma de diamante llamado “El ojo revelador”, pero para conseguirlo deberá usar su ingenio y habilidades para superar distintos obstáculos. Cuando finalmente alcanza el preciado tesoro, este le mostrará una verdad que había olvidado."
 authors = Array[String](["Robert Ignacio Vasquez Sanchez", "Jose Enrique Gonzales Amaro", "Diego Leonardo Choque Castro", "Erasmo Jesús Llanos Trujillo", "Edison Paucar Cisneros"])

--- a/scenes/quests/story_quests/eldrune/quest.tres
+++ b/scenes/quests/story_quests/eldrune/quest.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_ukbr7")
+language = "es"
 title = "Eldrune"
 description = "Lyrem es un joven mago de Eldline con un don inusual: puede escuchar las runas elementales. Mientras que la mayoría de los magos dominan un solo elemento —tres en el caso de los excepcionalmente talentosos—, Lyrem puede dominar tantos como descubra. Guiado por susurros ancestrales hacia runas prohibidas ocultas en templos y ruinas, adquiere nuevos poderes y descubre una oscura verdad: el Rey Malvado está regresando."
 authors = Array[String](["Josué Carmelo Murga Guimaray", "Jhonny Denis Mamani Moreno", "Edu Sergio Lazo Armas", "Manuel Augusto Díaz Guarda"])

--- a/scenes/quests/story_quests/renya_beyond_sorrow/quest.tres
+++ b/scenes/quests/story_quests/renya_beyond_sorrow/quest.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_kgprh")
+language = "es"
 title = "Renya: Beyond Sorrow"
 description = "Renya, cansada de ver que las almas no logran avanzar a la siguiente fase, decide viajar a DemoPenthos para poner orden. Sin embargo, pronto descubrirá que las almas que habitan allí no necesitan ser forzadas, sino comprendidas. En este viaje, Renya aprenderá a reconciliar su propio caos interno y a conectar con ellas desde la empatía."
 authors = Array[String](["Daniela Nayeli Suarez Franklin", "Francisco Bush Izaguirre Sonco ", "Bianca Pierina Espejo Sandoval", "Andrea Nicole Ugarte Calero"])

--- a/scenes/quests/story_quests/shjourney/quest.tres
+++ b/scenes/quests/story_quests/shjourney/quest.tres
@@ -5,6 +5,7 @@
 
 [resource]
 script = ExtResource("1_ssubp")
+language = "es"
 title = "Sueños nocturnos"
 description = "Cuando su hermana desaparece misteriosamente durante el sueño, Tim se lanza a un mundo de pesadillas vivientes donde la realidad se retuerce con sus temores más profundos. Enfrentando un laberinto que devora la memoria, una mazmorra poseída por melodías espectrales y un dios del inframundo sediento de almas, Tim deberá superar pruebas imposibles para reunir los fragmentos de luz que lo guíen hasta ella... antes de que el sueño se convierta en prisión eterna."
 authors = Array[String](["Gian Piero Daniel Cano Espejo", "Leopoldo Josue Brito Ruiz", "Joseph Montes de Oca Untiveros", "Leonardo Jesus Contreras Moriano.", "Shirley Torres"])


### PR DESCRIPTION
Add a field to the `Quest` resource, `language`, which holds the ISO 639 alpha-2 code for the language of the text in the quest.

Update all existing quests with the appropriate language.

Helps #2548 