### PR TITLE
Reinstate LoreQuests in StoryQuest kit

### DIFF
--- a/scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn
+++ b/scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn
@@ -242,7 +242,6 @@ position = Vector2(-575, 315)
 item = SubResource("Resource_u8qfb")
 collected_dialogue = ExtResource("21_x2ecx")
 dialogue_title = &"thread_collected"
-next_scene = "uid://cufkthb25mpxy"
 spawn_point_path = NodePath("SpawnPointAfterIntro")
 exit_transition = 1
 

--- a/tools/sqckck.sh
+++ b/tools/sqckck.sh
@@ -9,7 +9,6 @@ pushd "$(readlink -f "$(dirname "$0")/..")"
 VERSION=$(git describe --tags)
 declare -a PRUNE_FOLDERS=(
 	"assets/third_party/tiny-swords-non-cc0"
-	"scenes/quests/lore_quests"
 	"scenes/quests/story_quests"
 	"scenes/world_map"
 )


### PR DESCRIPTION
Reinstate LoreQuests in StoryQuest kit

These quests contain useful examples of using the components of our
game, not all of which are demonstrated in Dev Archipelago yet.

Stop stripping the lore_quests folder from the StoryQuest kit. This
increases the size of the kit by ~180 files and ~5 MB - not a lot.

Adjust the end of the tutorial quest to point to the home scene rather
than Fray's End. (I deliberately didn't do this before because it uses a
particular spawn point in Fray's End, but this still works with the "go
home" reference. If that spawn point does not exist (as it does not in
Dev Archipelago), it will just be ignored.)

Keep Fray's End excluded from the kit and don't add an elder that offers
these quests to Dev Archipelago. They can be found in the filesystem.

Resolves https://github.com/endlessm/threadbare/issues/2710
