### PR TITLE
sound settings: Remove pop from SFX volume slider

### DIFF
--- a/scenes/menus/options/components/sound_settings.tscn
+++ b/scenes/menus/options/components/sound_settings.tscn
@@ -4,7 +4,6 @@
 [ext_resource type="Script" uid="uid://r7cjyiw5log4" path="res://scenes/menus/options/components/options.gd" id="4_back"]
 [ext_resource type="Shortcut" uid="uid://c5pwgp1w8p3y1" path="res://scenes/ui_elements/shortcuts/back_shortcut.tres" id="4_k547c"]
 [ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="5_arrow"]
-[ext_resource type="AudioStream" uid="uid://cp8c37rnfsumh" path="res://scenes/ui_elements/dialogue/components/sounds/839827__tommylistens__bubble_5.wav" id="5_k547c"]
 
 [node name="SoundSettings" type="PanelContainer" unique_id=1536122933 node_paths=PackedStringArray("back_button")]
 anchors_preset = 8
@@ -65,9 +64,3 @@ shortcut = ExtResource("4_k547c")
 text = "Back"
 icon = ExtResource("5_arrow")
 flat = true
-
-[node name="TestSFXPlayer" type="AudioStreamPlayer" parent="." unique_id=1300034183]
-stream = ExtResource("5_k547c")
-bus = &"SFX"
-
-[connection signal="value_changed" from="VBoxContainer/GridContainer/SFXSlider" to="TestSFXPlayer" method="play" flags=3 unbinds=1]


### PR DESCRIPTION
sound settings: Remove pop from SFX volume slider

We now have a click sound that is by played the menu_ui_player, so the
pop is not needed.

Resolves https://github.com/endlessm/threadbare/issues/2831
