### PR TITLE
Add Memory helper lore dialogue for void runner

### DIFF
--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/runner_lore_helper.dialogue
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/runner_lore_helper.dialogue
@@ -7,8 +7,8 @@ Do you want to hear my story?
 - No => help_denied
 
 ~ help_accepted
-When I was young, I often wandered through these woods. I remember turning left to cross an old bridge, then heading left again into the forest. Among the trees, I would turn right and follow the trail of sand. Whenever I thought I was lost, I knew the signs to the Sanctuary would guide me home.
-
+When I was young, I often wandered through these woods. I remember turning left to cross an old bridge, then heading left again into the forest. 
+Among the trees, I would turn right and follow the trail of sand. Whenever I thought I was lost, I knew the signs to the Sanctuary would guide me home.
 Bye!
 do GameState.global.clear_help()
 => END

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/runner_lore_helper.dialogue
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/runner_lore_helper.dialogue
@@ -7,7 +7,8 @@ Do you want to hear my story?
 - No => help_denied
 
 ~ help_accepted
-Lore lore lore.
+When I was young, I often wandered through these woods. I remember turning left to cross an old bridge, then heading left again into the forest. Among the trees, I would turn right and follow the trail of sand. Whenever I thought I was lost, I knew the signs to the Sanctuary would guide me home.
+
 Bye!
 do GameState.global.clear_help()
 => END

--- a/scenes/quests/lore_quests/quest_002/1_void_runner/components/runner_lore_helper.dialogue
+++ b/scenes/quests/lore_quests/quest_002/1_void_runner/components/runner_lore_helper.dialogue
@@ -7,7 +7,7 @@ Do you want to hear my story?
 - No => help_denied
 
 ~ help_accepted
-When I was young, I often wandered through these woods. I remember turning left to cross an old bridge, then heading left again into the forest. 
+When I was young, I often wandered through these woods. I remember turning left to cross an old bridge, then heading left again into the forest.
 Among the trees, I would turn right and follow the trail of sand. Whenever I thought I was lost, I knew the signs to the Sanctuary would guide me home.
 Bye!
 do GameState.global.clear_help()


### PR DESCRIPTION
Replaces the placeholder Memory helper dialogue in the Void Runner quest with a short story that provides an indirect hint about the route through the level.

Fixes #2446
