### PR TITLE
Fix Storybook back navigation

### DIFF
--- a/scenes/menus/storybook/components/storybook.gd
+++ b/scenes/menus/storybook/components/storybook.gd
@@ -21,6 +21,7 @@ enum ContentTab { TOC, EN, ES, QUESTS }
 
 var _current_spread_index: int
 var _navigation_locked: bool = false
+var _previous_content_spread_index: int = 0
 
 var _quests_per_language: Dictionary[String, Array] = {}
 var _bookmark_indexes: Dictionary[ContentTab, int] = {}
@@ -31,7 +32,6 @@ var _show_language_bookmarks: bool
 
 @onready var quest_container: ScrollContainer = %QuestContainer
 @onready var storybook_page: StorybookPage = %StorybookPage
-@onready var back_button: Button = %BackButton
 @onready var animated_book: AnimatedSprite2D = %AnimatedSprite2D
 @onready var ui_container: Control = %StoryBookContent
 
@@ -143,11 +143,6 @@ func _populate_quest_lists() -> void:
 		spacer.custom_minimum_size.x = 500
 		right_quest_list.add_child(spacer)
 
-	#Connect UI Focus back to the back button safely
-	if previous_button:
-		previous_button.focus_neighbor_bottom = back_button.get_path()
-		back_button.focus_neighbor_top = previous_button.get_path()
-
 
 ## Method to build individual buttons (StoryQuests) and manage the focus chains
 func _create_quest_button(
@@ -168,7 +163,6 @@ func _create_quest_button(
 	button.set_meta("quest", quest)
 
 	button.pressed.connect(_on_quest_button_pressed.bind(button))
-	button.focus_next = back_button.get_path()
 	button.focus_entered.connect(quest_container.ensure_control_visible.bind(button))
 
 	if prev_btn:
@@ -204,15 +198,7 @@ func _update_page_visibility() -> void:
 				if not storybook_page.play_button.has_focus():
 					storybook_page.play_button.grab_focus()
 
-			back_button.focus_previous = storybook_page.play_button.get_path()
-			storybook_page.play_button.focus_next = back_button.get_path()
-
 			if storybook_page.restart_button.visible:
-				back_button.focus_next = storybook_page.restart_button.get_path()
-				back_button.focus_neighbor_right = storybook_page.restart_button.get_path()
-				storybook_page.restart_button.focus_previous = back_button.get_path()
-				storybook_page.restart_button.focus_neighbor_left = back_button.get_path()
-
 				storybook_page.restart_button.focus_next = storybook_page.play_button.get_path()
 				storybook_page.restart_button.focus_neighbor_right = (
 					storybook_page.play_button.get_path()
@@ -221,11 +207,6 @@ func _update_page_visibility() -> void:
 				storybook_page.play_button.focus_neighbor_left = (
 					storybook_page.restart_button.get_path()
 				)
-			else:
-				back_button.focus_next = storybook_page.play_button.get_path()
-				back_button.focus_neighbor_right = storybook_page.play_button.get_path()
-				storybook_page.play_button.focus_neighbor_left = back_button.get_path()
-				storybook_page.play_button.focus_previous = back_button.get_path()
 
 
 func _switch_to_page(spread_index: int) -> void:
@@ -270,7 +251,12 @@ func _on_right_button_pressed() -> void:
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed(&"ui_cancel"):
 		get_viewport().set_input_as_handled()
-		selected.emit(null, false)
+
+		if _current_spread_index >= _bookmark_indexes[ContentTab.QUESTS]:
+			_switch_to_page(_previous_content_spread_index)
+		else:
+			selected.emit(null, false)
+
 	elif event.is_action_pressed("next_tab"):
 		_on_right_button_pressed()
 	elif event.is_action_pressed("previous_tab"):
@@ -280,15 +266,12 @@ func _input(event: InputEvent) -> void:
 func _on_quest_button_pressed(button: Button) -> void:
 	var quest: Quest = button.get_meta("quest")
 	var quest_index := quests.find(quest)
+	_previous_content_spread_index = _current_spread_index
 	_switch_to_page(_bookmark_indexes[ContentTab.QUESTS] + quest_index)
 
 
 func _on_storybook_page_selected(quest: Quest, restart: bool) -> void:
 	selected.emit(quest, restart)
-
-
-func _on_back_button_pressed() -> void:
-	selected.emit(null, false)
 
 
 func _switch_to_bookmark(target_tab: ContentTab) -> void:

--- a/scenes/menus/storybook/storybook.tscn
+++ b/scenes/menus/storybook/storybook.tscn
@@ -4,7 +4,6 @@
 [ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="2_ofgxb"]
 [ext_resource type="PackedScene" uid="uid://cgtonist08yxn" path="res://scenes/menus/storybook/components/storybook_page.tscn" id="3_n2i2u"]
 [ext_resource type="SpriteFrames" uid="uid://dne3cxrhbjuno" path="res://scenes/menus/storybook/components/storybook_animation.tres" id="3_y0b3i"]
-[ext_resource type="Texture2D" uid="uid://xe25gqovxxpe" path="res://assets/first_party/icons/left_arrow.png" id="5_m2ghf"]
 [ext_resource type="Resource" uid="uid://ddxn14xw66ud8" path="res://scenes/quests/template_quests/NO_EDIT/quest.tres" id="5_ywp77"]
 [ext_resource type="Material" uid="uid://cruf3tlajs4jo" path="res://scenes/ui_elements/input_hints/components/drop_shadow_material.tres" id="9_xkl6m"]
 [ext_resource type="Texture2D" uid="uid://dgfsrkr8a370h" path="res://assets/third_party/kenney_input_prompts/steam-deck_sheet_default.png" id="10_p0vqm"]
@@ -135,29 +134,6 @@ offset_right = 418.0
 offset_bottom = 305.0
 theme_override_constants/margin_left = -5
 
-[node name="BackButton" type="Button" parent="VBoxContainer/CenterContainer/StoryBookContent" unique_id=633672164]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -298.0
-offset_top = 242.0
-offset_right = -88.0
-offset_bottom = 302.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_horizontal = 4
-size_flags_vertical = 8
-focus_next = NodePath("../StorybookPage/VBoxContainer/PlayButton")
-mouse_filter = 1
-theme_type_variation = &"FlatButton"
-text = "Back"
-icon = ExtResource("5_m2ghf")
-flat = true
-
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer" unique_id=1971907031]
 layout_mode = 2
 theme_override_constants/margin_right = 8
@@ -247,4 +223,3 @@ layout_mode = 2
 text = "ES"
 
 [connection signal="selected" from="VBoxContainer/CenterContainer/StoryBookContent/StorybookPage" to="." method="_on_storybook_page_selected"]
-[connection signal="pressed" from="VBoxContainer/CenterContainer/StoryBookContent/BackButton" to="." method="_on_back_button_pressed"]


### PR DESCRIPTION
## Summary

- Remove the Back button from the Storybook quest lists and individual quest pages.
- Return to the previous content list when pressing ESC/B from an individual quest.

Resolves #2457