### PR TITLE
Change text order for Dev's Archipelago dialogue

### DIFF
--- a/scenes/world_map/components/frays_end.dialogue
+++ b/scenes/world_map/components/frays_end.dialogue
@@ -68,10 +68,6 @@ Dolores: She said they’re still out there, even if I can’t see them... and t
 Dolores: Supposedly, they created a special area for themselves, as a playground to try out new things.
 Dolores: It was called “Dev Archipelago”.
 Dolores: Do you want to see it for yourself?
-- Not right now...
-	Dolores: OK! There are lots of other places to explore.
-	Dolores: Talk to me again if you change your mind.
-	=> END
 - Yes, I'm ready!
 	Dolores: That's the spirit!
 	do wait(0.5)
@@ -81,6 +77,10 @@ Dolores: Do you want to see it for yourself?
 	do wait(0.5)
 	Dolores: Wow, how did that bridge fix itself?
 	=> beach_go_to_dev_island
+- Not right now...
+	Dolores: OK! There are lots of other places to explore.
+	Dolores: Talk to me again if you change your mind.
+	=> END
 
 ~ beach_go_to_dev_island
 Dolores: Go on! Go across the bridge to Dev Archipelago.


### PR DESCRIPTION
Change the order of Dolores Dialogue for the Dev Archipelago to show first "Yes, I'm ready!" dialogue 