### PR TITLE
Add top/bottom/left/right-only broken bridge tiles

### DIFF
--- a/assets/first_party/tiles/Bridge_All.png
+++ b/assets/first_party/tiles/Bridge_All.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:241e9e56d3a2ff7bbc2e5a57c7513fddc094702edf255bb4dad6d474930fd4e3
-size 8712
+oid sha256:a8cf6efa4ba7ac3b4064ccb86dad28d23ba6c3c2d33dcd8d38a0427ccc511f01
+size 10733

--- a/tiles/bridges.tres
+++ b/tiles/bridges.tres
@@ -39,6 +39,14 @@ texture_region_size = Vector2i(64, 64)
 2:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-19.593307, -26.124409, -18.799213, 22.622784, 23.897308, 22.941414, 23.791874, -26.124409, -20.059814, -26.124409)
 1:3/0 = 0
 1:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-26.530273, -21.450008, 27.402245, -21.029629, 27.402245, 15.294277, -27.094748, 15.805267, -27.094748, -22.578957)
+3:0/0 = 0
+3:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-22.302483, -26.475206, -22.590256, 23.741352, 32, 23.597462, 32, -26.187431)
+3:1/0 = 0
+3:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(22.129639, -27.047337, 23.286812, 22.978374, -32, 22.66994, -32, -26.500923)
+3:2/0 = 0
+3:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-28.838629, -26.371155, -29.147064, 32, 28.221764, 32, 27.604889, -25.137415)
+3:3/0 = 0
+3:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-27.047329, 21.583221, -27.913328, -32, 27.604889, -32, 27.913322, 20.202465)
 
 [resource]
 tile_size = Vector2i(64, 64)


### PR DESCRIPTION
The tile "assets/first_party/tiles/Bridge_All.png" has been enlarged by 64 pixels to include four new 64x64 pixel cells on each side of the broken edge. The TileSet "res://tiles/bridges.tres" has been updated with square collision polygons in the non-bridge areas.

Resolves https://github.com/endlessm/threadbare/issues/1854