### PR TITLE
tools: Add script to load+save all scenes that use some resource

### DIFF
--- a/tools/bulk_resave_scenes.gd
+++ b/tools/bulk_resave_scenes.gd
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: The Threadbare Authors
+# SPDX-License-Identifier: MPL-2.0
+@tool
+class_name BulkResaveScenes
+extends EditorScript
+## Loads and saves all scenes which depend on particular resource(s)
+##
+## Edit [const DEPENDENCIES] then run this in the editor.
+## [br][br]
+## This can be useful when the dependency has code that adjusts the scene (or
+## itself) when opened in the editor. You can also use Project -> Tools ->
+## Upgrade Project Files... but that saves every scene in the project and takes
+## ages.
+
+const Util = preload("./util.gd")
+const DEPENDENCIES := [
+	"res://scenes/game_elements/props/collectible_item/collectible_item.tscn",
+]
+
+
+func _matches(scene_path: String) -> bool:
+	for dependency: String in ResourceLoader.get_dependencies(scene_path):
+		var path := dependency.get_slice("::", 2) if dependency.contains("::") else dependency
+		if path in DEPENDENCIES:
+			return true
+
+	return false
+
+
+func resave(ps: PackedScene) -> void:
+	var root_node := ps.instantiate(PackedScene.GenEditState.GEN_EDIT_STATE_INSTANCE)
+	var result := ps.pack(root_node)
+	if result == OK:
+		result = ResourceSaver.save(ps)
+		if result != OK:
+			prints("failed to save", ps, result)
+	else:
+		prints("failed to pack", ps, result)
+	root_node.queue_free()
+
+
+func _run() -> void:
+	for ps: PackedScene in Util.find_scenes("res://scenes/quests", _matches):
+		prints("-", ps.resource_path)
+		resave(ps)

--- a/tools/bulk_resave_scenes.gd.uid
+++ b/tools/bulk_resave_scenes.gd.uid
@@ -1,0 +1,1 @@
+uid://ckmx0dwqwraju


### PR DESCRIPTION
This is useful when making some change across all instances of a
script/scene:

1. Add migration code to the script that runs when the node is
   instantiated
2. Run this script
3. Remove the migration code
4. Commit the result

As commented here you can do this by running a built-in tool that does
this to *all* scenes but this can be much more disruptive.

You can also do this in the editor by using View Owners..., selecting
all, opening all the scenes, then saving each one. You can't use "save
all scenes" unless you have marked each scene as unsaved; and
`EditorInterface.mark_scene_as_unsaved()` only operates on the foreground
tab (haven't actually checked what happens if you bulk-open scenes and
call this during the loading of each one); so doing this by hand
involves hitting Ctrl+S, Ctrl+Shift+W, repeatedly.
