### PR TITLE
Eldrune projectile - Fix player ability check

### DIFF
--- a/scenes/quests/story_quests/eldrune/2_combat/combat_components/eldrune_projectile.gd
+++ b/scenes/quests/story_quests/eldrune/2_combat/combat_components/eldrune_projectile.gd
@@ -61,7 +61,7 @@ func _process(_delta: float) -> void:
 ## Returns the player if they're in fighting mode, null otherwise
 func _get_fighting_player() -> Player:
 	var player: Player = get_tree().get_first_node_in_group("player")
-	if player and GameState.has_ability(Enums.PlayerAbilities.ABILITY_A):
+	if player and GameState.player.has_ability(Enums.PlayerAbilities.ABILITY_A):
 		return player
 	return null
 


### PR DESCRIPTION
Updates the Eldrune projectile player ability check to use GameState.player.has_ability() instead of calling has_ability() directly from GameState.

This matches the current game state implementation, where has_ability() is defined in PlayerState.

The Eldrune combat level was tested after the change, and the projectile interaction no longer produces the previous error.

Fixes #2795