### PR TITLE
Storybook: Reduce list of quests per page by one

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -16,7 +16,7 @@ enum ContentTab { TOC, EN, ES, QUESTS }
 
 ## Quests to show in the storybook.
 @export var quests: Array[Quest]
-@export var quests_per_page: int = 8
+@export var quests_per_page: int = 7
 @export var fade_duration: float = 0.15
 
 var _current_spread_index: int


### PR DESCRIPTION
Since completion checkboxes were added in e3fa2b5a the list overflows and a scrollbar is shown. This is not desired. So reduce the amount of quests in the list from 8 to 7.