### PR TITLE
git_describe: Simplify "v0.1.2" to "0.1.2" not "0.1.2."

### DIFF
--- a/addons/threadbare_git_describe/version.gd
+++ b/addons/threadbare_git_describe/version.gd
@@ -31,7 +31,12 @@ static func simplify(full_version: String) -> String:
 	var result := regex.search(full_version)
 	if not result:
 		return "0.0.0"
-	return ".".join(result.strings.slice(1))
+
+	var base := result.strings[result.names["base"]]
+	if "count" in result.names:
+		var count := result.strings[result.names["count"]]
+		return base + "." + count
+	return base
 
 
 ## Gets the full `git describe`-style version


### PR DESCRIPTION
On the title screen we show the full output of `git describe --tags`,
which for an arbitrary change on that is not a tag looks like
`v0.2.2-24-g14ed33fee` and for a tag looks like `v0.2.2`.

For Windows executables, the version can only be up to 4
period-separated integers. So we simplify `v0.2.2-24-g14ed33fee` to
`0.2.2.24`, i.e. the nano field is the number of patches since the tag
represented by the major.minor.micro fields, and set this as the project
version.

However this logic was incorrect for tags: `v0.2.2` was reduced to
`0.2.2.` with a trailing period. The regexp nests a named match group
inside an optional non-capturing match group: `(?:-(?<count>\\d+).*)?`.
If the outer group doesn't match, the `"count"` field is not in the
`names` field of the `RegExMatch` object, but there is still an empty
entry for it in the `strings` field.

Indexes into the `strings` field via the `names` field (a map from group
name to its index in `strings`). Explicitly check whether `count`
matched, and don't include the empty non-match as the nano field if not.

Resolves https://github.com/endlessm/threadbare/issues/2711
