### PR TITLE
cat, sheep: Fix meow/baa position

### DIFF
--- a/scenes/game_elements/characters/npcs/cat/cat.tscn
+++ b/scenes/game_elements/characters/npcs/cat/cat.tscn
@@ -50,17 +50,17 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 visible = false
 position = Vector2(5, -28)
 shape = SubResource("RectangleShape2D_t04tf")
-debug_color = Color(0.6290859, 0.52632225, 0.15803415, 0.41960785)
+debug_color = Color(0.6, 0.545, 0, 0.42)
+
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="." unique_id=1698132789]
+stream = SubResource("AudioStreamRandomizer_8kxh7")
+bus = &"SFX"
 
 [node name="PetInteraction" type="Node" parent="." unique_id=929067504 node_paths=PackedStringArray("interact_area", "sound_effect_player", "fact_counter")]
 script = ExtResource("4_t04tf")
 interact_area = NodePath("../InteractArea")
-sound_effect_player = NodePath("AudioStreamPlayer2D")
+sound_effect_player = NodePath("../AudioStreamPlayer2D")
 fact_counter = NodePath("../FactCounter")
-
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="PetInteraction" unique_id=1698132789]
-stream = SubResource("AudioStreamRandomizer_8kxh7")
-bus = &"SFX"
 
 [node name="FactCounter" type="Node" parent="." unique_id=539544383]
 script = ExtResource("6_0bwy3")

--- a/scenes/game_elements/props/decoration/sheep/sheep.tscn
+++ b/scenes/game_elements/props/decoration/sheep/sheep.tscn
@@ -64,18 +64,18 @@ metadata/_custom_type_script = "uid://du8wfijr35r35"
 visible = false
 position = Vector2(5, -28)
 shape = SubResource("RectangleShape2D_tsjbs")
-debug_color = Color(0.6290859, 0.52632225, 0.15803415, 0.41960785)
+debug_color = Color(0.6, 0.545, 0, 0.42)
+
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="." unique_id=1930789457]
+stream = SubResource("AudioStreamRandomizer_3vki4")
+bus = &"SFX"
 
 [node name="PetInteraction" type="Node" parent="." unique_id=1162035923 node_paths=PackedStringArray("interact_area", "sound_effect_player", "shaker", "fact_counter")]
 script = ExtResource("4_pcfmk")
 interact_area = NodePath("../InteractArea")
-sound_effect_player = NodePath("AudioStreamPlayer2D")
+sound_effect_player = NodePath("../AudioStreamPlayer2D")
 shaker = NodePath("../AnimatedSprite2D/Shaker")
 fact_counter = NodePath("../FactCounter")
-
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="PetInteraction" unique_id=1930789457]
-stream = SubResource("AudioStreamRandomizer_3vki4")
-bus = &"SFX"
 
 [node name="FactCounter" type="Node" parent="." unique_id=2116673480]
 script = ExtResource("7_1k1ft")


### PR DESCRIPTION
Previously the AudioStreamPlayer2D was a child of a `Node` (not
`Node2D`). `Node`s do not have a position in the 2D scene, so the
resulting position of the AudioStreamPlayer2D was (0, 0). The
AudioStreamPlayer2D is set to attenuate over 2000px of distance so if
the cat/sheep was more than 2000px from the (0, 0) position of the
scene, its sound would be completely inaudible, and before that it would
be quieter. We never noticed this before because the sheep and cat
happen to be close to the origin of the scene! However it was noticeable
on the new enemy interaction island in Dev Archipelago.

Change the structure of each scene so that the AudioStreamPlayer2D node
is not a child of the PetInteraction (Node) but of the root (subclass of
Node2D).
