### PR TITLE
Fix scene link at end of tutorial

### DIFF
--- a/scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn
+++ b/scenes/quests/lore_quests/quest_000/6_grappling/tutorial_grappling.tscn
@@ -242,6 +242,7 @@ position = Vector2(-575, 315)
 item = SubResource("Resource_u8qfb")
 collected_dialogue = ExtResource("21_x2ecx")
 dialogue_title = &"thread_collected"
+target = 1
 spawn_point_path = NodePath("SpawnPointAfterIntro")
 exit_transition = 1
 


### PR DESCRIPTION
The imagination thread is a SceneLink which pointed to a specific scene (Fray's End) before. Since 5d704eda we removed the specific scene but the target enum wasn't set to "Home Scene". Since e2d8a726 the target enum was introduced.

Fix https://github.com/endlessm/threadbare/issues/2834