### PR TITLE
StoryQuest kit: Preconfigure Backstitch server

### DIFF
--- a/tools/sqckck.sh
+++ b/tools/sqckck.sh
@@ -31,6 +31,14 @@ rm .gitignore.template
 git add backstitch-launcher-*
 echo "::endgroup::"
 
+echo "::group::Preconfiguring Backstitch server"
+cat >backstitch.cfg <<EOF
+[backstitch]
+available_servers = "https://alpha.backstitch.dev/"
+server_url = "https://alpha.backstitch.dev/"
+EOF
+echo "::endgroup::"
+
 echo "::group::Committing pruned project"
 git switch --detach
 git add --update
@@ -41,7 +49,7 @@ echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
 echo "::endgroup::"
 
 echo "::group::Creating zip file"
-git archive --format=zip --prefix=threadbare-storyquest/ --output="threadbare-storyquest-kit.zip" @
+git archive --prefix=threadbare-storyquest/ --add-file=backstitch.cfg --format=zip --output="threadbare-storyquest-kit.zip" @
 echo "::endgroup::"
 
 echo "zip_file=threadbare-storyquest-kit.zip" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The latest Backstitch release does not offer
https://alpha.backstitch.dev/ by default, to encourage people not to use
this server for important data.

We want to reduce the number of manual/error-prone steps a learner must
follow to create/join a Backstitch project for their StoryQuest. Add a
backstitch.cfg file to the StoryQuest kit bundle.

As and when we have an Endless-provided server, we will switch this
preseeded file to point there.

Resolves https://github.com/endlessm/threadbare/issues/2825

