### PR TITLE
Issue 1331 replace bushes - Replace field bushes with crops

### DIFF
--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -328,130 +328,6 @@ scale = Vector2(1.1, 1.1)
 position = Vector2(2386, 960)
 sprite_frames = ExtResource("7_p2u32")
 
-[node name="Bush14" type="Sprite2D" parent="." unique_id=1895635127]
-position = Vector2(2348, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush15" type="Sprite2D" parent="." unique_id=1246338694]
-position = Vector2(3102, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush16" type="Sprite2D" parent="." unique_id=849373817]
-position = Vector2(3221, 725)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush17" type="Sprite2D" parent="." unique_id=2018160986]
-position = Vector2(2987, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush18" type="Sprite2D" parent="." unique_id=1058303181]
-position = Vector2(2599, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush19" type="Sprite2D" parent="." unique_id=646958806]
-position = Vector2(2382, 728)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush20" type="Sprite2D" parent="." unique_id=1066380817]
-position = Vector2(2459, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush21" type="Sprite2D" parent="." unique_id=1145255538]
-position = Vector2(2528, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush22" type="Sprite2D" parent="." unique_id=1493723887]
-position = Vector2(2673, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush23" type="Sprite2D" parent="." unique_id=175746385]
-position = Vector2(2753, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush24" type="Sprite2D" parent="." unique_id=1040675126]
-position = Vector2(2829, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush39" type="Sprite2D" parent="." unique_id=1285870624]
-position = Vector2(7145, 1060)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush46" type="Sprite2D" parent="." unique_id=1479038353]
-position = Vector2(7313, 1058)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush40" type="Sprite2D" parent="." unique_id=2094828725]
-position = Vector2(7255, 1114)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush41" type="Sprite2D" parent="." unique_id=483665645]
-position = Vector2(7255, 1061)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush42" type="Sprite2D" parent="." unique_id=1245446333]
-position = Vector2(7195, 1112)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush43" type="Sprite2D" parent="." unique_id=2124594502]
-position = Vector2(7197, 1059)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush44" type="Sprite2D" parent="." unique_id=810153908]
-position = Vector2(7141, 1113)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush25" type="Sprite2D" parent="." unique_id=1803653289]
-position = Vector2(2912, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush26" type="Sprite2D" parent="." unique_id=559247427]
-position = Vector2(3061, 728)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush27" type="Sprite2D" parent="." unique_id=125235965]
-position = Vector2(3144, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush28" type="Sprite2D" parent="." unique_id=1495778546]
-position = Vector2(3183, 682)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush29" type="Sprite2D" parent="." unique_id=299438753]
-position = Vector2(3023, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush30" type="Sprite2D" parent="." unique_id=563159353]
-position = Vector2(2951, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush31" type="Sprite2D" parent="." unique_id=2131328083]
-position = Vector2(2870, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush32" type="Sprite2D" parent="." unique_id=2048076406]
-position = Vector2(2791, 681)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush33" type="Sprite2D" parent="." unique_id=1870391516]
-position = Vector2(2712, 682)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush34" type="Sprite2D" parent="." unique_id=759214153]
-position = Vector2(2637, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush35" type="Sprite2D" parent="." unique_id=533493752]
-position = Vector2(2567, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush36" type="Sprite2D" parent="." unique_id=46556756]
-position = Vector2(2492, 681)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush37" type="Sprite2D" parent="." unique_id=220567071]
-position = Vector2(2422, 682)
-texture = ExtResource("13_f6dpy")
-
 [node name="Bush38" parent="." unique_id=1047144418 instance=ExtResource("10_0q07n")]
 position = Vector2(46, 138)
 
@@ -1123,6 +999,136 @@ script = ExtResource("56_4qmxg")
 
 [node name="Marker" type="Marker2D" parent="Helper" unique_id=1877766615]
 position = Vector2(0, -72)
+
+[node name="MiddleFieldBushes" type="Node2D" parent="." unique_id=1058693455]
+y_sort_enabled = true
+
+[node name="Bush14" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1895635127]
+position = Vector2(2348, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush15" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1246338694]
+position = Vector2(3102, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush16" type="Sprite2D" parent="MiddleFieldBushes" unique_id=849373817]
+position = Vector2(3221, 725)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush17" type="Sprite2D" parent="MiddleFieldBushes" unique_id=2018160986]
+position = Vector2(2987, 727)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush18" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1058303181]
+position = Vector2(2599, 726)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush19" type="Sprite2D" parent="MiddleFieldBushes" unique_id=646958806]
+position = Vector2(2382, 728)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush20" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1066380817]
+position = Vector2(2459, 727)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush21" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1145255538]
+position = Vector2(2528, 727)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush22" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1493723887]
+position = Vector2(2673, 727)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush23" type="Sprite2D" parent="MiddleFieldBushes" unique_id=175746385]
+position = Vector2(2753, 726)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush24" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1040675126]
+position = Vector2(2829, 726)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush25" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1803653289]
+position = Vector2(2912, 726)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush26" type="Sprite2D" parent="MiddleFieldBushes" unique_id=559247427]
+position = Vector2(3061, 728)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush27" type="Sprite2D" parent="MiddleFieldBushes" unique_id=125235965]
+position = Vector2(3144, 727)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush28" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1495778546]
+position = Vector2(3183, 682)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush29" type="Sprite2D" parent="MiddleFieldBushes" unique_id=299438753]
+position = Vector2(3023, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush30" type="Sprite2D" parent="MiddleFieldBushes" unique_id=563159353]
+position = Vector2(2951, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush31" type="Sprite2D" parent="MiddleFieldBushes" unique_id=2131328083]
+position = Vector2(2870, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush32" type="Sprite2D" parent="MiddleFieldBushes" unique_id=2048076406]
+position = Vector2(2791, 681)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush33" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1870391516]
+position = Vector2(2712, 682)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush34" type="Sprite2D" parent="MiddleFieldBushes" unique_id=759214153]
+position = Vector2(2637, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush35" type="Sprite2D" parent="MiddleFieldBushes" unique_id=533493752]
+position = Vector2(2567, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush36" type="Sprite2D" parent="MiddleFieldBushes" unique_id=46556756]
+position = Vector2(2492, 681)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush37" type="Sprite2D" parent="MiddleFieldBushes" unique_id=220567071]
+position = Vector2(2422, 682)
+texture = ExtResource("13_f6dpy")
+
+[node name="EndFieldBushes" type="Node2D" parent="." unique_id=252711983]
+y_sort_enabled = true
+
+[node name="Bush39" type="Sprite2D" parent="EndFieldBushes" unique_id=1285870624]
+position = Vector2(7145, 1060)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush46" type="Sprite2D" parent="EndFieldBushes" unique_id=1479038353]
+position = Vector2(7313, 1058)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush40" type="Sprite2D" parent="EndFieldBushes" unique_id=2094828725]
+position = Vector2(7255, 1114)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush41" type="Sprite2D" parent="EndFieldBushes" unique_id=483665645]
+position = Vector2(7255, 1061)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush42" type="Sprite2D" parent="EndFieldBushes" unique_id=1245446333]
+position = Vector2(7195, 1112)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush43" type="Sprite2D" parent="EndFieldBushes" unique_id=2124594502]
+position = Vector2(7197, 1059)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush44" type="Sprite2D" parent="EndFieldBushes" unique_id=810153908]
+position = Vector2(7141, 1113)
+texture = ExtResource("13_f6dpy")
 
 [connection signal="body_entered" from="CameraStuff/DeadEndArea" to="." method="_on_dead_end_area_body_entered"]
 [connection signal="body_exited" from="CameraStuff/DeadEndArea" to="." method="_on_dead_end_area_body_exited"]

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -60,6 +60,8 @@
 [ext_resource type="Script" uid="uid://du8wfijr35r35" path="res://scenes/game_elements/props/interact_area/interact_area.gd" id="54_llwyy"]
 [ext_resource type="Script" uid="uid://diskln3jup064" path="res://scenes/game_elements/characters/npcs/components/helper_character.gd" id="55_vnfb8"]
 [ext_resource type="Script" uid="uid://cuoe7myo0nd5y" path="res://scenes/quests/lore_quests/quest_001/3_stealth_level/components/fix_bridge.gd" id="56_4qmxg"]
+[ext_resource type="PackedScene" uid="uid://ccpgw7k4rlmea" path="res://scenes/game_elements/props/decoration/crops/barley.tscn" id="61_qsk04"]
+[ext_resource type="PackedScene" uid="uid://c78fj5em5tpm5" path="res://scenes/game_elements/props/decoration/crops/carrot.tscn" id="62_xqyqm"]
 
 [sub_resource type="Resource" id="Resource_c2gs0"]
 script = ExtResource("30_qg4dv")
@@ -1001,6 +1003,7 @@ script = ExtResource("56_4qmxg")
 position = Vector2(0, -72)
 
 [node name="MiddleFieldBushes" type="Node2D" parent="." unique_id=1058693455]
+visible = false
 y_sort_enabled = true
 
 [node name="Bush14" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1895635127]
@@ -1099,7 +1102,203 @@ texture = ExtResource("13_f6dpy")
 position = Vector2(2422, 682)
 texture = ExtResource("13_f6dpy")
 
+[node name="MiddleFieldBushes2" type="Node2D" parent="." unique_id=669269306]
+y_sort_enabled = true
+
+[node name="Bush14" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1921637249]
+visible = false
+position = Vector2(2348, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush15" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1276108111]
+visible = false
+position = Vector2(3102, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush16" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1927617394]
+visible = false
+position = Vector2(3221, 725)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush17" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=2074883758]
+visible = false
+position = Vector2(2987, 727)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush18" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1085177049]
+visible = false
+position = Vector2(2599, 726)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush19" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1300676957]
+visible = false
+position = Vector2(2382, 728)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush20" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=2137458117]
+visible = false
+position = Vector2(2459, 727)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush21" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=145769071]
+visible = false
+position = Vector2(2528, 727)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush22" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1638296094]
+visible = false
+position = Vector2(2673, 727)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush23" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=553975207]
+visible = false
+position = Vector2(2753, 726)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush24" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=106706112]
+visible = false
+position = Vector2(2829, 726)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush25" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1528625264]
+visible = false
+position = Vector2(2912, 726)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush26" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=306427506]
+visible = false
+position = Vector2(3061, 728)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush27" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=402778991]
+visible = false
+position = Vector2(3144, 727)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush28" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=665630089]
+visible = false
+position = Vector2(3183, 682)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush29" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=697204762]
+visible = false
+position = Vector2(3023, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush30" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=26347146]
+visible = false
+position = Vector2(2951, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush31" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1947967455]
+visible = false
+position = Vector2(2870, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush32" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1869404873]
+visible = false
+position = Vector2(2791, 681)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush33" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1069512880]
+visible = false
+position = Vector2(2712, 682)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush34" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1113575946]
+visible = false
+position = Vector2(2637, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush35" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=586428092]
+visible = false
+position = Vector2(2567, 683)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush36" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1161047123]
+visible = false
+position = Vector2(2492, 681)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush37" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1554740220]
+visible = false
+position = Vector2(2422, 682)
+texture = ExtResource("13_f6dpy")
+
+[node name="Barley" parent="MiddleFieldBushes2" unique_id=831247970 instance=ExtResource("61_qsk04")]
+position = Vector2(2348, 683)
+
+[node name="Barley2" parent="MiddleFieldBushes2" unique_id=1304420119 instance=ExtResource("61_qsk04")]
+position = Vector2(3102, 683)
+
+[node name="Barley3" parent="MiddleFieldBushes2" unique_id=445080751 instance=ExtResource("61_qsk04")]
+position = Vector2(3221, 725)
+
+[node name="Barley4" parent="MiddleFieldBushes2" unique_id=830287809 instance=ExtResource("61_qsk04")]
+position = Vector2(2987, 727)
+
+[node name="Barley5" parent="MiddleFieldBushes2" unique_id=1636863251 instance=ExtResource("61_qsk04")]
+position = Vector2(2599, 726)
+
+[node name="Barley6" parent="MiddleFieldBushes2" unique_id=1084201485 instance=ExtResource("61_qsk04")]
+position = Vector2(2382, 728)
+
+[node name="Barley7" parent="MiddleFieldBushes2" unique_id=136732394 instance=ExtResource("61_qsk04")]
+position = Vector2(2459, 727)
+
+[node name="Barley8" parent="MiddleFieldBushes2" unique_id=187498037 instance=ExtResource("61_qsk04")]
+position = Vector2(2528, 727)
+
+[node name="Barley9" parent="MiddleFieldBushes2" unique_id=1788789497 instance=ExtResource("61_qsk04")]
+position = Vector2(2673, 727)
+
+[node name="Barley10" parent="MiddleFieldBushes2" unique_id=227234547 instance=ExtResource("61_qsk04")]
+position = Vector2(2753, 726)
+
+[node name="Barley11" parent="MiddleFieldBushes2" unique_id=1817180277 instance=ExtResource("61_qsk04")]
+position = Vector2(2829, 726)
+
+[node name="Barley12" parent="MiddleFieldBushes2" unique_id=1155939345 instance=ExtResource("61_qsk04")]
+position = Vector2(2912, 726)
+
+[node name="Barley13" parent="MiddleFieldBushes2" unique_id=1911297830 instance=ExtResource("61_qsk04")]
+position = Vector2(3061, 728)
+
+[node name="Barley14" parent="MiddleFieldBushes2" unique_id=643776586 instance=ExtResource("61_qsk04")]
+position = Vector2(3144, 727)
+
+[node name="Barley15" parent="MiddleFieldBushes2" unique_id=1916044884 instance=ExtResource("61_qsk04")]
+position = Vector2(3183, 682)
+
+[node name="Barley16" parent="MiddleFieldBushes2" unique_id=390307022 instance=ExtResource("61_qsk04")]
+position = Vector2(3023, 683)
+
+[node name="Barley17" parent="MiddleFieldBushes2" unique_id=1850173294 instance=ExtResource("61_qsk04")]
+position = Vector2(2951, 683)
+
+[node name="Barley18" parent="MiddleFieldBushes2" unique_id=1992044872 instance=ExtResource("61_qsk04")]
+position = Vector2(2870, 683)
+
+[node name="Barley19" parent="MiddleFieldBushes2" unique_id=538598760 instance=ExtResource("61_qsk04")]
+position = Vector2(2791, 681)
+
+[node name="Barley20" parent="MiddleFieldBushes2" unique_id=260442273 instance=ExtResource("61_qsk04")]
+position = Vector2(2712, 682)
+
+[node name="Barley21" parent="MiddleFieldBushes2" unique_id=1212442662 instance=ExtResource("61_qsk04")]
+position = Vector2(2637, 683)
+
+[node name="Barley22" parent="MiddleFieldBushes2" unique_id=158353006 instance=ExtResource("61_qsk04")]
+position = Vector2(2567, 683)
+
+[node name="Barley23" parent="MiddleFieldBushes2" unique_id=112277879 instance=ExtResource("61_qsk04")]
+position = Vector2(2492, 681)
+
+[node name="Barley24" parent="MiddleFieldBushes2" unique_id=646050395 instance=ExtResource("61_qsk04")]
+position = Vector2(2422, 682)
+
 [node name="EndFieldBushes" type="Node2D" parent="." unique_id=252711983]
+visible = false
 y_sort_enabled = true
 
 [node name="Bush39" type="Sprite2D" parent="EndFieldBushes" unique_id=1285870624]
@@ -1129,6 +1328,65 @@ texture = ExtResource("13_f6dpy")
 [node name="Bush44" type="Sprite2D" parent="EndFieldBushes" unique_id=810153908]
 position = Vector2(7141, 1113)
 texture = ExtResource("13_f6dpy")
+
+[node name="EndFieldBushes2" type="Node2D" parent="." unique_id=1042222237]
+y_sort_enabled = true
+
+[node name="Bush39" type="Sprite2D" parent="EndFieldBushes2" unique_id=655378025]
+visible = false
+position = Vector2(7145, 1060)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush46" type="Sprite2D" parent="EndFieldBushes2" unique_id=1444780401]
+visible = false
+position = Vector2(7313, 1058)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush40" type="Sprite2D" parent="EndFieldBushes2" unique_id=1817722390]
+visible = false
+position = Vector2(7255, 1114)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush41" type="Sprite2D" parent="EndFieldBushes2" unique_id=459789045]
+visible = false
+position = Vector2(7255, 1061)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush42" type="Sprite2D" parent="EndFieldBushes2" unique_id=42652581]
+visible = false
+position = Vector2(7195, 1112)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush43" type="Sprite2D" parent="EndFieldBushes2" unique_id=578597258]
+visible = false
+position = Vector2(7197, 1059)
+texture = ExtResource("13_f6dpy")
+
+[node name="Bush44" type="Sprite2D" parent="EndFieldBushes2" unique_id=134103522]
+visible = false
+position = Vector2(7141, 1113)
+texture = ExtResource("13_f6dpy")
+
+[node name="Carrot" parent="EndFieldBushes2" unique_id=1754863128 instance=ExtResource("62_xqyqm")]
+position = Vector2(7145, 1060)
+
+[node name="Carrot2" parent="EndFieldBushes2" unique_id=1062737757 instance=ExtResource("62_xqyqm")]
+position = Vector2(7313, 1058)
+
+[node name="Carrot3" parent="EndFieldBushes2" unique_id=1378603798 instance=ExtResource("62_xqyqm")]
+position = Vector2(7255, 1114)
+
+[node name="Carrot4" parent="EndFieldBushes2" unique_id=990491588 instance=ExtResource("62_xqyqm")]
+position = Vector2(7255, 1061)
+
+[node name="Carrot5" parent="EndFieldBushes2" unique_id=329861797 instance=ExtResource("62_xqyqm")]
+position = Vector2(7195, 1112)
+
+[node name="Carrot6" parent="EndFieldBushes2" unique_id=1977317770 instance=ExtResource("62_xqyqm")]
+position = Vector2(7197, 1059)
+
+[node name="Carrot7" parent="EndFieldBushes2" unique_id=519122335 instance=ExtResource("62_xqyqm")]
+position = Vector2(7141, 1113)
 
 [connection signal="body_entered" from="CameraStuff/DeadEndArea" to="." method="_on_dead_end_area_body_entered"]
 [connection signal="body_exited" from="CameraStuff/DeadEndArea" to="." method="_on_dead_end_area_body_exited"]

--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -19,7 +19,6 @@
 [ext_resource type="PackedScene" uid="uid://cfcgrfvtn04yp" path="res://scenes/ui_elements/hud/hud.tscn" id="10_idy4y"]
 [ext_resource type="PackedScene" uid="uid://7873qa54birk" path="res://scenes/game_elements/props/tree/tree.tscn" id="11_75rvf"]
 [ext_resource type="PackedScene" uid="uid://dua6mynlw2ptw" path="res://scenes/game_elements/props/checkpoint/checkpoint.tscn" id="11_idy4y"]
-[ext_resource type="Texture2D" uid="uid://ck738xogv1kp5" path="res://assets/third_party/tiny-swords/Deco/11.png" id="13_f6dpy"]
 [ext_resource type="Texture2D" uid="uid://ctwx8gghts62p" path="res://assets/third_party/tiny-swords/Deco/06.png" id="14_v7vlq"]
 [ext_resource type="Texture2D" uid="uid://cw330muutqql7" path="res://assets/third_party/tiny-swords/Deco/05.png" id="15_7kcq2"]
 [ext_resource type="SpriteFrames" uid="uid://r0w8oerw0kga" path="res://scenes/game_elements/props/decoration/water_rock/components/water_rock_01.tres" id="16_pld6d"]
@@ -1002,390 +1001,103 @@ script = ExtResource("56_4qmxg")
 [node name="Marker" type="Marker2D" parent="Helper" unique_id=1877766615]
 position = Vector2(0, -72)
 
-[node name="MiddleFieldBushes" type="Node2D" parent="." unique_id=1058693455]
-visible = false
+[node name="MiddleFieldBushes" type="Node2D" parent="." unique_id=669269306]
 y_sort_enabled = true
 
-[node name="Bush14" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1895635127]
-position = Vector2(2348, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush15" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1246338694]
-position = Vector2(3102, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush16" type="Sprite2D" parent="MiddleFieldBushes" unique_id=849373817]
-position = Vector2(3221, 725)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush17" type="Sprite2D" parent="MiddleFieldBushes" unique_id=2018160986]
-position = Vector2(2987, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush18" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1058303181]
-position = Vector2(2599, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush19" type="Sprite2D" parent="MiddleFieldBushes" unique_id=646958806]
-position = Vector2(2382, 728)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush20" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1066380817]
-position = Vector2(2459, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush21" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1145255538]
-position = Vector2(2528, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush22" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1493723887]
-position = Vector2(2673, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush23" type="Sprite2D" parent="MiddleFieldBushes" unique_id=175746385]
-position = Vector2(2753, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush24" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1040675126]
-position = Vector2(2829, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush25" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1803653289]
-position = Vector2(2912, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush26" type="Sprite2D" parent="MiddleFieldBushes" unique_id=559247427]
-position = Vector2(3061, 728)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush27" type="Sprite2D" parent="MiddleFieldBushes" unique_id=125235965]
-position = Vector2(3144, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush28" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1495778546]
-position = Vector2(3183, 682)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush29" type="Sprite2D" parent="MiddleFieldBushes" unique_id=299438753]
-position = Vector2(3023, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush30" type="Sprite2D" parent="MiddleFieldBushes" unique_id=563159353]
-position = Vector2(2951, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush31" type="Sprite2D" parent="MiddleFieldBushes" unique_id=2131328083]
-position = Vector2(2870, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush32" type="Sprite2D" parent="MiddleFieldBushes" unique_id=2048076406]
-position = Vector2(2791, 681)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush33" type="Sprite2D" parent="MiddleFieldBushes" unique_id=1870391516]
-position = Vector2(2712, 682)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush34" type="Sprite2D" parent="MiddleFieldBushes" unique_id=759214153]
-position = Vector2(2637, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush35" type="Sprite2D" parent="MiddleFieldBushes" unique_id=533493752]
-position = Vector2(2567, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush36" type="Sprite2D" parent="MiddleFieldBushes" unique_id=46556756]
-position = Vector2(2492, 681)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush37" type="Sprite2D" parent="MiddleFieldBushes" unique_id=220567071]
-position = Vector2(2422, 682)
-texture = ExtResource("13_f6dpy")
-
-[node name="MiddleFieldBushes2" type="Node2D" parent="." unique_id=669269306]
-y_sort_enabled = true
-
-[node name="Bush14" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1921637249]
-visible = false
-position = Vector2(2348, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush15" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1276108111]
-visible = false
-position = Vector2(3102, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush16" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1927617394]
-visible = false
-position = Vector2(3221, 725)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush17" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=2074883758]
-visible = false
-position = Vector2(2987, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush18" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1085177049]
-visible = false
-position = Vector2(2599, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush19" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1300676957]
-visible = false
-position = Vector2(2382, 728)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush20" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=2137458117]
-visible = false
-position = Vector2(2459, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush21" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=145769071]
-visible = false
-position = Vector2(2528, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush22" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1638296094]
-visible = false
-position = Vector2(2673, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush23" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=553975207]
-visible = false
-position = Vector2(2753, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush24" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=106706112]
-visible = false
-position = Vector2(2829, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush25" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1528625264]
-visible = false
-position = Vector2(2912, 726)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush26" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=306427506]
-visible = false
-position = Vector2(3061, 728)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush27" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=402778991]
-visible = false
-position = Vector2(3144, 727)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush28" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=665630089]
-visible = false
-position = Vector2(3183, 682)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush29" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=697204762]
-visible = false
-position = Vector2(3023, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush30" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=26347146]
-visible = false
-position = Vector2(2951, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush31" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1947967455]
-visible = false
-position = Vector2(2870, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush32" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1869404873]
-visible = false
-position = Vector2(2791, 681)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush33" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1069512880]
-visible = false
-position = Vector2(2712, 682)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush34" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1113575946]
-visible = false
-position = Vector2(2637, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush35" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=586428092]
-visible = false
-position = Vector2(2567, 683)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush36" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1161047123]
-visible = false
-position = Vector2(2492, 681)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush37" type="Sprite2D" parent="MiddleFieldBushes2" unique_id=1554740220]
-visible = false
-position = Vector2(2422, 682)
-texture = ExtResource("13_f6dpy")
-
-[node name="Barley" parent="MiddleFieldBushes2" unique_id=831247970 instance=ExtResource("61_qsk04")]
+[node name="Barley" parent="MiddleFieldBushes" unique_id=831247970 instance=ExtResource("61_qsk04")]
 position = Vector2(2348, 683)
 
-[node name="Barley2" parent="MiddleFieldBushes2" unique_id=1304420119 instance=ExtResource("61_qsk04")]
+[node name="Barley2" parent="MiddleFieldBushes" unique_id=1304420119 instance=ExtResource("61_qsk04")]
 position = Vector2(3102, 683)
 
-[node name="Barley3" parent="MiddleFieldBushes2" unique_id=445080751 instance=ExtResource("61_qsk04")]
+[node name="Barley3" parent="MiddleFieldBushes" unique_id=445080751 instance=ExtResource("61_qsk04")]
 position = Vector2(3221, 725)
 
-[node name="Barley4" parent="MiddleFieldBushes2" unique_id=830287809 instance=ExtResource("61_qsk04")]
+[node name="Barley4" parent="MiddleFieldBushes" unique_id=830287809 instance=ExtResource("61_qsk04")]
 position = Vector2(2987, 727)
 
-[node name="Barley5" parent="MiddleFieldBushes2" unique_id=1636863251 instance=ExtResource("61_qsk04")]
+[node name="Barley5" parent="MiddleFieldBushes" unique_id=1636863251 instance=ExtResource("61_qsk04")]
 position = Vector2(2599, 726)
 
-[node name="Barley6" parent="MiddleFieldBushes2" unique_id=1084201485 instance=ExtResource("61_qsk04")]
+[node name="Barley6" parent="MiddleFieldBushes" unique_id=1084201485 instance=ExtResource("61_qsk04")]
 position = Vector2(2382, 728)
 
-[node name="Barley7" parent="MiddleFieldBushes2" unique_id=136732394 instance=ExtResource("61_qsk04")]
+[node name="Barley7" parent="MiddleFieldBushes" unique_id=136732394 instance=ExtResource("61_qsk04")]
 position = Vector2(2459, 727)
 
-[node name="Barley8" parent="MiddleFieldBushes2" unique_id=187498037 instance=ExtResource("61_qsk04")]
+[node name="Barley8" parent="MiddleFieldBushes" unique_id=187498037 instance=ExtResource("61_qsk04")]
 position = Vector2(2528, 727)
 
-[node name="Barley9" parent="MiddleFieldBushes2" unique_id=1788789497 instance=ExtResource("61_qsk04")]
+[node name="Barley9" parent="MiddleFieldBushes" unique_id=1788789497 instance=ExtResource("61_qsk04")]
 position = Vector2(2673, 727)
 
-[node name="Barley10" parent="MiddleFieldBushes2" unique_id=227234547 instance=ExtResource("61_qsk04")]
+[node name="Barley10" parent="MiddleFieldBushes" unique_id=227234547 instance=ExtResource("61_qsk04")]
 position = Vector2(2753, 726)
 
-[node name="Barley11" parent="MiddleFieldBushes2" unique_id=1817180277 instance=ExtResource("61_qsk04")]
+[node name="Barley11" parent="MiddleFieldBushes" unique_id=1817180277 instance=ExtResource("61_qsk04")]
 position = Vector2(2829, 726)
 
-[node name="Barley12" parent="MiddleFieldBushes2" unique_id=1155939345 instance=ExtResource("61_qsk04")]
+[node name="Barley12" parent="MiddleFieldBushes" unique_id=1155939345 instance=ExtResource("61_qsk04")]
 position = Vector2(2912, 726)
 
-[node name="Barley13" parent="MiddleFieldBushes2" unique_id=1911297830 instance=ExtResource("61_qsk04")]
+[node name="Barley13" parent="MiddleFieldBushes" unique_id=1911297830 instance=ExtResource("61_qsk04")]
 position = Vector2(3061, 728)
 
-[node name="Barley14" parent="MiddleFieldBushes2" unique_id=643776586 instance=ExtResource("61_qsk04")]
+[node name="Barley14" parent="MiddleFieldBushes" unique_id=643776586 instance=ExtResource("61_qsk04")]
 position = Vector2(3144, 727)
 
-[node name="Barley15" parent="MiddleFieldBushes2" unique_id=1916044884 instance=ExtResource("61_qsk04")]
+[node name="Barley15" parent="MiddleFieldBushes" unique_id=1916044884 instance=ExtResource("61_qsk04")]
 position = Vector2(3183, 682)
 
-[node name="Barley16" parent="MiddleFieldBushes2" unique_id=390307022 instance=ExtResource("61_qsk04")]
+[node name="Barley16" parent="MiddleFieldBushes" unique_id=390307022 instance=ExtResource("61_qsk04")]
 position = Vector2(3023, 683)
 
-[node name="Barley17" parent="MiddleFieldBushes2" unique_id=1850173294 instance=ExtResource("61_qsk04")]
+[node name="Barley17" parent="MiddleFieldBushes" unique_id=1850173294 instance=ExtResource("61_qsk04")]
 position = Vector2(2951, 683)
 
-[node name="Barley18" parent="MiddleFieldBushes2" unique_id=1992044872 instance=ExtResource("61_qsk04")]
+[node name="Barley18" parent="MiddleFieldBushes" unique_id=1992044872 instance=ExtResource("61_qsk04")]
 position = Vector2(2870, 683)
 
-[node name="Barley19" parent="MiddleFieldBushes2" unique_id=538598760 instance=ExtResource("61_qsk04")]
+[node name="Barley19" parent="MiddleFieldBushes" unique_id=538598760 instance=ExtResource("61_qsk04")]
 position = Vector2(2791, 681)
 
-[node name="Barley20" parent="MiddleFieldBushes2" unique_id=260442273 instance=ExtResource("61_qsk04")]
+[node name="Barley20" parent="MiddleFieldBushes" unique_id=260442273 instance=ExtResource("61_qsk04")]
 position = Vector2(2712, 682)
 
-[node name="Barley21" parent="MiddleFieldBushes2" unique_id=1212442662 instance=ExtResource("61_qsk04")]
+[node name="Barley21" parent="MiddleFieldBushes" unique_id=1212442662 instance=ExtResource("61_qsk04")]
 position = Vector2(2637, 683)
 
-[node name="Barley22" parent="MiddleFieldBushes2" unique_id=158353006 instance=ExtResource("61_qsk04")]
+[node name="Barley22" parent="MiddleFieldBushes" unique_id=158353006 instance=ExtResource("61_qsk04")]
 position = Vector2(2567, 683)
 
-[node name="Barley23" parent="MiddleFieldBushes2" unique_id=112277879 instance=ExtResource("61_qsk04")]
+[node name="Barley23" parent="MiddleFieldBushes" unique_id=112277879 instance=ExtResource("61_qsk04")]
 position = Vector2(2492, 681)
 
-[node name="Barley24" parent="MiddleFieldBushes2" unique_id=646050395 instance=ExtResource("61_qsk04")]
+[node name="Barley24" parent="MiddleFieldBushes" unique_id=646050395 instance=ExtResource("61_qsk04")]
 position = Vector2(2422, 682)
 
-[node name="EndFieldBushes" type="Node2D" parent="." unique_id=252711983]
-visible = false
+[node name="EndFieldBushes" type="Node2D" parent="." unique_id=1042222237]
 y_sort_enabled = true
 
-[node name="Bush39" type="Sprite2D" parent="EndFieldBushes" unique_id=1285870624]
-position = Vector2(7145, 1060)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush46" type="Sprite2D" parent="EndFieldBushes" unique_id=1479038353]
-position = Vector2(7313, 1058)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush40" type="Sprite2D" parent="EndFieldBushes" unique_id=2094828725]
-position = Vector2(7255, 1114)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush41" type="Sprite2D" parent="EndFieldBushes" unique_id=483665645]
-position = Vector2(7255, 1061)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush42" type="Sprite2D" parent="EndFieldBushes" unique_id=1245446333]
-position = Vector2(7195, 1112)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush43" type="Sprite2D" parent="EndFieldBushes" unique_id=2124594502]
-position = Vector2(7197, 1059)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush44" type="Sprite2D" parent="EndFieldBushes" unique_id=810153908]
-position = Vector2(7141, 1113)
-texture = ExtResource("13_f6dpy")
-
-[node name="EndFieldBushes2" type="Node2D" parent="." unique_id=1042222237]
-y_sort_enabled = true
-
-[node name="Bush39" type="Sprite2D" parent="EndFieldBushes2" unique_id=655378025]
-visible = false
-position = Vector2(7145, 1060)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush46" type="Sprite2D" parent="EndFieldBushes2" unique_id=1444780401]
-visible = false
-position = Vector2(7313, 1058)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush40" type="Sprite2D" parent="EndFieldBushes2" unique_id=1817722390]
-visible = false
-position = Vector2(7255, 1114)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush41" type="Sprite2D" parent="EndFieldBushes2" unique_id=459789045]
-visible = false
-position = Vector2(7255, 1061)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush42" type="Sprite2D" parent="EndFieldBushes2" unique_id=42652581]
-visible = false
-position = Vector2(7195, 1112)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush43" type="Sprite2D" parent="EndFieldBushes2" unique_id=578597258]
-visible = false
-position = Vector2(7197, 1059)
-texture = ExtResource("13_f6dpy")
-
-[node name="Bush44" type="Sprite2D" parent="EndFieldBushes2" unique_id=134103522]
-visible = false
-position = Vector2(7141, 1113)
-texture = ExtResource("13_f6dpy")
-
-[node name="Carrot" parent="EndFieldBushes2" unique_id=1754863128 instance=ExtResource("62_xqyqm")]
+[node name="Carrot" parent="EndFieldBushes" unique_id=1754863128 instance=ExtResource("62_xqyqm")]
 position = Vector2(7145, 1060)
 
-[node name="Carrot2" parent="EndFieldBushes2" unique_id=1062737757 instance=ExtResource("62_xqyqm")]
+[node name="Carrot2" parent="EndFieldBushes" unique_id=1062737757 instance=ExtResource("62_xqyqm")]
 position = Vector2(7313, 1058)
 
-[node name="Carrot3" parent="EndFieldBushes2" unique_id=1378603798 instance=ExtResource("62_xqyqm")]
+[node name="Carrot3" parent="EndFieldBushes" unique_id=1378603798 instance=ExtResource("62_xqyqm")]
 position = Vector2(7255, 1114)
 
-[node name="Carrot4" parent="EndFieldBushes2" unique_id=990491588 instance=ExtResource("62_xqyqm")]
+[node name="Carrot4" parent="EndFieldBushes" unique_id=990491588 instance=ExtResource("62_xqyqm")]
 position = Vector2(7255, 1061)
 
-[node name="Carrot5" parent="EndFieldBushes2" unique_id=329861797 instance=ExtResource("62_xqyqm")]
+[node name="Carrot5" parent="EndFieldBushes" unique_id=329861797 instance=ExtResource("62_xqyqm")]
 position = Vector2(7195, 1112)
 
-[node name="Carrot6" parent="EndFieldBushes2" unique_id=1977317770 instance=ExtResource("62_xqyqm")]
+[node name="Carrot6" parent="EndFieldBushes" unique_id=1977317770 instance=ExtResource("62_xqyqm")]
 position = Vector2(7197, 1059)
 
-[node name="Carrot7" parent="EndFieldBushes2" unique_id=519122335 instance=ExtResource("62_xqyqm")]
+[node name="Carrot7" parent="EndFieldBushes" unique_id=519122335 instance=ExtResource("62_xqyqm")]
 position = Vector2(7141, 1113)
 
 [connection signal="body_entered" from="CameraStuff/DeadEndArea" to="." method="_on_dead_end_area_body_entered"]


### PR DESCRIPTION
Replaces the bushes in the middle and end fields with barley and carrot crops, preserving their original positions.

The crops were organized under their corresponding Node2D containers with Y Sort enabled to preserve the correct visual layering with the player.

The old bush nodes were removed after review, and the level was tested again to confirm that the crops and player layer correctly.

Issue: #1331