### PR TITLE
Player: Make sight and harm collision shapes outline only

### DIFF
--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -418,7 +418,7 @@ character = NodePath("../..")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PlayerInteraction/CharacterSight" unique_id=255765935]
 position = Vector2(47, -30)
 shape = SubResource("RectangleShape2D_blfj0")
-debug_color = Color(0.600391, 0.54335, 0, 0.42)
+debug_color = Color(0.6, 0.54, 0, 0)
 
 [node name="PlayerRepel" parent="." unique_id=1324972992 instance=ExtResource("12_tnibl")]
 unique_name_in_owner = true
@@ -452,7 +452,7 @@ collision_mask = 256
 [node name="CollisionShape2D" type="CollisionShape2D" parent="PlayerHarm/HitBox" unique_id=1807630823]
 position = Vector2(0, -28.5)
 shape = SubResource("RectangleShape2D_je7p5")
-debug_color = Color(0.94902, 0.231373, 0, 0.419608)
+debug_color = Color(0.95, 0.2375, 0, 0)
 
 [node name="GotHitAnimation" type="AnimationPlayer" parent="PlayerHarm" unique_id=1067804411]
 unique_name_in_owner = true


### PR DESCRIPTION
Too many collision shapes overlapping can be hard to understand for debugging. Changing them to alpha zero leaves them as outlines, as long as `debug/shapes/collision/draw_2d_outlines` is `true` (the default).
