### PR TITLE
Add completion indicators to Storybook quests

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -49,9 +49,6 @@ func _fade_in_ui() -> void:
 	tween.tween_property(ui_container, "modulate:a", 1.0, fade_duration)
 
 
-#func _ready() -> void:
-	#animated_book.animation_finished.connect(_on_animation_finished)
-	#_populate_quest_lists()
 func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
 	_populate_quest_lists()
@@ -105,16 +102,14 @@ func _create_quest_button(
 	var button := Button.new()
 	button.text = quest.get_title()
 	button.theme_type_variation = "FlatButton"
-	
-	##Verification of completed quests <3
+
 	if quest in GameState.global.completed_quests:
 		button.icon = button.get_theme_icon("checked", "CheckBox")
 	else:
 		button.icon = button.get_theme_icon("unchecked", "CheckBox")
+
 	parent_container.add_child(button)
-	
-	
-	
+
 	button.set_meta("quest_index", quest_index)
 
 	button.pressed.connect(_on_quest_button_pressed.bind(button))

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -107,6 +107,7 @@ func _create_quest_button(
 		button.icon = button.get_theme_icon("checked", "CheckBox")
 	else:
 		button.icon = button.get_theme_icon("unchecked", "CheckBox")
+	button.icon_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 
 	parent_container.add_child(button)
 

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -102,6 +102,7 @@ func _create_quest_button(
 	var button := Button.new()
 	button.text = quest.get_title()
 	button.theme_type_variation = "FlatButton"
+	button.alignment = HORIZONTAL_ALIGNMENT_LEFT
 
 	if quest in GameState.global.completed_quests:
 		button.icon = button.get_theme_icon("checked", "CheckBox")

--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -49,6 +49,9 @@ func _fade_in_ui() -> void:
 	tween.tween_property(ui_container, "modulate:a", 1.0, fade_duration)
 
 
+#func _ready() -> void:
+	#animated_book.animation_finished.connect(_on_animation_finished)
+	#_populate_quest_lists()
 func _ready() -> void:
 	animated_book.animation_finished.connect(_on_animation_finished)
 	_populate_quest_lists()
@@ -102,7 +105,16 @@ func _create_quest_button(
 	var button := Button.new()
 	button.text = quest.get_title()
 	button.theme_type_variation = "FlatButton"
+	
+	##Verification of completed quests <3
+	if quest in GameState.global.completed_quests:
+		button.icon = button.get_theme_icon("checked", "CheckBox")
+	else:
+		button.icon = button.get_theme_icon("unchecked", "CheckBox")
 	parent_container.add_child(button)
+	
+	
+	
 	button.set_meta("quest_index", quest_index)
 
 	button.pressed.connect(_on_quest_button_pressed.bind(button))


### PR DESCRIPTION
- Added completion indicators to Storybook quests.
- Completed quests display a checked checkbox.
- Uncompleted quests display an unchecked checkbox.
- Uses `GameState.global.completed_quests` to determine the quest status.

Resolves https://github.com/endlessm/threadbare/issues/1274#issuecomment-5400854148