### PR TITLE
Fix missing collision and occluder on tower prop

### DIFF
--- a/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
+++ b/scenes/quests/lore_quests/quest_001/3_stealth_level/stealth_level.tscn
@@ -137,6 +137,12 @@ _data = {
 }
 point_count = 2
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_so0j7"]
+size = Vector2(87.499756, 85)
+
+[sub_resource type="OccluderPolygon2D" id="OccluderPolygon2D_6ihr4"]
+polygon = PackedVector2Array(-48.75, 78.75, -51.25, -80, 51.24951, -75, 41.24951, 81.25)
+
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_idy4y"]
 size = Vector2(115, 379)
 
@@ -854,6 +860,18 @@ texture = ExtResource("21_foy1n")
 position = Vector2(6114, 900)
 scale = Vector2(0.8, 0.8)
 texture = ExtResource("22_djpoe")
+
+[node name="StaticBody2D" type="StaticBody2D" parent="EnemyGuards/TowerPatchworkRuined1" unique_id=350946213]
+collision_layer = 10
+collision_mask = 4
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="EnemyGuards/TowerPatchworkRuined1/StaticBody2D" unique_id=1222164061]
+position = Vector2(-2.5, 33.75)
+scale = Vector2(0.99999976, 0.99999976)
+shape = SubResource("RectangleShape2D_so0j7")
+
+[node name="LightOccluder2D" type="LightOccluder2D" parent="EnemyGuards/TowerPatchworkRuined1" unique_id=1547249159]
+occluder = SubResource("OccluderPolygon2D_6ihr4")
 
 [node name="Checkpoints" type="Node2D" parent="." unique_id=1706243097]
 y_sort_enabled = true


### PR DESCRIPTION
This pull request adds collision physics and visual occlusion to the tower in the stealth mission level. Previously, the tower only existed as a visual sprite, allowing the player to pass through it and the guards to detect them through the structure.

The tower scene has been updated with a StaticBody2D containing collision shapes, preventing player overlap and ensuring the guard's line of sight is properly blocked. A LightOccluder2D has also been added to block the guard's light through visual projection.

Resolves
https://github.com/endlessm/threadbare/issues/2248