### PR TITLE
Add a white flash when the player takes damage

### DIFF
--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -337,10 +337,10 @@ tracks/0/path = NodePath("../PlayerSprite:modulate")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.19999999, 0.4, 0.6),
+"times": PackedFloat32Array(0, 0.06666667, 0.4, 0.6),
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
-"values": [Color(1, 0, 0, 1), Color(1, 1, 1, 1), Color(1, 0, 0, 0.33333334), Color(1, 1, 1, 1)]
+"values": [Color(18.892002, 18.892002, 18.892002, 1), Color(18.892002, 18.892002, 18.892002, 1), Color(1, 1, 1, 0.33333334), Color(1, 1, 1, 1)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_1n58k"]

--- a/scenes/game_elements/characters/player/player.tscn
+++ b/scenes/game_elements/characters/player/player.tscn
@@ -329,7 +329,7 @@ tracks/0/keys = {
 
 [sub_resource type="Animation" id="Animation_4ypcv"]
 resource_name = "got_hit"
-length = 0.3
+length = 0.6
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -337,10 +337,10 @@ tracks/0/path = NodePath("../PlayerSprite:modulate")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.3),
-"transitions": PackedFloat32Array(1, 1),
+"times": PackedFloat32Array(0, 0.19999999, 0.4, 0.6),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
-"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+"values": [Color(1, 0, 0, 1), Color(1, 1, 1, 1), Color(1, 0, 0, 0.33333334), Color(1, 1, 1, 1)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_1n58k"]


### PR DESCRIPTION
This updates the player's GotHitAnimation node to use white instead of red.

Resolves #1743 