### PR TITLE
Disable collision and hitbox when FragileBarrel breaks

### DIFF
--- a/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
+++ b/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
@@ -12,6 +12,7 @@ signal barrel_destroyed(barrel_instance: FragileBarrel)
 @onready var shatter_sound: AudioStreamPlayer2D = %ShatterSound
 @onready var health_component: HealthComponent = %HealthComponent
 
+@onready var hit_box_collision_shape_2d: CollisionShape2D = %HitBoxCollisionShape2D
 
 func _ready() -> void:
 	super._ready()
@@ -46,6 +47,9 @@ func _on_health_component_health_depleted() -> void:
 	crack_overlay_node.visible = false
 
 	shatter_sound.play()
+
+	hit_box_collision_shape_2d.set_deferred("disabled", true)
+	collision_shape_2d.set_deferred("disabled", true)
 
 	# Play destruction animation directly
 	animated_sprite_2d.play("shatter")

--- a/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
+++ b/scenes/game_elements/props/filling_barrel/components/fragile_barrel.gd
@@ -11,8 +11,8 @@ signal barrel_destroyed(barrel_instance: FragileBarrel)
 @onready var crack_sound: AudioStreamPlayer2D = %CrackSound
 @onready var shatter_sound: AudioStreamPlayer2D = %ShatterSound
 @onready var health_component: HealthComponent = %HealthComponent
-
 @onready var hit_box_collision_shape_2d: CollisionShape2D = %HitBoxCollisionShape2D
+
 
 func _ready() -> void:
 	super._ready()

--- a/scenes/game_elements/props/filling_barrel/filling_barrel.tscn
+++ b/scenes/game_elements/props/filling_barrel/filling_barrel.tscn
@@ -250,7 +250,8 @@ position = Vector2(2, -18)
 collision_layer = 0
 collision_mask = 256
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="HitBox" unique_id=426954511]
+[node name="HitBoxCollisionShape2D" type="CollisionShape2D" parent="HitBox" unique_id=426954511]
+unique_name_in_owner = true
 position = Vector2(-2, 5)
 shape = SubResource("RectangleShape2D_8tegq")
 


### PR DESCRIPTION
When a FragileBarrel depletes its health and shatters, its solid collision shape and hitbox collision shape remained active in the scene. This left invisible blocking geometry in the world and caused the barrel to continue absorbing projectile hits after destruction.

To fix this, the hitbox collision shape is now marked as a Scene Unique Name (%HitBoxCollisionShape2D) in the scene. In fragile_barrel.gd, both the solid collision shape and the hitbox collision shape are disabled in a deferred manner when the health depleted signal is handled.

Note that collision_shape_2d is not explicitly redeclared in FragileBarrel.gd because it is already declared and initialized in the parent class FillingBarrel.

Resolves https://github.com/endlessm/threadbare/issues/2708