### PR TITLE
Storybook: Adding language bookmarks

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -237,7 +237,7 @@ func _switch_to_page(spread_index: int) -> void:
 	if spread_index == _current_spread_index:
 		return
 
-	var total_spreads: int = _bookmark_indexes[ContentTab.QUESTS] + quests.size()
+	var total_spreads: int = _bookmark_indexes[ContentTab.QUESTS] + quests.size() - 1
 	if spread_index < 0 or spread_index > total_spreads:
 		return
 

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -12,6 +12,13 @@ extends CanvasLayer
 ## [param quest] set to [code]null[/code].
 signal selected(quest: Quest, restart: bool)
 
+enum ContentTab { TOC, EN, ES }
+const TAB_LANGUAGES := {
+	ContentTab.TOC: "",
+	ContentTab.EN: "en",
+	ContentTab.ES: "es",
+}
+
 ## Quests to show in the storybook.
 @export var quests: Array[Quest]
 @export var quests_per_page: int = 8:
@@ -22,13 +29,12 @@ signal selected(quest: Quest, restart: bool)
 
 var quests_per_spread: int = 16
 
+var _current_tab: ContentTab = ContentTab.TOC
 var _current_spread_index: int = -1
 var _navigation_locked: bool = false
 var _current_list_page: int = 0
 
 var _filtered_quests: Array[Quest] = []
-
-var _current_tab_index: int = 0  # 0: TOC, 1: EN, 2: ES
 
 @onready var left_quest_list: VBoxContainer = %LeftQuestList
 @onready var right_quest_list: VBoxContainer = %RightQuestList
@@ -250,7 +256,7 @@ func _on_left_button_pressed() -> void:
 			return
 
 		# Flipping back from the first page returns to full table of contents
-		_switch_bookmark_tab(0, "")
+		_switch_bookmark_tab(ContentTab.TOC)
 		return
 
 	_switch_to_page(_current_spread_index - 1)
@@ -309,15 +315,15 @@ func reset_focus() -> void:
 
 
 func _on_toc_bookmark_pressed() -> void:
-	_switch_bookmark_tab(0, "")
+	_switch_bookmark_tab(ContentTab.TOC)
 
 
 func _on_en_bookmark_pressed() -> void:
-	_switch_bookmark_tab(1, "en")
+	_switch_bookmark_tab(ContentTab.EN)
 
 
 func _on_es_bookmark_pressed() -> void:
-	_switch_bookmark_tab(2, "es")
+	_switch_bookmark_tab(ContentTab.ES)
 
 
 func _show_table_of_contents() -> void:
@@ -326,9 +332,7 @@ func _show_table_of_contents() -> void:
 
 
 func _filter_quests_by_language(lang_code: String) -> void:
-	_filtered_quests = quests.filter(
-		func(quest: Quest) -> bool: return quest.language == lang_code
-	)
+	_filtered_quests = quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
 	_reset_storybook_list_view()
 
 
@@ -339,19 +343,20 @@ func _reset_storybook_list_view() -> void:
 	_update_page_visibility()
 
 
-func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
-	if _navigation_locked or target_tab_index == _current_tab_index:
+func _switch_bookmark_tab(target_tab: ContentTab) -> void:
+	if _navigation_locked or (target_tab == _current_tab and _current_spread_index == 0):
 		return
 
 	_navigation_locked = true
-	var old_tab_index: int = _current_tab_index
-	_current_tab_index = target_tab_index
+	var old_tab: ContentTab = _current_tab
+	_current_tab = target_tab
+	var lang_code: String = TAB_LANGUAGES.get(target_tab, "")
 
 	# Fade out UI
 	await _fade_out_ui()
 
 	# Flip forward if target > current, otherwise flip backward
-	if target_tab_index > old_tab_index:
+	if target_tab > old_tab:
 		animated_book.play("book_right")
 	else:
 		animated_book.play("book_left")

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -78,9 +78,9 @@ func _ready() -> void:
 		else:
 			_quests_per_language[language].append(q)
 
-	toc_bookmark_button.pressed.connect(_on_toc_bookmark_pressed)
-	en_bookmark_button.pressed.connect(_on_en_bookmark_pressed)
-	es_bookmark_button.pressed.connect(_on_es_bookmark_pressed)
+	toc_bookmark_button.pressed.connect(_switch_bookmark_tab.bind(ContentTab.TOC))
+	en_bookmark_button.pressed.connect(_switch_bookmark_tab.bind(ContentTab.EN))
+	es_bookmark_button.pressed.connect(_switch_bookmark_tab.bind(ContentTab.ES))
 
 	_update_bookmark_visibility()
 	_populate_quest_lists()
@@ -317,18 +317,6 @@ func _on_back_button_pressed() -> void:
 
 func reset_focus() -> void:
 	_switch_to_page(0)
-
-
-func _on_toc_bookmark_pressed() -> void:
-	_switch_bookmark_tab(ContentTab.TOC)
-
-
-func _on_en_bookmark_pressed() -> void:
-	_switch_bookmark_tab(ContentTab.EN)
-
-
-func _on_es_bookmark_pressed() -> void:
-	_switch_bookmark_tab(ContentTab.ES)
 
 
 func _show_table_of_contents() -> void:

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -26,6 +26,10 @@ var _current_spread_index: int = -1
 var _navigation_locked: bool = false
 var _current_list_page: int = 0
 
+## A copy of all quests loaded on ready (before filtering)
+var _all_quests: Array[Quest] = []
+var _current_tab_index: int = 0  # 0: TOC, 1: EN, 2: ES
+
 @onready var left_quest_list: VBoxContainer = %LeftQuestList
 @onready var right_quest_list: VBoxContainer = %RightQuestList
 
@@ -34,6 +38,11 @@ var _current_list_page: int = 0
 @onready var back_button: Button = %BackButton
 @onready var animated_book: AnimatedSprite2D = %AnimatedSprite2D
 @onready var ui_container: Control = %StoryBookContent
+
+#Bookmark button references
+@onready var toc_bookmark_button: Button = %TOCBookmark
+@onready var en_bookmark_button: Button = %ENBookmark
+@onready var es_bookmark_button: Button = %ESBookmark
 
 
 func _fade_out_ui() -> void:
@@ -51,6 +60,18 @@ func _fade_in_ui() -> void:
 
 func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
+
+	# Saving a copy of all quests
+	_all_quests = quests.duplicate()
+
+	# Connecting the bookmark buttons
+	if toc_bookmark_button:
+		toc_bookmark_button.pressed.connect(_on_toc_bookmark_pressed)
+	if en_bookmark_button:
+		en_bookmark_button.pressed.connect(_on_en_bookmark_pressed)
+	if es_bookmark_button:
+		es_bookmark_button.pressed.connect(_on_es_bookmark_pressed)
+
 	_populate_quest_lists()
 
 
@@ -206,16 +227,21 @@ func _on_left_button_pressed() -> void:
 		return
 
 	# If we are on the main index, turn pages back inside the list
-	if _current_spread_index == 0 and _current_list_page > 0:
-		_navigation_locked = true
-		_current_list_page -= 1
-		await _fade_out_ui()
-		animated_book.play("book_left")
-		await animated_book.animation_finished
-		_populate_quest_lists()
-		_update_page_visibility()
-		_fade_in_ui()
-		_navigation_locked = false
+	if _current_spread_index == 0:
+		if _current_list_page > 0:
+			_navigation_locked = true
+			_current_list_page -= 1
+			await _fade_out_ui()
+			animated_book.play("book_left")
+			await animated_book.animation_finished
+			_populate_quest_lists()
+			_update_page_visibility()
+			_fade_in_ui()
+			_navigation_locked = false
+			return
+
+		# Flipping back from the first page returns to full table of contents
+		_switch_bookmark_tab(0, "")
 		return
 
 	_switch_to_page(_current_spread_index - 1)
@@ -271,3 +297,69 @@ func _on_back_button_pressed() -> void:
 
 func reset_focus() -> void:
 	_switch_to_page(0)
+
+
+func _on_toc_bookmark_pressed() -> void:
+	_switch_bookmark_tab(0, "")
+
+
+func _on_en_bookmark_pressed() -> void:
+	_switch_bookmark_tab(1, "en")
+
+
+func _on_es_bookmark_pressed() -> void:
+	_switch_bookmark_tab(2, "es")
+
+
+func _show_table_of_contents() -> void:
+	quests = _all_quests.duplicate()
+	_reset_storybook_list_view()
+
+
+func _filter_quests_by_language(lang_code: String) -> void:
+	quests = _all_quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
+	_reset_storybook_list_view()
+
+
+func _reset_storybook_list_view() -> void:
+	_current_list_page = 0
+	_current_spread_index = 0
+	_populate_quest_lists()
+	_update_page_visibility()
+
+
+func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
+	if _navigation_locked or target_tab_index == _current_tab_index:
+		return
+
+	_navigation_locked = true
+	var old_tab_index: int = _current_tab_index
+	_current_tab_index = target_tab_index
+
+	# Fade out UI
+	await _fade_out_ui()
+
+	# Flip forward if target > current, otherwise flip backward
+	if target_tab_index > old_tab_index:
+		animated_book.play("book_right")
+	else:
+		animated_book.play("book_left")
+
+	# Wait for animation to finish before rebuilding list
+	await animated_book.animation_finished
+
+	# Filter quests array
+	if lang_code == "":
+		quests = _all_quests.duplicate()
+	else:
+		quests = _all_quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
+
+	# Reset page counters and reload UI
+	_current_list_page = 0
+	_current_spread_index = 0
+	_populate_quest_lists()
+	_update_page_visibility()
+
+	# Fade back in
+	_fade_in_ui()
+	_navigation_locked = false

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -363,7 +363,7 @@ func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
 	if lang_code == "":
 		_filtered_quests = quests
 	else:
-		_filtered_quests = _all_quests.filter(
+		_filtered_quests = quests.filter(
 			func(quest: Quest) -> bool: return quest.language == lang_code
 		)
 

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -352,7 +352,7 @@ func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
 
 	# Filter quests array
 	if lang_code == "":
-		_filtered_quests = _all_quests
+		_filtered_quests = quests
 	else:
 		_filtered_quests = _all_quests.filter(
 			func(quest: Quest) -> bool: return quest.language == lang_code

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -312,7 +312,7 @@ func _on_es_bookmark_pressed() -> void:
 
 
 func _show_table_of_contents() -> void:
-	_filtered_quests = _all_quests
+	_filtered_quests = quests
 	_reset_storybook_list_view()
 
 

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -361,7 +361,7 @@ func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
 
 	# Filter quests array
 	if lang_code == "":
-		_filtered_quests = _all_quests
+		_filtered_quests = quests
 	else:
 		_filtered_quests = _all_quests.filter(
 			func(quest: Quest) -> bool: return quest.language == lang_code

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -148,8 +148,6 @@ func _populate_quest_lists() -> void:
 		previous_button.focus_neighbor_bottom = back_button.get_path()
 		back_button.focus_neighbor_top = previous_button.get_path()
 
-	reset_focus()
-
 
 ## Method to build individual buttons (StoryQuests) and manage the focus chains
 func _create_quest_button(
@@ -291,10 +289,6 @@ func _on_storybook_page_selected(quest: Quest, restart: bool) -> void:
 
 func _on_back_button_pressed() -> void:
 	selected.emit(null, false)
-
-
-func reset_focus() -> void:
-	_switch_to_page(0)
 
 
 func _switch_to_bookmark(target_tab: ContentTab) -> void:

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -72,6 +72,7 @@ func _ready() -> void:
 	if es_bookmark_button:
 		es_bookmark_button.pressed.connect(_on_es_bookmark_pressed)
 
+	_update_bookmark_visibility()
 	_populate_quest_lists()
 
 
@@ -363,3 +364,22 @@ func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
 	# Fade back in
 	_fade_in_ui()
 	_navigation_locked = false
+
+
+func _update_bookmark_visibility() -> void:
+	var unique_languages := []
+	for q in _all_quests:
+		if q.language != "" and q.language not in unique_languages:
+			unique_languages.append(q.language)
+
+	# Only show language bookmarks if there is more than 1 language
+	var show_language_tabs: bool = unique_languages.size() > 1
+
+	# Check if at least one quest exists for each language
+	var has_en: bool = _all_quests.any(func(q: Quest) -> bool: return q.language == "en")
+	var has_es: bool = _all_quests.any(func(q: Quest) -> bool: return q.language == "es")
+
+	if en_bookmark_button:
+		en_bookmark_button.visible = show_language_tabs and has_en
+	if es_bookmark_button:
+		es_bookmark_button.visible = show_language_tabs and has_es

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -26,8 +26,6 @@ var _current_spread_index: int = -1
 var _navigation_locked: bool = false
 var _current_list_page: int = 0
 
-## A copy of all quests loaded on ready (before filtering)
-var _all_quests: Array[Quest] = []
 var _filtered_quests: Array[Quest] = []
 
 var _current_tab_index: int = 0  # 0: TOC, 1: EN, 2: ES

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -317,7 +317,7 @@ func _show_table_of_contents() -> void:
 
 
 func _filter_quests_by_language(lang_code: String) -> void:
-	_filtered_quests = _all_quests.filter(
+	_filtered_quests = quests.filter(
 		func(quest: Quest) -> bool: return quest.language == lang_code
 	)
 	_reset_storybook_list_view()

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -380,7 +380,7 @@ func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
 
 func _update_bookmark_visibility() -> void:
 	var unique_languages := []
-	for q in _all_quests:
+	for q in quests:
 		if q.language != "" and q.language not in unique_languages:
 			unique_languages.append(q.language)
 

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -19,7 +19,7 @@ enum ContentTab { TOC, EN, ES, QUESTS }
 @export var quests_per_page: int = 8
 @export var fade_duration: float = 0.15
 
-var _current_spread_index: int = -1
+var _current_spread_index: int
 var _navigation_locked: bool = false
 
 var _quests_per_language: Dictionary[String, Array] = {}
@@ -246,17 +246,13 @@ func _switch_to_page(spread_index: int) -> void:
 	var old_index := _current_spread_index
 	_current_spread_index = spread_index
 
-	if old_index != -1:
-		await _fade_out_ui()
+	await _fade_out_ui()
 
-		if spread_index > old_index:
-			animated_book.play("book_right")
-		else:
-			animated_book.play("book_left")
-		ui_container.visible = false
+	if spread_index > old_index:
+		animated_book.play("book_right")
 	else:
-		_update_page_visibility()
-		_navigation_locked = false
+		animated_book.play("book_left")
+	ui_container.visible = false
 
 
 func _on_animation_finished() -> void:

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -371,7 +371,7 @@ func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
 
 func _update_bookmark_visibility() -> void:
 	var unique_languages := []
-	for q in _all_quests:
+	for q in quests:
 		if q.language != "" and q.language not in unique_languages:
 			unique_languages.append(q.language)
 

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -34,6 +34,7 @@ var _current_spread_index: int = -1
 var _navigation_locked: bool = false
 var _current_list_page: int = 0
 
+var _quests_per_language: Dictionary[String, Array] = {}
 var _filtered_quests: Array[Quest] = []
 
 @onready var left_quest_list: VBoxContainer = %LeftQuestList
@@ -68,14 +69,18 @@ func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
 
 	_filtered_quests = quests
+	_quests_per_language = {}
+	for q in quests:
+		# If language is not defined, assume English:
+		var language: String = q.language if q.language else "en"
+		if language not in _quests_per_language:
+			_quests_per_language[language] = [q]
+		else:
+			_quests_per_language[language].append(q)
 
-	# Connecting the bookmark buttons
-	if toc_bookmark_button:
-		toc_bookmark_button.pressed.connect(_on_toc_bookmark_pressed)
-	if en_bookmark_button:
-		en_bookmark_button.pressed.connect(_on_en_bookmark_pressed)
-	if es_bookmark_button:
-		es_bookmark_button.pressed.connect(_on_es_bookmark_pressed)
+	toc_bookmark_button.pressed.connect(_on_toc_bookmark_pressed)
+	en_bookmark_button.pressed.connect(_on_en_bookmark_pressed)
+	es_bookmark_button.pressed.connect(_on_es_bookmark_pressed)
 
 	_update_bookmark_visibility()
 	_populate_quest_lists()
@@ -384,19 +389,8 @@ func _switch_bookmark_tab(target_tab: ContentTab) -> void:
 
 
 func _update_bookmark_visibility() -> void:
-	var unique_languages := []
-	for q in quests:
-		if q.language != "" and q.language not in unique_languages:
-			unique_languages.append(q.language)
-
-	# Only show language bookmarks if there is more than 1 language
-	var show_language_tabs: bool = unique_languages.size() > 1
-
-	# Check if at least one quest exists for each language
-	var has_en: bool = quests.any(func(q: Quest) -> bool: return q.language == "en")
-	var has_es: bool = quests.any(func(q: Quest) -> bool: return q.language == "es")
-
-	if en_bookmark_button:
-		en_bookmark_button.visible = show_language_tabs and has_en
-	if es_bookmark_button:
-		es_bookmark_button.visible = show_language_tabs and has_es
+	# Only show language bookmarks if there are quests for both English and Spanish, which are the
+	# existing bookmarks so far.
+	var show_language_bookmarks := "en" in _quests_per_language and "es" in _quests_per_language
+	en_bookmark_button.visible = show_language_bookmarks
+	es_bookmark_button.visible = show_language_bookmarks

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -28,6 +28,8 @@ var _current_list_page: int = 0
 
 ## A copy of all quests loaded on ready (before filtering)
 var _all_quests: Array[Quest] = []
+var _filtered_quests: Array[Quest] = []
+
 var _current_tab_index: int = 0  # 0: TOC, 1: EN, 2: ES
 
 @onready var left_quest_list: VBoxContainer = %LeftQuestList
@@ -62,7 +64,8 @@ func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
 
 	# Saving a copy of all quests
-	_all_quests = quests.duplicate()
+	_all_quests = quests
+	_filtered_quests = quests
 
 	# Connecting the bookmark buttons
 	if toc_bookmark_button:
@@ -96,11 +99,11 @@ func _populate_quest_lists() -> void:
 	var previous_button: Button = null
 
 	# Building the left page
-	for i in range(left_start, min(left_end, quests.size())):
+	for i in range(left_start, min(left_end, _filtered_quests.size())):
 		previous_button = _create_quest_button(i, left_quest_list, previous_button)
 
 	#Building the right page
-	for i in range(right_start, min(right_end, quests.size())):
+	for i in range(right_start, min(right_end, _filtered_quests.size())):
 		previous_button = _create_quest_button(i, right_quest_list, previous_button)
 	# If the right page is empty, add a blank Control spacer so it maintains its width
 	if right_quest_list.get_child_count() == 0:
@@ -120,7 +123,7 @@ func _populate_quest_lists() -> void:
 func _create_quest_button(
 	quest_index: int, parent_container: VBoxContainer, prev_btn: Button
 ) -> Button:
-	var quest: Quest = quests[quest_index]
+	var quest: Quest = _filtered_quests[quest_index]
 	var button := Button.new()
 	button.text = quest.get_title()
 	button.theme_type_variation = "FlatButton"
@@ -154,8 +157,8 @@ func _update_page_visibility() -> void:
 		storybook_page.visible = true
 
 		var quest_index: int = _current_spread_index - 1
-		if quest_index >= 0 and quest_index < quests.size():
-			var quest: Quest = quests[quest_index]
+		if quest_index >= 0 and quest_index < _filtered_quests.size():
+			var quest: Quest = _filtered_quests[quest_index]
 			storybook_page.quest = quest
 
 			if storybook_page.play_button and is_instance_valid(storybook_page.play_button):
@@ -190,7 +193,7 @@ func _switch_to_page(spread_index: int) -> void:
 	if _navigation_locked:
 		return
 
-	var total_spreads: int = quests.size() + 1
+	var total_spreads: int = _filtered_quests.size() + 1
 	if total_spreads <= 1:
 		return
 
@@ -255,7 +258,7 @@ func _on_right_button_pressed() -> void:
 	# If we are on the main index, check if there are more quests to reveal on a new page
 	if _current_spread_index == 0:
 		var max_visible_so_far: int = (_current_list_page + 1) * quests_per_page * 2
-		if quests.size() > max_visible_so_far:
+		if _filtered_quests.size() > max_visible_so_far:
 			_navigation_locked = true
 			_current_list_page += 1
 			await _fade_out_ui()
@@ -313,12 +316,14 @@ func _on_es_bookmark_pressed() -> void:
 
 
 func _show_table_of_contents() -> void:
-	quests = _all_quests.duplicate()
+	_filtered_quests = _all_quests
 	_reset_storybook_list_view()
 
 
 func _filter_quests_by_language(lang_code: String) -> void:
-	quests = _all_quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
+	_filtered_quests = _all_quests.filter(
+		func(quest: Quest) -> bool: return quest.language == lang_code
+	)
 	_reset_storybook_list_view()
 
 
@@ -351,9 +356,11 @@ func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
 
 	# Filter quests array
 	if lang_code == "":
-		quests = _all_quests.duplicate()
+		_filtered_quests = _all_quests
 	else:
-		quests = _all_quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
+		_filtered_quests = _all_quests.filter(
+			func(quest: Quest) -> bool: return quest.language == lang_code
+		)
 
 	# Reset page counters and reload UI
 	_current_list_page = 0

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -24,6 +24,7 @@ var _navigation_locked: bool = false
 
 var _quests_per_language: Dictionary[String, Array] = {}
 var _bookmark_indexes: Dictionary[ContentTab, int] = {}
+var _show_language_bookmarks: bool
 
 @onready var left_quest_list: VBoxContainer = %LeftQuestList
 @onready var right_quest_list: VBoxContainer = %RightQuestList
@@ -65,22 +66,38 @@ func _ready() -> void:
 		else:
 			_quests_per_language[language].append(q)
 
-	_bookmark_indexes[ContentTab.TOC] = 0
-	_bookmark_indexes[ContentTab.EN] = ceil(quests.size() / float(quests_per_page * 2))
-	_bookmark_indexes[ContentTab.ES] = (
-		_bookmark_indexes[ContentTab.EN]
-		+ ceil(_quests_per_language.get("en", []).size() / float(quests_per_page * 2))
-	)
-	_bookmark_indexes[ContentTab.QUESTS] = (
-		_bookmark_indexes[ContentTab.ES]
-		+ ceil(_quests_per_language.get("es", []).size() / float(quests_per_page * 2))
-	)
+	# Only show language bookmarks if there are quests for both English and Spanish, which are the
+	# existing bookmarks so far.
+	_show_language_bookmarks = "en" in _quests_per_language and "es" in _quests_per_language
+
+	var last_index := 0
+	_bookmark_indexes[ContentTab.TOC] = last_index
+	if _show_language_bookmarks:
+		_bookmark_indexes[ContentTab.EN] = (
+			last_index + ceil(quests.size() / float(quests_per_page * 2))
+		)
+		last_index = _bookmark_indexes[ContentTab.EN]
+		_bookmark_indexes[ContentTab.ES] = (
+			last_index
+			+ ceil(_quests_per_language.get("en", []).size() / float(quests_per_page * 2))
+		)
+		last_index = _bookmark_indexes[ContentTab.ES]
+		_bookmark_indexes[ContentTab.QUESTS] = (
+			last_index
+			+ ceil(_quests_per_language.get("es", []).size() / float(quests_per_page * 2))
+		)
+	else:
+		_bookmark_indexes[ContentTab.QUESTS] = (
+			last_index + ceil(quests.size() / float(quests_per_page * 2))
+		)
 
 	toc_bookmark_button.pressed.connect(_switch_to_bookmark.bind(ContentTab.TOC))
 	en_bookmark_button.pressed.connect(_switch_to_bookmark.bind(ContentTab.EN))
 	es_bookmark_button.pressed.connect(_switch_to_bookmark.bind(ContentTab.ES))
 
-	_update_bookmark_visibility()
+	en_bookmark_button.visible = _show_language_bookmarks
+	es_bookmark_button.visible = _show_language_bookmarks
+
 	_update_page_visibility()
 
 
@@ -98,7 +115,7 @@ func _populate_quest_lists() -> void:
 	var content_quests: Array[Quest]
 	var spread_index: int
 
-	if _current_spread_index < _bookmark_indexes[ContentTab.EN]:
+	if not _show_language_bookmarks or _current_spread_index < _bookmark_indexes[ContentTab.EN]:
 		spread_index = _current_spread_index - _bookmark_indexes[ContentTab.TOC]
 		content_quests.assign(quests)
 	elif _current_spread_index < _bookmark_indexes[ContentTab.ES]:
@@ -286,11 +303,3 @@ func reset_focus() -> void:
 
 func _switch_to_bookmark(target_tab: ContentTab) -> void:
 	_switch_to_page(_bookmark_indexes[target_tab])
-
-
-func _update_bookmark_visibility() -> void:
-	# Only show language bookmarks if there are quests for both English and Spanish, which are the
-	# existing bookmarks so far.
-	var show_language_bookmarks := "en" in _quests_per_language and "es" in _quests_per_language
-	en_bookmark_button.visible = show_language_bookmarks
-	es_bookmark_button.visible = show_language_bookmarks

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -13,10 +13,6 @@ extends CanvasLayer
 signal selected(quest: Quest, restart: bool)
 
 enum ContentTab { TOC, EN, ES, QUESTS }
-const TAB_LANGUAGES := {
-	ContentTab.EN: "en",
-	ContentTab.ES: "es",
-}
 
 ## Quests to show in the storybook.
 @export var quests: Array[Quest]
@@ -99,25 +95,24 @@ func _populate_quest_lists() -> void:
 	_clear_list(left_quest_list)
 	_clear_list(right_quest_list)
 
-	var previous_button: Button = null
-
-	var spread_quests: Array[Quest]
+	var content_quests: Array[Quest]
+	var spread_index: int
 
 	if _current_spread_index < _bookmark_indexes[ContentTab.EN]:
-		var i := _current_spread_index - _bookmark_indexes[ContentTab.TOC]
-		var start := i * quests_per_page * 2
-		var end := start + quests_per_page * 2
-		spread_quests.assign(quests.slice(start, end))
+		spread_index = _current_spread_index - _bookmark_indexes[ContentTab.TOC]
+		content_quests.assign(quests)
 	elif _current_spread_index < _bookmark_indexes[ContentTab.ES]:
-		var i := _current_spread_index - _bookmark_indexes[ContentTab.EN]
-		var start := i * quests_per_page * 2
-		var end := start + quests_per_page * 2
-		spread_quests.assign(_quests_per_language.get("en", []).slice(start, end))
+		spread_index = _current_spread_index - _bookmark_indexes[ContentTab.EN]
+		content_quests.assign(_quests_per_language.get("en", []))
 	elif _current_spread_index < _bookmark_indexes[ContentTab.QUESTS]:
-		var i := _current_spread_index - _bookmark_indexes[ContentTab.ES]
-		var start := i * quests_per_page * 2
-		var end := start + quests_per_page * 2
-		spread_quests.assign(_quests_per_language.get("es", []).slice(start, end))
+		spread_index = _current_spread_index - _bookmark_indexes[ContentTab.ES]
+		content_quests.assign(_quests_per_language.get("es", []))
+
+	var start := spread_index * quests_per_page * 2
+	var end := start + quests_per_page * 2
+	var spread_quests: Array[Quest] = content_quests.slice(start, end)
+
+	var previous_button: Button = null
 
 	for q: Quest in spread_quests.slice(0, quests_per_page):
 		previous_button = _create_quest_button(q, left_quest_list, previous_button)

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -12,6 +12,13 @@ extends CanvasLayer
 ## [param quest] set to [code]null[/code].
 signal selected(quest: Quest, restart: bool)
 
+enum ContentTab { TOC, EN, ES }
+const TAB_LANGUAGES := {
+	ContentTab.TOC: "",
+	ContentTab.EN: "en",
+	ContentTab.ES: "es",
+}
+
 ## Quests to show in the storybook.
 @export var quests: Array[Quest]
 @export var quests_per_page: int = 8:
@@ -22,13 +29,12 @@ signal selected(quest: Quest, restart: bool)
 
 var quests_per_spread: int = 16
 
+var _current_tab: ContentTab = ContentTab.TOC
 var _current_spread_index: int = -1
 var _navigation_locked: bool = false
 var _current_list_page: int = 0
 
 var _filtered_quests: Array[Quest] = []
-
-var _current_tab_index: int = 0  # 0: TOC, 1: EN, 2: ES
 
 @onready var left_quest_list: VBoxContainer = %LeftQuestList
 @onready var right_quest_list: VBoxContainer = %RightQuestList
@@ -241,7 +247,7 @@ func _on_left_button_pressed() -> void:
 			return
 
 		# Flipping back from the first page returns to full table of contents
-		_switch_bookmark_tab(0, "")
+		_switch_bookmark_tab(ContentTab.TOC)
 		return
 
 	_switch_to_page(_current_spread_index - 1)
@@ -300,15 +306,15 @@ func reset_focus() -> void:
 
 
 func _on_toc_bookmark_pressed() -> void:
-	_switch_bookmark_tab(0, "")
+	_switch_bookmark_tab(ContentTab.TOC)
 
 
 func _on_en_bookmark_pressed() -> void:
-	_switch_bookmark_tab(1, "en")
+	_switch_bookmark_tab(ContentTab.EN)
 
 
 func _on_es_bookmark_pressed() -> void:
-	_switch_bookmark_tab(2, "es")
+	_switch_bookmark_tab(ContentTab.ES)
 
 
 func _show_table_of_contents() -> void:
@@ -317,9 +323,7 @@ func _show_table_of_contents() -> void:
 
 
 func _filter_quests_by_language(lang_code: String) -> void:
-	_filtered_quests = quests.filter(
-		func(quest: Quest) -> bool: return quest.language == lang_code
-	)
+	_filtered_quests = quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
 	_reset_storybook_list_view()
 
 
@@ -330,19 +334,20 @@ func _reset_storybook_list_view() -> void:
 	_update_page_visibility()
 
 
-func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
-	if _navigation_locked or target_tab_index == _current_tab_index:
+func _switch_bookmark_tab(target_tab: ContentTab) -> void:
+	if _navigation_locked or (target_tab == _current_tab and _current_spread_index == 0):
 		return
 
 	_navigation_locked = true
-	var old_tab_index: int = _current_tab_index
-	_current_tab_index = target_tab_index
+	var old_tab: ContentTab = _current_tab
+	_current_tab = target_tab
+	var lang_code: String = TAB_LANGUAGES.get(target_tab, "")
 
 	# Fade out UI
 	await _fade_out_ui()
 
 	# Flip forward if target > current, otherwise flip backward
-	if target_tab_index > old_tab_index:
+	if target_tab > old_tab:
 		animated_book.play("book_right")
 	else:
 		animated_book.play("book_left")

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -61,8 +61,6 @@ func _fade_in_ui() -> void:
 func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
 
-	# Saving a copy of all quests
-	_all_quests = quests
 	_filtered_quests = quests
 
 	# Connecting the bookmark buttons

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -28,6 +28,8 @@ var _current_list_page: int = 0
 
 ## A copy of all quests loaded on ready (before filtering)
 var _all_quests: Array[Quest] = []
+var _filtered_quests: Array[Quest] = []
+
 var _current_tab_index: int = 0  # 0: TOC, 1: EN, 2: ES
 
 @onready var left_quest_list: VBoxContainer = %LeftQuestList
@@ -62,7 +64,8 @@ func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
 
 	# Saving a copy of all quests
-	_all_quests = quests.duplicate()
+	_all_quests = quests
+	_filtered_quests = quests
 
 	# Connecting the bookmark buttons
 	if toc_bookmark_button:
@@ -96,11 +99,11 @@ func _populate_quest_lists() -> void:
 	var previous_button: Button = null
 
 	# Building the left page
-	for i in range(left_start, min(left_end, quests.size())):
+	for i in range(left_start, min(left_end, _filtered_quests.size())):
 		previous_button = _create_quest_button(i, left_quest_list, previous_button)
 
 	#Building the right page
-	for i in range(right_start, min(right_end, quests.size())):
+	for i in range(right_start, min(right_end, _filtered_quests.size())):
 		previous_button = _create_quest_button(i, right_quest_list, previous_button)
 	# If the right page is empty, add a blank Control spacer so it maintains its width
 	if right_quest_list.get_child_count() == 0:
@@ -120,7 +123,7 @@ func _populate_quest_lists() -> void:
 func _create_quest_button(
 	quest_index: int, parent_container: VBoxContainer, prev_btn: Button
 ) -> Button:
-	var quest: Quest = quests[quest_index]
+	var quest: Quest = _filtered_quests[quest_index]
 	var button := Button.new()
 	button.text = quest.get_title()
 	button.theme_type_variation = "FlatButton"
@@ -163,8 +166,8 @@ func _update_page_visibility() -> void:
 		storybook_page.visible = true
 
 		var quest_index: int = _current_spread_index - 1
-		if quest_index >= 0 and quest_index < quests.size():
-			var quest: Quest = quests[quest_index]
+		if quest_index >= 0 and quest_index < _filtered_quests.size():
+			var quest: Quest = _filtered_quests[quest_index]
 			storybook_page.quest = quest
 
 			if storybook_page.play_button and is_instance_valid(storybook_page.play_button):
@@ -199,7 +202,7 @@ func _switch_to_page(spread_index: int) -> void:
 	if _navigation_locked:
 		return
 
-	var total_spreads: int = quests.size() + 1
+	var total_spreads: int = _filtered_quests.size() + 1
 	if total_spreads <= 1:
 		return
 
@@ -264,7 +267,7 @@ func _on_right_button_pressed() -> void:
 	# If we are on the main index, check if there are more quests to reveal on a new page
 	if _current_spread_index == 0:
 		var max_visible_so_far: int = (_current_list_page + 1) * quests_per_page * 2
-		if quests.size() > max_visible_so_far:
+		if _filtered_quests.size() > max_visible_so_far:
 			_navigation_locked = true
 			_current_list_page += 1
 			await _fade_out_ui()
@@ -322,12 +325,14 @@ func _on_es_bookmark_pressed() -> void:
 
 
 func _show_table_of_contents() -> void:
-	quests = _all_quests.duplicate()
+	_filtered_quests = _all_quests
 	_reset_storybook_list_view()
 
 
 func _filter_quests_by_language(lang_code: String) -> void:
-	quests = _all_quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
+	_filtered_quests = _all_quests.filter(
+		func(quest: Quest) -> bool: return quest.language == lang_code
+	)
 	_reset_storybook_list_view()
 
 
@@ -360,9 +365,11 @@ func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
 
 	# Filter quests array
 	if lang_code == "":
-		quests = _all_quests.duplicate()
+		_filtered_quests = _all_quests
 	else:
-		quests = _all_quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
+		_filtered_quests = _all_quests.filter(
+			func(quest: Quest) -> bool: return quest.language == lang_code
+		)
 
 	# Reset page counters and reload UI
 	_current_list_page = 0

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -72,6 +72,7 @@ func _ready() -> void:
 	if es_bookmark_button:
 		es_bookmark_button.pressed.connect(_on_es_bookmark_pressed)
 
+	_update_bookmark_visibility()
 	_populate_quest_lists()
 
 
@@ -372,3 +373,22 @@ func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
 	# Fade back in
 	_fade_in_ui()
 	_navigation_locked = false
+
+
+func _update_bookmark_visibility() -> void:
+	var unique_languages := []
+	for q in _all_quests:
+		if q.language != "" and q.language not in unique_languages:
+			unique_languages.append(q.language)
+
+	# Only show language bookmarks if there is more than 1 language
+	var show_language_tabs: bool = unique_languages.size() > 1
+
+	# Check if at least one quest exists for each language
+	var has_en: bool = _all_quests.any(func(q: Quest) -> bool: return q.language == "en")
+	var has_es: bool = _all_quests.any(func(q: Quest) -> bool: return q.language == "es")
+
+	if en_bookmark_button:
+		en_bookmark_button.visible = show_language_tabs and has_en
+	if es_bookmark_button:
+		es_bookmark_button.visible = show_language_tabs and has_es

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -321,7 +321,7 @@ func _on_es_bookmark_pressed() -> void:
 
 
 func _show_table_of_contents() -> void:
-	_filtered_quests = _all_quests
+	_filtered_quests = quests
 	_reset_storybook_list_view()
 
 

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -39,7 +39,7 @@ var _current_tab_index: int = 0  # 0: TOC, 1: EN, 2: ES
 @onready var animated_book: AnimatedSprite2D = %AnimatedSprite2D
 @onready var ui_container: Control = %StoryBookContent
 
-#Bookmark button references
+# Bookmark button references
 @onready var toc_bookmark_button: Button = %TOCBookmark
 @onready var en_bookmark_button: Button = %ENBookmark
 @onready var es_bookmark_button: Button = %ESBookmark

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -326,7 +326,7 @@ func _show_table_of_contents() -> void:
 
 
 func _filter_quests_by_language(lang_code: String) -> void:
-	_filtered_quests = _all_quests.filter(
+	_filtered_quests = quests.filter(
 		func(quest: Quest) -> bool: return quest.language == lang_code
 	)
 	_reset_storybook_list_view()

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -379,8 +379,8 @@ func _update_bookmark_visibility() -> void:
 	var show_language_tabs: bool = unique_languages.size() > 1
 
 	# Check if at least one quest exists for each language
-	var has_en: bool = _all_quests.any(func(q: Quest) -> bool: return q.language == "en")
-	var has_es: bool = _all_quests.any(func(q: Quest) -> bool: return q.language == "es")
+	var has_en: bool = quests.any(func(q: Quest) -> bool: return q.language == "en")
+	var has_es: bool = quests.any(func(q: Quest) -> bool: return q.language == "es")
 
 	if en_bookmark_button:
 		en_bookmark_button.visible = show_language_tabs and has_en

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -12,30 +12,22 @@ extends CanvasLayer
 ## [param quest] set to [code]null[/code].
 signal selected(quest: Quest, restart: bool)
 
-enum ContentTab { TOC, EN, ES }
+enum ContentTab { TOC, EN, ES, QUESTS }
 const TAB_LANGUAGES := {
-	ContentTab.TOC: "",
 	ContentTab.EN: "en",
 	ContentTab.ES: "es",
 }
 
 ## Quests to show in the storybook.
 @export var quests: Array[Quest]
-@export var quests_per_page: int = 8:
-	set(value):
-		quests_per_page = value
-		quests_per_spread = value * 2
+@export var quests_per_page: int = 8
 @export var fade_duration: float = 0.15
 
-var quests_per_spread: int = 16
-
-var _current_tab: ContentTab = ContentTab.TOC
 var _current_spread_index: int = -1
 var _navigation_locked: bool = false
-var _current_list_page: int = 0
 
 var _quests_per_language: Dictionary[String, Array] = {}
-var _filtered_quests: Array[Quest] = []
+var _bookmark_indexes: Dictionary[ContentTab, int] = {}
 
 @onready var left_quest_list: VBoxContainer = %LeftQuestList
 @onready var right_quest_list: VBoxContainer = %RightQuestList
@@ -68,7 +60,6 @@ func _fade_in_ui() -> void:
 func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
 
-	_filtered_quests = quests
 	_quests_per_language = {}
 	for q in quests:
 		# If language is not defined, assume English:
@@ -78,12 +69,23 @@ func _ready() -> void:
 		else:
 			_quests_per_language[language].append(q)
 
-	toc_bookmark_button.pressed.connect(_switch_bookmark_tab.bind(ContentTab.TOC))
-	en_bookmark_button.pressed.connect(_switch_bookmark_tab.bind(ContentTab.EN))
-	es_bookmark_button.pressed.connect(_switch_bookmark_tab.bind(ContentTab.ES))
+	_bookmark_indexes[ContentTab.TOC] = 0
+	_bookmark_indexes[ContentTab.EN] = ceil(quests.size() / float(quests_per_page * 2))
+	_bookmark_indexes[ContentTab.ES] = (
+		_bookmark_indexes[ContentTab.EN]
+		+ ceil(_quests_per_language.get("en", []).size() / float(quests_per_page * 2))
+	)
+	_bookmark_indexes[ContentTab.QUESTS] = (
+		_bookmark_indexes[ContentTab.ES]
+		+ ceil(_quests_per_language.get("es", []).size() / float(quests_per_page * 2))
+	)
+
+	toc_bookmark_button.pressed.connect(_switch_to_bookmark.bind(ContentTab.TOC))
+	en_bookmark_button.pressed.connect(_switch_to_bookmark.bind(ContentTab.EN))
+	es_bookmark_button.pressed.connect(_switch_to_bookmark.bind(ContentTab.ES))
 
 	_update_bookmark_visibility()
-	_populate_quest_lists()
+	_update_page_visibility()
 
 
 func _clear_list(quest_list: Node) -> void:
@@ -97,21 +99,32 @@ func _populate_quest_lists() -> void:
 	_clear_list(left_quest_list)
 	_clear_list(right_quest_list)
 
-	#Calculate the quest slices for this specific book spread
-	var left_start: int = _current_list_page * quests_per_page * 2
-	var left_end: int = left_start + quests_per_page
-	var right_start: int = left_end
-	var right_end: int = right_start + quests_per_page
-
 	var previous_button: Button = null
 
-	# Building the left page
-	for i in range(left_start, min(left_end, _filtered_quests.size())):
-		previous_button = _create_quest_button(i, left_quest_list, previous_button)
+	var spread_quests: Array[Quest]
 
-	#Building the right page
-	for i in range(right_start, min(right_end, _filtered_quests.size())):
-		previous_button = _create_quest_button(i, right_quest_list, previous_button)
+	if _current_spread_index < _bookmark_indexes[ContentTab.EN]:
+		var i := _current_spread_index - _bookmark_indexes[ContentTab.TOC]
+		var start := i * quests_per_page * 2
+		var end := start + quests_per_page * 2
+		spread_quests.assign(quests.slice(start, end))
+	elif _current_spread_index < _bookmark_indexes[ContentTab.ES]:
+		var i := _current_spread_index - _bookmark_indexes[ContentTab.EN]
+		var start := i * quests_per_page * 2
+		var end := start + quests_per_page * 2
+		spread_quests.assign(_quests_per_language.get("en", []).slice(start, end))
+	elif _current_spread_index < _bookmark_indexes[ContentTab.QUESTS]:
+		var i := _current_spread_index - _bookmark_indexes[ContentTab.ES]
+		var start := i * quests_per_page * 2
+		var end := start + quests_per_page * 2
+		spread_quests.assign(_quests_per_language.get("es", []).slice(start, end))
+
+	for q: Quest in spread_quests.slice(0, quests_per_page):
+		previous_button = _create_quest_button(q, left_quest_list, previous_button)
+
+	for q: Quest in spread_quests.slice(quests_per_page):
+		previous_button = _create_quest_button(q, right_quest_list, previous_button)
+
 	# If the right page is empty, add a blank Control spacer so it maintains its width
 	if right_quest_list.get_child_count() == 0:
 		var spacer: Control = Control.new()
@@ -128,9 +141,8 @@ func _populate_quest_lists() -> void:
 
 ## Method to build individual buttons (StoryQuests) and manage the focus chains
 func _create_quest_button(
-	quest_index: int, parent_container: VBoxContainer, prev_btn: Button
+	quest: Quest, parent_container: VBoxContainer, prev_btn: Button
 ) -> Button:
-	var quest: Quest = _filtered_quests[quest_index]
 	var button := Button.new()
 	button.text = quest.get_title()
 	button.theme_type_variation = "FlatButton"
@@ -143,8 +155,7 @@ func _create_quest_button(
 	button.icon_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 
 	parent_container.add_child(button)
-
-	button.set_meta("quest_index", quest_index)
+	button.set_meta("quest", quest)
 
 	button.pressed.connect(_on_quest_button_pressed.bind(button))
 	button.focus_next = back_button.get_path()
@@ -159,9 +170,11 @@ func _create_quest_button(
 
 ## Show/hide index or detail pages
 func _update_page_visibility() -> void:
-	if _current_spread_index == 0:
+	if _current_spread_index < _bookmark_indexes[ContentTab.QUESTS]:
 		quest_container.visible = true
 		storybook_page.visible = false
+
+		_populate_quest_lists()
 
 		# Grab focus on the first visible item of the left page
 		if left_quest_list.get_child_count() > 0:
@@ -172,9 +185,9 @@ func _update_page_visibility() -> void:
 		quest_container.visible = false
 		storybook_page.visible = true
 
-		var quest_index: int = _current_spread_index - 1
-		if quest_index >= 0 and quest_index < _filtered_quests.size():
-			var quest: Quest = _filtered_quests[quest_index]
+		var quest_index := _current_spread_index - _bookmark_indexes[ContentTab.QUESTS]
+		if quest_index >= 0 and quest_index < quests.size():
+			var quest := quests[quest_index]
 			storybook_page.quest = quest
 
 			if storybook_page.play_button and is_instance_valid(storybook_page.play_button):
@@ -209,24 +222,22 @@ func _switch_to_page(spread_index: int) -> void:
 	if _navigation_locked:
 		return
 
-	var total_spreads: int = _filtered_quests.size() + 1
-	if total_spreads <= 1:
-		return
-
-	if spread_index < 0 or spread_index >= total_spreads:
-		return
-
 	if spread_index == _current_spread_index:
 		return
 
+	var total_spreads: int = _bookmark_indexes[ContentTab.QUESTS] + quests.size()
+	if spread_index < 0 or spread_index > total_spreads:
+		return
+
 	_navigation_locked = true
-	var old_index: int = _current_spread_index
+
+	var old_index := _current_spread_index
 	_current_spread_index = spread_index
 
 	if old_index != -1:
 		await _fade_out_ui()
 
-		if spread_index > old_index or (spread_index == 0 and old_index == total_spreads - 1):
+		if spread_index > old_index:
 			animated_book.play("book_right")
 		else:
 			animated_book.play("book_left")
@@ -243,49 +254,10 @@ func _on_animation_finished() -> void:
 
 
 func _on_left_button_pressed() -> void:
-	if _navigation_locked:
-		return
-
-	# If we are on the main index, turn pages back inside the list
-	if _current_spread_index == 0:
-		if _current_list_page > 0:
-			_navigation_locked = true
-			_current_list_page -= 1
-			await _fade_out_ui()
-			animated_book.play("book_left")
-			await animated_book.animation_finished
-			_populate_quest_lists()
-			_update_page_visibility()
-			_fade_in_ui()
-			_navigation_locked = false
-			return
-
-		# Flipping back from the first page returns to full table of contents
-		_switch_bookmark_tab(ContentTab.TOC)
-		return
-
 	_switch_to_page(_current_spread_index - 1)
 
 
 func _on_right_button_pressed() -> void:
-	if _navigation_locked:
-		return
-
-	# If we are on the main index, check if there are more quests to reveal on a new page
-	if _current_spread_index == 0:
-		var max_visible_so_far: int = (_current_list_page + 1) * quests_per_page * 2
-		if _filtered_quests.size() > max_visible_so_far:
-			_navigation_locked = true
-			_current_list_page += 1
-			await _fade_out_ui()
-			animated_book.play("book_right")
-			await animated_book.animation_finished
-			_populate_quest_lists()
-			_update_page_visibility()
-			_fade_in_ui()
-			_navigation_locked = false
-			return
-
 	_switch_to_page(_current_spread_index + 1)
 
 
@@ -300,11 +272,9 @@ func _input(event: InputEvent) -> void:
 
 
 func _on_quest_button_pressed(button: Button) -> void:
-	if not button.has_meta("quest_index"):
-		return
-
-	var quest_index: int = button.get_meta("quest_index")
-	_switch_to_page(quest_index + 1)
+	var quest: Quest = button.get_meta("quest")
+	var quest_index := quests.find(quest)
+	_switch_to_page(_bookmark_indexes[ContentTab.QUESTS] + quest_index)
 
 
 func _on_storybook_page_selected(quest: Quest, restart: bool) -> void:
@@ -319,61 +289,8 @@ func reset_focus() -> void:
 	_switch_to_page(0)
 
 
-func _show_table_of_contents() -> void:
-	_filtered_quests = quests
-	_reset_storybook_list_view()
-
-
-func _filter_quests_by_language(lang_code: String) -> void:
-	_filtered_quests = quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
-	_reset_storybook_list_view()
-
-
-func _reset_storybook_list_view() -> void:
-	_current_list_page = 0
-	_current_spread_index = 0
-	_populate_quest_lists()
-	_update_page_visibility()
-
-
-func _switch_bookmark_tab(target_tab: ContentTab) -> void:
-	if _navigation_locked or (target_tab == _current_tab and _current_spread_index == 0):
-		return
-
-	_navigation_locked = true
-	var old_tab: ContentTab = _current_tab
-	_current_tab = target_tab
-	var lang_code: String = TAB_LANGUAGES.get(target_tab, "")
-
-	# Fade out UI
-	await _fade_out_ui()
-
-	# Flip forward if target > current, otherwise flip backward
-	if target_tab > old_tab:
-		animated_book.play("book_right")
-	else:
-		animated_book.play("book_left")
-
-	# Wait for animation to finish before rebuilding list
-	await animated_book.animation_finished
-
-	# Filter quests array
-	if lang_code == "":
-		_filtered_quests = quests
-	else:
-		_filtered_quests = quests.filter(
-			func(quest: Quest) -> bool: return quest.language == lang_code
-		)
-
-	# Reset page counters and reload UI
-	_current_list_page = 0
-	_current_spread_index = 0
-	_populate_quest_lists()
-	_update_page_visibility()
-
-	# Fade back in
-	_fade_in_ui()
-	_navigation_locked = false
+func _switch_to_bookmark(target_tab: ContentTab) -> void:
+	_switch_to_page(_bookmark_indexes[target_tab])
 
 
 func _update_bookmark_visibility() -> void:

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -354,7 +354,7 @@ func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
 	if lang_code == "":
 		_filtered_quests = quests
 	else:
-		_filtered_quests = _all_quests.filter(
+		_filtered_quests = quests.filter(
 			func(quest: Quest) -> bool: return quest.language == lang_code
 		)
 

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -388,8 +388,8 @@ func _update_bookmark_visibility() -> void:
 	var show_language_tabs: bool = unique_languages.size() > 1
 
 	# Check if at least one quest exists for each language
-	var has_en: bool = _all_quests.any(func(q: Quest) -> bool: return q.language == "en")
-	var has_es: bool = _all_quests.any(func(q: Quest) -> bool: return q.language == "es")
+	var has_en: bool = quests.any(func(q: Quest) -> bool: return q.language == "en")
+	var has_es: bool = quests.any(func(q: Quest) -> bool: return q.language == "es")
 
 	if en_bookmark_button:
 		en_bookmark_button.visible = show_language_tabs and has_en

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -26,6 +26,10 @@ var _current_spread_index: int = -1
 var _navigation_locked: bool = false
 var _current_list_page: int = 0
 
+## A copy of all quests loaded on ready (before filtering)
+var _all_quests: Array[Quest] = []
+var _current_tab_index: int = 0  # 0: TOC, 1: EN, 2: ES
+
 @onready var left_quest_list: VBoxContainer = %LeftQuestList
 @onready var right_quest_list: VBoxContainer = %RightQuestList
 
@@ -34,6 +38,11 @@ var _current_list_page: int = 0
 @onready var back_button: Button = %BackButton
 @onready var animated_book: AnimatedSprite2D = %AnimatedSprite2D
 @onready var ui_container: Control = %StoryBookContent
+
+#Bookmark button references
+@onready var toc_bookmark_button: Button = %TOCBookmark
+@onready var en_bookmark_button: Button = %ENBookmark
+@onready var es_bookmark_button: Button = %ESBookmark
 
 
 func _fade_out_ui() -> void:
@@ -51,6 +60,18 @@ func _fade_in_ui() -> void:
 
 func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
+
+	# Saving a copy of all quests
+	_all_quests = quests.duplicate()
+
+	# Connecting the bookmark buttons
+	if toc_bookmark_button:
+		toc_bookmark_button.pressed.connect(_on_toc_bookmark_pressed)
+	if en_bookmark_button:
+		en_bookmark_button.pressed.connect(_on_en_bookmark_pressed)
+	if es_bookmark_button:
+		es_bookmark_button.pressed.connect(_on_es_bookmark_pressed)
+
 	_populate_quest_lists()
 
 
@@ -215,16 +236,21 @@ func _on_left_button_pressed() -> void:
 		return
 
 	# If we are on the main index, turn pages back inside the list
-	if _current_spread_index == 0 and _current_list_page > 0:
-		_navigation_locked = true
-		_current_list_page -= 1
-		await _fade_out_ui()
-		animated_book.play("book_left")
-		await animated_book.animation_finished
-		_populate_quest_lists()
-		_update_page_visibility()
-		_fade_in_ui()
-		_navigation_locked = false
+	if _current_spread_index == 0:
+		if _current_list_page > 0:
+			_navigation_locked = true
+			_current_list_page -= 1
+			await _fade_out_ui()
+			animated_book.play("book_left")
+			await animated_book.animation_finished
+			_populate_quest_lists()
+			_update_page_visibility()
+			_fade_in_ui()
+			_navigation_locked = false
+			return
+
+		# Flipping back from the first page returns to full table of contents
+		_switch_bookmark_tab(0, "")
 		return
 
 	_switch_to_page(_current_spread_index - 1)
@@ -280,3 +306,69 @@ func _on_back_button_pressed() -> void:
 
 func reset_focus() -> void:
 	_switch_to_page(0)
+
+
+func _on_toc_bookmark_pressed() -> void:
+	_switch_bookmark_tab(0, "")
+
+
+func _on_en_bookmark_pressed() -> void:
+	_switch_bookmark_tab(1, "en")
+
+
+func _on_es_bookmark_pressed() -> void:
+	_switch_bookmark_tab(2, "es")
+
+
+func _show_table_of_contents() -> void:
+	quests = _all_quests.duplicate()
+	_reset_storybook_list_view()
+
+
+func _filter_quests_by_language(lang_code: String) -> void:
+	quests = _all_quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
+	_reset_storybook_list_view()
+
+
+func _reset_storybook_list_view() -> void:
+	_current_list_page = 0
+	_current_spread_index = 0
+	_populate_quest_lists()
+	_update_page_visibility()
+
+
+func _switch_bookmark_tab(target_tab_index: int, lang_code: String) -> void:
+	if _navigation_locked or target_tab_index == _current_tab_index:
+		return
+
+	_navigation_locked = true
+	var old_tab_index: int = _current_tab_index
+	_current_tab_index = target_tab_index
+
+	# Fade out UI
+	await _fade_out_ui()
+
+	# Flip forward if target > current, otherwise flip backward
+	if target_tab_index > old_tab_index:
+		animated_book.play("book_right")
+	else:
+		animated_book.play("book_left")
+
+	# Wait for animation to finish before rebuilding list
+	await animated_book.animation_finished
+
+	# Filter quests array
+	if lang_code == "":
+		quests = _all_quests.duplicate()
+	else:
+		quests = _all_quests.filter(func(quest: Quest) -> bool: return quest.language == lang_code)
+
+	# Reset page counters and reload UI
+	_current_list_page = 0
+	_current_spread_index = 0
+	_populate_quest_lists()
+	_update_page_visibility()
+
+	# Fade back in
+	_fade_in_ui()
+	_navigation_locked = false

--- a/scenes/menus/storybook/components/storybook_test.gd
+++ b/scenes/menus/storybook/components/storybook_test.gd
@@ -15,7 +15,7 @@ var english_titles := [
 ]
 
 var spanish_titles := [
-	"El tejido oscurot",
+	"El tejido oscuro",
 	"El Señor de las Agujas",
 ]
 

--- a/scenes/menus/storybook/components/storybook_test.gd
+++ b/scenes/menus/storybook/components/storybook_test.gd
@@ -28,13 +28,19 @@ var titles := english_titles + spanish_titles + french_titles
 
 func _ready() -> void:
 	var quests: Array[Quest] = []
+	var titles_count: Dictionary[String, int] = {}
+	for t: String in titles:
+		titles_count[t] = 0
+
 	for i in range(quests_amount):
 		var q := Quest.new()
-		q.title = titles.pick_random()
+		var t: String = titles.pick_random()
+		titles_count[t] += 1
+		q.title = "%s %d" % [t, titles_count[t]] if titles_count[t] > 1 else t
 
-		if q.title in spanish_titles:
+		if t in spanish_titles:
 			q.language = "es"
-		elif q.title in french_titles:
+		elif t in french_titles:
 			q.language = "fr"
 		else:
 			q.language = "en"

--- a/scenes/menus/storybook/components/storybook_test.gd
+++ b/scenes/menus/storybook/components/storybook_test.gd
@@ -7,13 +7,23 @@ const STORYBOOK_SCENE := preload("uid://bhm7fdjvppt8b")
 @export_range(0, 100, 1, "or_greater") var quests_amount: int = 30
 
 var titles := [
-	"Lord of the Needles",
+	"El Señor de las Agujas",
 	"The Secret of Crochet",
-	"The Dark Knit",
+	"El tejido oscurot",
 	"The Needle and the Sorcerer",
 	"Conan the Weaver",
 	"Return to Fray's End",
 	"The Little HushRoom",
+	"Le Seigneur des Aiguilles",
+]
+
+var spanish_titles := [
+	"El Señor de las Agujas",
+	"El tejido oscurot",
+]
+
+var french_titles := [
+	"Le Seigneur des Aiguilles",
 ]
 
 
@@ -22,6 +32,14 @@ func _ready() -> void:
 	for i in range(quests_amount):
 		var q := Quest.new()
 		q.title = titles.pick_random()
+
+		if q.title in spanish_titles:
+			q.language = "es"
+		elif q.title in french_titles:
+			q.language = "fr"
+		else:
+			q.language = "en"
+
 		quests.append(q)
 	var storybook := STORYBOOK_SCENE.instantiate()
 	storybook.quests = quests

--- a/scenes/menus/storybook/components/storybook_test.gd
+++ b/scenes/menus/storybook/components/storybook_test.gd
@@ -29,6 +29,11 @@ var titles := english_titles + spanish_titles + french_titles
 func _ready() -> void:
 	var quests: Array[Quest] = []
 	var titles_count: Dictionary[String, int] = {}
+	var debug_info := {
+		"en": 0,
+		"es": 0,
+		"fr": 0,
+	}
 	for t: String in titles:
 		titles_count[t] = 0
 
@@ -40,12 +45,17 @@ func _ready() -> void:
 
 		if t in spanish_titles:
 			q.language = "es"
+			debug_info["es"] += 1
 		elif t in french_titles:
 			q.language = "fr"
+			debug_info["fr"] += 1
 		else:
 			q.language = "en"
+			debug_info["en"] += 1
 
 		quests.append(q)
 	var storybook := STORYBOOK_SCENE.instantiate()
 	storybook.quests = quests
 	add_child(storybook)
+	debug_info["total"] = quests_amount
+	prints(debug_info)

--- a/scenes/menus/storybook/components/storybook_test.gd
+++ b/scenes/menus/storybook/components/storybook_test.gd
@@ -6,25 +6,24 @@ const STORYBOOK_SCENE := preload("uid://bhm7fdjvppt8b")
 
 @export_range(0, 100, 1, "or_greater") var quests_amount: int = 30
 
-var titles := [
-	"El Señor de las Agujas",
+var english_titles := [
 	"The Secret of Crochet",
-	"El tejido oscurot",
 	"The Needle and the Sorcerer",
 	"Conan the Weaver",
 	"Return to Fray's End",
 	"The Little HushRoom",
-	"Le Seigneur des Aiguilles",
 ]
 
 var spanish_titles := [
-	"El Señor de las Agujas",
 	"El tejido oscurot",
+	"El Señor de las Agujas",
 ]
 
 var french_titles := [
 	"Le Seigneur des Aiguilles",
 ]
+
+var titles := english_titles + spanish_titles + french_titles
 
 
 func _ready() -> void:

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -239,14 +239,12 @@ text = "TOC"
 [node name="ENBookmark" type="Button" parent="BookmarkContainer" unique_id=399694213]
 unique_name_in_owner = true
 layout_mode = 2
-text = "EN
-"
+text = "EN"
 
 [node name="ESBookmark" type="Button" parent="BookmarkContainer" unique_id=278781945]
 unique_name_in_owner = true
 layout_mode = 2
-text = "ES
-"
+text = "ES"
 
 [connection signal="selected" from="VBoxContainer/CenterContainer/StoryBookContent/StorybookPage" to="." method="_on_storybook_page_selected"]
 [connection signal="pressed" from="VBoxContainer/CenterContainer/StoryBookContent/BackButton" to="." method="_on_back_button_pressed"]

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -1,7 +1,6 @@
 [gd_scene format=3 uid="uid://bhm7fdjvppt8b"]
 
 [ext_resource type="Script" uid="uid://5bt5um5g1g3p" path="res://scenes/menus/storybook/components/storybook.gd" id="1_gw8hn"]
-[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="3_21r2o"]
 [ext_resource type="PackedScene" uid="uid://cgtonist08yxn" path="res://scenes/menus/storybook/components/storybook_page.tscn" id="3_n2i2u"]
 [ext_resource type="SpriteFrames" uid="uid://dne3cxrhbjuno" path="res://scenes/menus/storybook/components/storybook_animation.tres" id="3_y0b3i"]
 [ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="5_m2ghf"]
@@ -24,7 +23,7 @@ region = Rect2(576, 576, 64, 64)
 
 [node name="Storybook" type="CanvasLayer" unique_id=438542807]
 script = ExtResource("1_gw8hn")
-quests = Array[ExtResource("3_21r2o")]([ExtResource("5_ywp77")])
+quests = [ExtResource("5_ywp77")]
 
 [node name="ColorRect" type="ColorRect" parent="." unique_id=1792675940]
 modulate = Color(0, 0, 0, 0.70000005)
@@ -157,6 +156,30 @@ theme_type_variation = &"FlatButton"
 text = "Back"
 icon = ExtResource("5_m2ghf")
 flat = true
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/CenterContainer/StoryBookContent" unique_id=1654245298]
+layout_mode = 0
+offset_left = -158.0
+offset_top = -297.0
+offset_right = 412.0
+offset_bottom = -222.0
+
+[node name="TOCBookmark" type="Button" parent="VBoxContainer/CenterContainer/StoryBookContent/HBoxContainer" unique_id=460814141]
+unique_name_in_owner = true
+layout_mode = 2
+text = "TOC"
+
+[node name="ENBookmark" type="Button" parent="VBoxContainer/CenterContainer/StoryBookContent/HBoxContainer" unique_id=399694213]
+unique_name_in_owner = true
+layout_mode = 2
+text = "EN
+"
+
+[node name="ESBookmark" type="Button" parent="VBoxContainer/CenterContainer/StoryBookContent/HBoxContainer" unique_id=278781945]
+unique_name_in_owner = true
+layout_mode = 2
+text = "ES
+"
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer" unique_id=1971907031]
 layout_mode = 2

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://bhm7fdjvppt8b"]
 
 [ext_resource type="Script" uid="uid://5bt5um5g1g3p" path="res://scenes/menus/storybook/components/storybook.gd" id="1_gw8hn"]
+[ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="2_ofgxb"]
 [ext_resource type="PackedScene" uid="uid://cgtonist08yxn" path="res://scenes/menus/storybook/components/storybook_page.tscn" id="3_n2i2u"]
 [ext_resource type="SpriteFrames" uid="uid://dne3cxrhbjuno" path="res://scenes/menus/storybook/components/storybook_animation.tres" id="3_y0b3i"]
 [ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="5_m2ghf"]
@@ -23,7 +24,7 @@ region = Rect2(576, 576, 64, 64)
 
 [node name="Storybook" type="CanvasLayer" unique_id=438542807]
 script = ExtResource("1_gw8hn")
-quests = [ExtResource("5_ywp77")]
+quests = Array[ExtResource("2_ofgxb")]([ExtResource("5_ywp77")])
 
 [node name="ColorRect" type="ColorRect" parent="." unique_id=1792675940]
 modulate = Color(0, 0, 0, 0.70000005)
@@ -157,30 +158,6 @@ text = "Back"
 icon = ExtResource("5_m2ghf")
 flat = true
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/CenterContainer/StoryBookContent" unique_id=1654245298]
-layout_mode = 0
-offset_left = -158.0
-offset_top = -297.0
-offset_right = 412.0
-offset_bottom = -222.0
-
-[node name="TOCBookmark" type="Button" parent="VBoxContainer/CenterContainer/StoryBookContent/HBoxContainer" unique_id=460814141]
-unique_name_in_owner = true
-layout_mode = 2
-text = "TOC"
-
-[node name="ENBookmark" type="Button" parent="VBoxContainer/CenterContainer/StoryBookContent/HBoxContainer" unique_id=399694213]
-unique_name_in_owner = true
-layout_mode = 2
-text = "EN
-"
-
-[node name="ESBookmark" type="Button" parent="VBoxContainer/CenterContainer/StoryBookContent/HBoxContainer" unique_id=278781945]
-unique_name_in_owner = true
-layout_mode = 2
-text = "ES
-"
-
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer" unique_id=1971907031]
 layout_mode = 2
 theme_override_constants/margin_right = 8
@@ -247,6 +224,29 @@ text = "Next"
 editor_description = "This empty control expands to fill the center of the hbox, pushing any controls packed after it to the right margin."
 layout_mode = 2
 size_flags_horizontal = 3
+
+[node name="BookmarkContainer" type="HBoxContainer" parent="." unique_id=1654245298]
+offset_left = 474.0
+offset_top = 14.0
+offset_right = 805.0
+offset_bottom = 89.0
+
+[node name="TOCBookmark" type="Button" parent="BookmarkContainer" unique_id=460814141]
+unique_name_in_owner = true
+layout_mode = 2
+text = "TOC"
+
+[node name="ENBookmark" type="Button" parent="BookmarkContainer" unique_id=399694213]
+unique_name_in_owner = true
+layout_mode = 2
+text = "EN
+"
+
+[node name="ESBookmark" type="Button" parent="BookmarkContainer" unique_id=278781945]
+unique_name_in_owner = true
+layout_mode = 2
+text = "ES
+"
 
 [connection signal="selected" from="VBoxContainer/CenterContainer/StoryBookContent/StorybookPage" to="." method="_on_storybook_page_selected"]
 [connection signal="pressed" from="VBoxContainer/CenterContainer/StoryBookContent/BackButton" to="." method="_on_back_button_pressed"]


### PR DESCRIPTION
Add TOC (table of contents), EN, and ES bookmarks to the storybook, to allow players to filter quests by language in addition to the full list.

The current bookmarks are placeholder buttons for now, they should be themed in the future.

It behaves like a real book, although the animation shows a single page swipe even when going to pages far away. For example: if there are 30 quests, of which 20 are EN and 10 are ES, the calculation should be:

- 2 spreads for ToC (30 < 16 * 2)
- 2 spreads for EN (20 < 16 * 2)
- 1 spread for ES (10 < 16)

Then the spread index is:

- _current_spread_index == 0 -> ToC 1st spread
- _current_spread_index == 1 -> ToC 2nd spread
- _current_spread_index == 2 -> EN 1st spread
- _current_spread_index == 3 -> EN 2nd spread
- _current_spread_index == 4 -> ES only spread
- _current_spread_index == 7 -> Quest 1
- _current_spread_index == 8 -> Quest 2
- ...
- _current_spread_index == 24 -> Quest 30

Having quests in a single language (all English or all Spanish) hides the EN and ES bookmarks and the per-language spreads.

Resolves #2548 