### PR TITLE
CollectibleItem: Move to "walls" physics layer

### DIFF
--- a/scenes/game_elements/props/collectible_item/collectible_item.tscn
+++ b/scenes/game_elements/props/collectible_item/collectible_item.tscn
@@ -333,6 +333,7 @@ stream = ExtResource("5_oh62b")
 bus = &"SFX"
 
 [node name="StaticBody2D" type="StaticBody2D" parent="." unique_id=9475262]
+collision_layer = 16
 collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D" unique_id=1204681631]


### PR DESCRIPTION
CollectibleItem: Move to "walls" physics layer

They are not really walls, but they are certainly not "players", the
(default) physics layer they were in before.
