### PR TITLE
InputWalkBehavior: Check if the player got stuck

### DIFF
--- a/scenes/dev/grapple/grapple_gym_1/grapple_gym_1.tscn
+++ b/scenes/dev/grapple/grapple_gym_1/grapple_gym_1.tscn
@@ -77,6 +77,9 @@ position = Vector2(913, 485)
 [node name="HookablePin4" parent="OnTheGround/Pins" unique_id=1250193180 instance=ExtResource("6_pxkjf")]
 position = Vector2(1169, 303)
 
+[node name="HookablePin11" parent="OnTheGround/Pins" unique_id=2071223292 instance=ExtResource("6_pxkjf")]
+position = Vector2(1026, 143)
+
 [node name="HookablePin5" parent="OnTheGround/Pins" unique_id=1480625723 instance=ExtResource("6_pxkjf")]
 position = Vector2(2017, 166)
 
@@ -92,7 +95,7 @@ position = Vector2(3687, 662)
 [node name="HookablePin9" parent="OnTheGround/Pins" unique_id=1322673471 instance=ExtResource("6_pxkjf")]
 position = Vector2(3108, 250)
 
-[node name="HookablePin10" parent="OnTheGround/Pins" unique_id=2071223292 instance=ExtResource("6_pxkjf")]
+[node name="HookablePin10" parent="OnTheGround/Pins" unique_id=2047299180 instance=ExtResource("6_pxkjf")]
 position = Vector2(3671, 105)
 
 [node name="Needles" type="Node2D" parent="OnTheGround" unique_id=835311089]
@@ -159,10 +162,15 @@ Notice that the needle on the left is not
 accessible for keyboard-only users."
 
 [node name="Sign4" parent="OnTheGround/Signs" unique_id=436998371 instance=ExtResource("8_m27j3")]
-position = Vector2(1242, 93)
+position = Vector2(1347, 92)
 direction = 1
 text = "Needles can be used to chain
 together a longer string."
+
+[node name="Sign8" parent="OnTheGround/Signs" unique_id=1639018305 instance=ExtResource("8_m27j3")]
+position = Vector2(1184, 93)
+text = "Position the pins carefully.
+The player may fall in water and get stuck!"
 
 [node name="Sign5" parent="OnTheGround/Signs" unique_id=580295205 instance=ExtResource("8_m27j3")]
 position = Vector2(3572, 900)

--- a/scenes/game_elements/characters/player/components/player.gd
+++ b/scenes/game_elements/characters/player/components/player.gd
@@ -71,6 +71,8 @@ var _system_controllers: Array[Node] = []
 @onready var player_hook: PlayerHook = %PlayerHook
 @onready var player_sprite: AnimatedSprite2D = %PlayerSprite
 @onready var player_dust_particles: GPUParticles2D = %PlayerDustParticles
+@onready var stuck_shaker: Shaker = %StuckShaker
+@onready var stuck_timer: Timer = %StuckTimer
 @onready var _walk_sound: AudioStreamPlayer2D = %WalkSound
 
 
@@ -151,6 +153,9 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
+	input_walk_behavior.stuck_changed.connect(_on_input_walk_behavior_stuck_changed)
+	stuck_timer.timeout.connect(defeat)
+
 	GameState.player.abilities_changed.connect(_on_abilities_changed)
 	GameState.player_changed.connect(_on_player_state_changed)
 
@@ -159,6 +164,14 @@ func _on_player_state_changed(old: PlayerState, new: PlayerState) -> void:
 	old.abilities_changed.disconnect(_on_abilities_changed)
 	new.abilities_changed.connect(_on_abilities_changed)
 	_on_abilities_changed()
+
+
+func _on_input_walk_behavior_stuck_changed(is_stuck: bool) -> void:
+	if is_stuck:
+		stuck_shaker.shake()
+		stuck_timer.start()
+	else:
+		stuck_timer.stop()
 
 
 func _set_speeds(new_speeds: CharacterSpeeds) -> void:

--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="Script" uid="uid://csev4hv57utxv" path="res://scenes/game_logic/walk_behaviors/character_speeds.gd" id="3_cvb4d"]
 [ext_resource type="Script" uid="uid://bpu6jo4kvehlg" path="res://scenes/game_elements/characters/player/components/player_interaction.gd" id="3_dqkch"]
 [ext_resource type="Script" uid="uid://qro4uo83ba8f" path="res://scenes/game_elements/characters/player/components/player_sprite.gd" id="3_qlg0r"]
+[ext_resource type="Script" uid="uid://dunsvrhq42214" path="res://scenes/game_elements/fx/shaker/shaker.gd" id="4_ecbbk"]
 [ext_resource type="Script" uid="uid://necvar42rnih" path="res://scenes/game_elements/props/character_sight/character_sight.gd" id="6_3in67"]
 [ext_resource type="Script" uid="uid://e78f8iq448e1" path="res://scenes/game_elements/characters/player/components/animation_player.gd" id="7_0owmy"]
 [ext_resource type="AudioStream" uid="uid://cx6jv2cflrmqu" path="res://assets/third_party/sounds/characters/player/Foot.ogg" id="11_blfj0"]
@@ -363,6 +364,19 @@ script = ExtResource("2_5lbww")
 speeds = SubResource("Resource_cvb4d")
 character = NodePath("..")
 metadata/_custom_type_script = "uid://c8xbryhknipab"
+
+[node name="StuckTimer" type="Timer" parent="InputWalkBehavior" unique_id=383350805]
+unique_name_in_owner = true
+wait_time = 2.0
+
+[node name="StuckShaker" type="Node2D" parent="InputWalkBehavior" unique_id=1890601821 node_paths=PackedStringArray("target")]
+unique_name_in_owner = true
+script = ExtResource("4_ecbbk")
+target = NodePath("../../PlayerSprite")
+shake_intensity = 20.0
+duration = 2.0
+frequency = 20.0
+metadata/_custom_type_script = "uid://dunsvrhq42214"
 
 [node name="PlayerDustParticles" type="GPUParticles2D" parent="." unique_id=785276606]
 unique_name_in_owner = true

--- a/scenes/game_logic/walk_behaviors/input_walk_behavior.gd
+++ b/scenes/game_logic/walk_behaviors/input_walk_behavior.gd
@@ -21,6 +21,9 @@ var input_vector: Vector2
 var is_running: bool:
 	set = _set_is_running
 
+var _is_stuck: bool
+var _last_safe_position: Vector2
+
 
 func _set_is_running(new_is_running: bool) -> void:
 	if is_running == new_is_running:
@@ -52,6 +55,15 @@ func _physics_process(delta: float) -> void:
 	)
 	character.velocity = character.velocity.move_toward(input_vector, step * delta)
 	character.move_and_slide()
+
+	# Check if the player got stuck (is colliding after the move_and_slide).
+	var collision := character.move_and_collide(Vector2.ZERO, true)
+	_is_stuck = collision != null
+	if _is_stuck:
+		character.velocity = Vector2.ZERO
+		character.position = _last_safe_position
+	else:
+		_last_safe_position = character.global_position
 
 	# When using an analogue joystick, this can be false even if the player is
 	# holding the "run" button, because the joystick may be inclined only slightly.

--- a/scenes/game_logic/walk_behaviors/input_walk_behavior.gd
+++ b/scenes/game_logic/walk_behaviors/input_walk_behavior.gd
@@ -10,6 +10,9 @@ extends BaseCharacterBehavior
 ## Emitted when the character starts or stops running.
 signal running_changed(is_running: bool)
 
+## Emitted when the character stuck state changes.
+signal stuck_changed(is_stuck: bool)
+
 ## Parameters controlling the speed at which this character walks. If unset, the default values of
 ## [CharacterSpeeds] are used.
 @export var speeds: CharacterSpeeds
@@ -21,8 +24,9 @@ var input_vector: Vector2
 var is_running: bool:
 	set = _set_is_running
 
-var _is_stuck: bool
-var _last_safe_position: Vector2
+## True if the character still collides after moving.
+var is_stuck: bool:
+	set = _set_is_stuck
 
 
 func _set_is_running(new_is_running: bool) -> void:
@@ -30,6 +34,13 @@ func _set_is_running(new_is_running: bool) -> void:
 		return
 	is_running = new_is_running
 	running_changed.emit(is_running)
+
+
+func _set_is_stuck(new_is_stuck: bool) -> void:
+	if is_stuck == new_is_stuck:
+		return
+	is_stuck = new_is_stuck
+	stuck_changed.emit(is_stuck)
 
 
 func _ready() -> void:
@@ -58,12 +69,7 @@ func _physics_process(delta: float) -> void:
 
 	# Check if the player got stuck (is colliding after the move_and_slide).
 	var collision := character.move_and_collide(Vector2.ZERO, true)
-	_is_stuck = collision != null
-	if _is_stuck:
-		character.velocity = Vector2.ZERO
-		character.position = _last_safe_position
-	else:
-		_last_safe_position = character.global_position
+	is_stuck = collision != null
 
 	# When using an analogue joystick, this can be false even if the player is
 	# holding the "run" button, because the joystick may be inclined only slightly.


### PR DESCRIPTION
And if so, defeat the player.

### InputWalkBehavior: Check if the character got stuck

That is, if after calling move_and_slide() it still collides with anything.
And emit a signal when this state changes.

### Player: Defeat after being stuck for 2 seconds

Add a 2 seconds timer and use it to call defeat on timeout. Start or stop the
timer depending on the input walk signal "is stuck".

Add a shaking animation to the player sprite when it becomes stuck.

And if so, set velocity to zero and go back to the previous position otherwise.

### Dev Grapple: Add example of pin positioned in water

Helps https://github.com/endlessm/threadbare/issues/2704