### PR TITLE
Update to Dialogue Manager 4.1.0

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -993,6 +993,7 @@ namespace DialogueManagerRuntime
             InlineMutations = (Array<Godot.Collections.Array>)data.Get("inline_mutations");
             Time = (string)data.Get("time");
             Tags = (Array<string>)data.Get("tags");
+            ExtraGameStates = (Array<Variant>)data.Get("extra_game_states");
 
             foreach (var concurrent_line_data in (Array<RefCounted>)data.Get("concurrent_lines"))
             {

--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -102,13 +102,18 @@ func find_imported_cues(text: String, path: String) -> void:
 
 		if import_data.size() == 0 or not import_data.has("path"): continue
 
+		# If a UID is given then convert it to a path
+		var import_data_path: String = import_data.path
+		if import_data_path.begins_with("uid://"):
+			import_data_path = ResourceUID.get_id_path(ResourceUID.text_to_id(import_data_path))
+
 		if known_imports.has(import_data.path):
 			add_error(id, 0, DMConstants.ERR_FILE_ALREADY_IMPORTED)
 		elif known_imports.values().has(import_data.prefix):
 			add_error(id, 0, DMConstants.ERR_DUPLICATE_IMPORT_NAME)
 		else:
 			# Get cues from other file and map them to the known list of cues.
-			var cached_file_data: Dictionary = DMCache.get_file_data(import_data.path)
+			var cached_file_data: Dictionary = DMCache.get_file_data(import_data_path)
 
 			# Guard against failed loads -- namely during reimport cascade.
 			if cached_file_data.is_empty():
@@ -118,13 +123,13 @@ func find_imported_cues(text: String, path: String) -> void:
 
 			var external_cues: Dictionary = cached_file_data.cues
 			if external_cues.is_empty():
-				var content: PackedStringArray = FileAccess.get_file_as_string(import_data.path).split("\n")
+				var content: PackedStringArray = FileAccess.get_file_as_string(import_data_path).split("\n")
 				for i: int in range(0, content.size()):
 					var l: String = content[i]
 					if not "/" in l and get_line_type(l) == DMConstants.TYPE_CUE:
 						external_cues[l.substr(2).strip_edges()] = str(i)
 
-			var uid: String = ResourceUID.path_to_uid(import_data.path).replace("uid://", "")
+			var uid: String = ResourceUID.path_to_uid(import_data_path).replace("uid://", "")
 			for cue_key: String in external_cues:
 				# Ignore any cues that are already a reference
 				if "/" in cue_key: continue

--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -56,7 +56,6 @@ var font_size: int:
 		return font_size
 
 var WEIGHTED_RANDOM_PREFIX: RegEx = RegEx.create_from_string("^\\%[\\d.]+\\s")
-var STATIC_REGEX: RegEx = RegEx.create_from_string("^static var (?<property>[a-zA-Z_0-9]+)(:\\s?(?<type>[a-zA-Z_0-9]+))?")
 var STATIC_CONTENT_REGEX: RegEx = RegEx.create_from_string("static (var|func)")
 
 var compiler_regex: DMCompilerRegEx = DMCompilerRegEx.new()
@@ -162,6 +161,11 @@ func _drop_data(at_position: Vector2, data: Variant) -> void:
 						alias =  "_".join(bits.slice(0, end))
 						if not alias in known_aliases:
 							break
+
+					# convert the file path to a uid
+					if EditorInterface.get_editor_settings().get("text_editor/behavior/files/drop_preload_resources_as_uid"):
+						file = ResourceUID.path_to_uid(file)
+
 					insert_line_at(i, "import \"%s\" as %s\n" % [file, alias])
 					set_caret_line(i)
 					break
@@ -592,13 +596,14 @@ func _get_members_for_script(script: Variant) -> Array[Dictionary]:
 				type = "constant"
 			})
 
-		# Check for static properties
-		for line: String in script.source_code.split("\n"):
-			var matching: RegExMatch = STATIC_REGEX.search(line)
-			if matching:
+		# Check for static properties. NOTE: Godot doesn't include static properties in the script property list but
+		# they are listed on the script itself.
+		for m: Dictionary in script.get_property_list():
+			if m.usage & PROPERTY_USAGE_SCRIPT_VARIABLE:
 				members.append({
-					name = matching.strings[matching.names.property],
-					type = "property"
+					name = m.name,
+					type = "property",
+					"class_name" = m.get("class_name", "")
 				})
 	elif script.resource_path.ends_with(".cs"):
 		var dotnet: RefCounted = load(DMPlugin.get_plugin_path() + "/DialogueManager.cs").new()
@@ -729,8 +734,8 @@ func _find_definition_in_script(script: Script, member_name: String) -> Dictiona
 
 	if script is GDScript:
 		# Try to find the line in a GDScript file.
-		var method_regex: RegEx = RegEx.create_from_string("^\\s*func\\s+" + member_name + "\\s*\\(")
-		var property_regex: RegEx = RegEx.create_from_string("^(@.*\\s)?\\s*var\\s+" + member_name + "\\s*[:\\s=]")
+		var method_regex: RegEx = RegEx.create_from_string("^(\\s*static )?\\s*func\\s+" + member_name + "\\s*\\(")
+		var property_regex: RegEx = RegEx.create_from_string("^(\\s*static )?(@.*\\s)?\\s*var\\s+" + member_name + "\\s*[:\\s=]?")
 		var signal_regex: RegEx = RegEx.create_from_string("^\\s*signal\\s+" + member_name + "\\s*[\\(\\s]")
 		var const_regex: RegEx = RegEx.create_from_string("^\\s*const\\s+" + member_name + "\\s*[:\\s=]")
 		var enum_regex: RegEx = RegEx.create_from_string("^\\s*enum\\s+" + member_name + "[\\s$]")
@@ -1098,21 +1103,20 @@ func _resolve_script_for_property_chain(segments: PackedStringArray) -> Variant:
 						# Constant isn't an enum or an inner class
 						return null
 
-		# Static properties. NOTE: Godot doesn't programatically find static properties
-		# so we have to manually find them.
-		if not found_property and current_script is Script and current_script.source_code.contains("static var"):
-			for line: String in current_script.source_code.split("\n"):
-				var matched: RegExMatch = STATIC_REGEX.search(line)
-				if matched and matched.strings[matched.names.property] == property_name:
-					if matched.names.has("type"):
-						var type: String = matched.strings[matched.names.type]
-						current_script = _get_script_for_class_name(type)
-						if current_script == null:
-							return null
-						found_property = true
-						break
-					else:
+		# Static properties. NOTE: Godot doesn't include static properties in the script property list but
+		# they are listed on the script itself.
+		if not found_property and current_script is Script:
+			for property_info: Dictionary in current_script.get_property_list():
+				if property_info.usage & PROPERTY_USAGE_SCRIPT_VARIABLE and property_info.name == property_name:
+					var prop_class_name: String = property_info.get("class_name", "")
+					if prop_class_name == "":
+						# Property doesn't have a class type, can't go deeper
 						return null
+					current_script = _get_script_for_class_name(prop_class_name)
+					if current_script == null:
+						return null
+					found_property = true
+					break
 
 		if not found_property:
 			return null

--- a/addons/dialogue_manager/components/export_to_csv_dialog.gd
+++ b/addons/dialogue_manager/components/export_to_csv_dialog.gd
@@ -1,0 +1,100 @@
+@tool
+
+extends ConfirmationDialog
+
+
+var delimiter: String = ","
+
+@onready var file_dialog: FileDialog = %FileDialog
+@onready var path_edit: LineEdit = %PathEdit
+@onready var path_button: Button = %PathButton
+@onready var locale_edit: LineEdit = %LocaleEdit
+@onready var delimiter_menu: OptionButton = %DelimiterMenu
+@onready var include_character_names_button: CheckBox = %IncludeCharacterNamesButton
+@onready var include_notes_button: CheckBox = %IncludeNotesButton
+@onready var path_label: Label = %PathLabel
+@onready var locale_label: Label = %LocaleLabel
+@onready var delimiter_label: Label = %DelimiterLabel
+
+
+func _ready() -> void:
+	path_button.icon = get_theme_icon("Folder", "EditorIcons")
+	path_button.text = ""
+
+	delimiter_menu.get_popup().about_to_popup.connect(_on_delimiter_menu_about_to_popup)
+	delimiter_menu.get_popup().index_pressed.connect(_on_delimiter_menu_index_pressed)
+	delimiter_menu.text = DMConstants.translate("Comma")
+
+	locale_edit.text = TranslationServer.get_tool_locale()
+
+	title = DMConstants.translate("Simple CSV export...")
+	get_ok_button().text = DMConstants.translate("Export simple CSV")
+	get_ok_button().disabled = true
+
+	path_label.text = DMConstants.translate("CSV path")
+	locale_label.text = DMConstants.translate("Default locale")
+	delimiter_label.text = DMConstants.translate("Default delimiter")
+	include_character_names_button.text = DMConstants.translate("Include character name column")
+	include_notes_button.text = DMConstants.translate("Include notes column")
+
+	path_edit.grab_focus()
+
+
+#region Signals
+
+
+func _on_path_button_pressed() -> void:
+	file_dialog.popup_centered()
+
+
+func _on_file_dialog_file_selected(path: String) -> void:
+	path_edit.text = path
+
+
+func _on_file_dialog_confirmed() -> void:
+	path_edit.text = file_dialog.current_path
+
+
+func _on_confirmed() -> void:
+	DMTranslationUtilities.export_all_translations_to_csv(
+		path_edit.text,
+		locale_edit.text,
+		delimiter,
+		include_character_names_button.button_pressed,
+		include_notes_button.button_pressed
+	)
+	hide()
+
+
+func _on_delimiter_menu_about_to_popup() -> void:
+	var menu: PopupMenu = delimiter_menu.get_popup()
+	menu.clear()
+
+	menu.add_item(DMConstants.translate("Comma"))
+	menu.add_item(DMConstants.translate("Tab"))
+	menu.add_item(DMConstants.translate("Semicolon"))
+
+
+func _on_delimiter_menu_index_pressed(index: int) -> void:
+	var menu: PopupMenu = delimiter_menu.get_popup()
+	delimiter_menu.text = menu.get_item_text(index)
+
+	match index:
+		0: # comma
+			delimiter = ","
+		1: # tab
+			delimiter = "\t"
+		2: # semicolon
+			delimiter = ";"
+
+
+func _on_locale_edit_focus_exited() -> void:
+	if locale_edit.text.is_empty():
+		locale_edit.text = TranslationServer.get_tool_locale()
+
+
+func _on_path_edit_text_changed(new_text: String) -> void:
+	get_ok_button().disabled = new_text.is_empty()
+
+
+#endregion

--- a/addons/dialogue_manager/components/export_to_csv_dialog.gd.uid
+++ b/addons/dialogue_manager/components/export_to_csv_dialog.gd.uid
@@ -1,0 +1,1 @@
+uid://cnqjxwe5nbejq

--- a/addons/dialogue_manager/components/export_to_csv_dialog.tscn
+++ b/addons/dialogue_manager/components/export_to_csv_dialog.tscn
@@ -1,0 +1,93 @@
+[gd_scene format=3 uid="uid://lde7jsbv6f24"]
+
+[ext_resource type="Script" uid="uid://cnqjxwe5nbejq" path="res://addons/dialogue_manager/components/export_to_csv_dialog.gd" id="1_k3ych"]
+
+[node name="ExportToCsvDialog" type="ConfirmationDialog" unique_id=1024741315]
+oversampling_override = 1.0
+position = Vector2i(0, 36)
+size = Vector2i(331, 333)
+visible = true
+script = ExtResource("1_k3ych")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1863046707]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -49.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 10
+
+[node name="Path" type="VBoxContainer" parent="VBoxContainer" unique_id=2103397162]
+layout_mode = 2
+
+[node name="PathLabel" type="Label" parent="VBoxContainer/Path" unique_id=357180185]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "CSV path"
+
+[node name="CsvPath" type="HBoxContainer" parent="VBoxContainer/Path" unique_id=1360380745]
+layout_mode = 2
+
+[node name="PathEdit" type="LineEdit" parent="VBoxContainer/Path/CsvPath" unique_id=10294760]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="PathButton" type="Button" parent="VBoxContainer/Path/CsvPath" unique_id=1307396272]
+unique_name_in_owner = true
+layout_mode = 2
+text = "..."
+
+[node name="Locale" type="VBoxContainer" parent="VBoxContainer" unique_id=2082649931]
+layout_mode = 2
+
+[node name="LocaleLabel" type="Label" parent="VBoxContainer/Locale" unique_id=130476924]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Default locale "
+
+[node name="LocaleEdit" type="LineEdit" parent="VBoxContainer/Locale" unique_id=1329469690]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(200, 0)
+layout_mode = 2
+placeholder_text = "en"
+
+[node name="Delimiter" type="VBoxContainer" parent="VBoxContainer" unique_id=1277602714]
+layout_mode = 2
+
+[node name="DelimiterLabel" type="Label" parent="VBoxContainer/Delimiter" unique_id=2104070692]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Default delimiter "
+
+[node name="DelimiterMenu" type="OptionButton" parent="VBoxContainer/Delimiter" unique_id=537449544]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="IncludeCharacterNamesButton" type="CheckBox" parent="VBoxContainer" unique_id=714454400]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Include character names"
+
+[node name="IncludeNotesButton" type="CheckBox" parent="VBoxContainer" unique_id=1875570652]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Include notes"
+
+[node name="FileDialog" type="FileDialog" parent="." unique_id=1143071127]
+unique_name_in_owner = true
+filters = PackedStringArray("*.csv")
+
+[connection signal="confirmed" from="." to="." method="_on_confirmed"]
+[connection signal="text_changed" from="VBoxContainer/Path/CsvPath/PathEdit" to="." method="_on_path_edit_text_changed"]
+[connection signal="pressed" from="VBoxContainer/Path/CsvPath/PathButton" to="." method="_on_path_button_pressed"]
+[connection signal="focus_exited" from="VBoxContainer/Locale/LocaleEdit" to="." method="_on_default_locale_edit_focus_exited"]
+[connection signal="confirmed" from="FileDialog" to="." method="_on_file_dialog_confirmed"]
+[connection signal="file_selected" from="FileDialog" to="." method="_on_file_dialog_file_selected"]

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -757,10 +757,16 @@ func translate(data: Dictionary) -> String:
 		return data.text
 
 	var static_id: String = data.get(&"static_id", data.text)
-	if static_id.is_empty() or static_id == data.text:
-		return tr(data.text, "dialogue")
+	if DMSettings.get_setting(DMSettings.USE_STATIC_IDS_AS_TRANSLATION_KEYS, true):
+		if static_id.is_empty() or static_id == data.text:
+			return tr(data.text, "dialogue")
+		else:
+			return tr(static_id, "dialogue")
 	else:
-		return tr(static_id, "dialogue")
+		if static_id.is_empty() or static_id == data.text:
+			return tr(data.text)
+		else:
+			return tr(data.text, static_id)
 
 
 # Create a line of dialogue
@@ -860,16 +866,18 @@ func _send_state_to_debugger() -> void:
 
 	var serialised_context: Dictionary = {}
 	for key: String in _registered_contexts.keys():
-		serialised_context[key] = _get_serialised_state_node(
-			key,
-			_registered_contexts.get(key)
-		)
+		if is_instance_valid(_registered_contexts.get(key)):
+			serialised_context[key] = _get_serialised_state_node(
+				key,
+				_registered_contexts.get(key)
+			)
 	var serialised_autoloads: Dictionary = {}
 	for key: String in _autoloads.keys():
-		serialised_autoloads[key] = _get_serialised_state_node(
-			key,
-			_autoloads.get(key)
-		)
+		if is_instance_valid(_autoloads.get(key)):
+			serialised_autoloads[key] = _get_serialised_state_node(
+				key,
+				_autoloads.get(key)
+			)
 	EngineDebugger.send_message("dm:state", [serialised_context, serialised_autoloads])
 
 

--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -45,25 +45,34 @@ func _parse_file(path: String) -> Array[PackedStringArray]:
 		translated_lines.append(line)
 
 		var has_static_id: bool = static_id != "" and static_id != line.text
+		var use_static_id_as_key: bool = DMSettings.get_setting(DMSettings.USE_STATIC_IDS_AS_TRANSLATION_KEYS, true)
 
-		var message: String = static_id.replace('"', '\"') if has_static_id else line.text
-		var context: String = "dialogue"
 		var plural: String = ""
 		var extra_details: PackedStringArray = []
 		if line.has("character"):
 			extra_details.append("Character: %s" % line.get("character", ""))
-		if has_static_id and not line.text.is_empty():
+		if has_static_id and use_static_id_as_key and not line.text.is_empty():
 			extra_details.append("Line: %s" % line.text)
 		if line.has("notes"):
 			extra_details.append("Notes: %s" % line.get("notes", ""))
 		var notes: String = "\n".join(extra_details)
-		msgs.append(PackedStringArray([
-			message,
-			context,
-			plural,
-			notes,
-			key
-		]))
+
+		if use_static_id_as_key:
+			msgs.append(PackedStringArray([
+				static_id.replace('"', '\"') if has_static_id else line.text,
+				"dialogue",
+				plural,
+				notes,
+				key
+			]))
+		else:
+			msgs.append(PackedStringArray([
+				line.text,
+				static_id if has_static_id else "",
+				plural,
+				notes,
+				key
+			]))
 
 	return msgs
 

--- a/addons/dialogue_manager/import_plugin.gd
+++ b/addons/dialogue_manager/import_plugin.gd
@@ -99,6 +99,9 @@ func _import(source_file: String, save_path: String, _options: Dictionary, _plat
 	resource.character_names = result.character_names
 	resource.lines = result.lines
 
+	if DMSettings.get_setting(DMSettings.INCLUDE_RAW_TEXT_IN_DIALOGUE_RESOURCE_META_DATA, false):
+		resource.set_meta("raw_text", raw_text)
+
 	# Clear errors and possibly trigger any cascade recompiles
 	DMCache.add_file(source_file, result)
 

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -521,3 +521,36 @@ msgstr "Get example projects..."
 
 msgid "Buy my game..."
 msgstr "Buy my game..."
+
+msgid "Simple CSV export..."
+msgstr "Simple CSV export..."
+
+msgid "Auto"
+msgstr "Auto"
+
+msgid "Comma"
+msgstr "Comma"
+
+msgid "Semicolon"
+msgstr "Semicolon"
+
+msgid "Tab"
+msgstr "Tab"
+
+msgid "CSV path"
+msgstr "CSV path"
+
+msgid "Default locale"
+msgstr "Default locale"
+
+msgid "Default delimiter"
+msgstr "Default delimiter"
+
+msgid "Include character name column"
+msgstr "Include character name column"
+
+msgid "Include notes coloumn"
+msgstr "Include notes coloumn"
+
+msgid "Export simple CSV"
+msgstr "Export simple CSV"

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -511,3 +511,30 @@ msgstr ""
 
 msgid "Buy my game..."
 msgstr ""
+
+msgid "Simple CSV export..."
+msgstr ""
+
+msgid "Auto"
+msgstr ""
+
+msgid "Comma"
+msgstr ""
+
+msgid "Semicolon"
+msgstr ""
+
+msgid "Tab"
+msgstr ""
+
+msgid "CSV path"
+msgstr ""
+
+msgid "Default locale"
+msgstr ""
+
+msgid "Default delimiter"
+msgstr ""
+
+msgid "Export simple CSV"
+msgstr ""

--- a/addons/dialogue_manager/nodes/context/DialogueStateContext.cs
+++ b/addons/dialogue_manager/nodes/context/DialogueStateContext.cs
@@ -45,7 +45,10 @@ namespace DialogueManagerRuntime
         {
             if (!Engine.IsEditorHint())
             {
-                DialogueManager.Instance.Call("register_state_context", Alias, Target);
+                Callable.From(() =>
+                {
+                    DialogueManager.Instance.Call("register_state_context", Alias, Target);
+                }).CallDeferred();
             }
         }
 

--- a/addons/dialogue_manager/nodes/context/dialogue_state_context.gd
+++ b/addons/dialogue_manager/nodes/context/dialogue_state_context.gd
@@ -25,7 +25,9 @@ class_name DialogueStateContext extends Node
 
 func _enter_tree() -> void:
 	if not Engine.is_editor_hint():
-		Engine.get_singleton("DialogueManager").register_state_context(alias, target)
+		(func() -> void:
+			Engine.get_singleton("DialogueManager").register_state_context(alias, target)
+		).call_deferred()
 
 
 func _exit_tree() -> void:

--- a/addons/dialogue_manager/nodes/responses_menu/DialogueResponsesMenu.cs
+++ b/addons/dialogue_manager/nodes/responses_menu/DialogueResponsesMenu.cs
@@ -120,7 +120,7 @@ namespace DialogueManagerRuntime
             {
                 Control item = items[i];
 
-                item.FocusMode = FocusModeEnum.All;
+                item.FocusMode = Control.FocusModeEnum.All;
 
                 item.FocusNeighborLeft = item.GetPath();
                 item.FocusNeighborRight = item.GetPath();

--- a/addons/dialogue_manager/plugin.cfg
+++ b/addons/dialogue_manager/plugin.cfg
@@ -3,5 +3,5 @@
 name="Dialogue Manager"
 description="A powerful branching dialogue system"
 author="Nathan Hoad"
-version="4.0.3"
+version="4.1.0"
 script="plugin.gd"

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -386,12 +386,15 @@ func _update_localization() -> void:
 
 func _create_translations_tool_menu_item() -> PopupMenu:
 	var tool_menu: PopupMenu = PopupMenu.new()
-	tool_menu.add_icon_item(_get_plugin_icon(), "Create balloon...")
-	tool_menu.add_icon_item(main_view.get_theme_icon("Translation", "EditorIcons"), DMConstants.translate("generate_line_ids"))
-	tool_menu.index_pressed.connect(func(index: int) -> void:
-		match index:
+	tool_menu.add_icon_item(_get_plugin_icon(), "Create balloon...", 0)
+	tool_menu.add_separator()
+	tool_menu.add_icon_item(main_view.get_theme_icon("Translation", "EditorIcons"), DMConstants.translate("generate_line_ids"), 1)
+	tool_menu.add_icon_item(main_view.get_theme_icon("DirAccess", "EditorIcons"), DMConstants.translate("Simple CSV export..."), 2)
+	tool_menu.id_pressed.connect(func(id: int) -> void:
+		match id:
 			0: # create balloon
 				_create_dialogue_balloon()
+
 			1: # generate IDs
 				var confirm: ConfirmationDialog = ConfirmationDialog.new()
 				confirm.title = DMConstants.translate("generate_ids.warning_title")
@@ -406,6 +409,11 @@ func _create_translations_tool_menu_item() -> PopupMenu:
 				)
 				add_child(confirm)
 				confirm.popup_centered()
+
+			2: # Simple CSV export
+				var csv_dialog: ConfirmationDialog = load(get_plugin_path() + "/components/export_to_csv_dialog.tscn").instantiate()
+				add_child(csv_dialog)
+				csv_dialog.popup_centered()
 	)
 	return tool_menu
 

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -11,6 +11,7 @@ const WRAP_LONG_LINES: StringName = &"editor/wrap_long_lines"
 ## The template to start new dialogue files with.
 const NEW_FILE_TEMPLATE: StringName = &"editor/new_file_template"
 
+const USE_STATIC_IDS_AS_TRANSLATION_KEYS: StringName = &"editor/translations/use_static_ids_as_translation_keys"
 ## Show lines without statis IDs as errors.
 const MISSING_TRANSLATIONS_ARE_ERRORS: StringName = &"editor/translations/missing_translations_are_errors"
 ## Include character names in the list of translatable strings.
@@ -35,6 +36,9 @@ const WARN_ABOUT_METHOD_PROPERTY_OR_SIGNAL_NAME_CONFLICTS: StringName = &"runtim
 
 ## Bypass any missing state when running dialogue.
 const IGNORE_MISSING_STATE_VALUES: StringName = &"runtime/advanced/ignore_missing_state_values"
+## Keep a copy of the raw text in a [DialogueResource] meta data
+const INCLUDE_RAW_TEXT_IN_DIALOGUE_RESOURCE_META_DATA: StringName = &"runtime/advanced/include_raw_text_in_dialogue_resource_meta_data"
+
 ## Whether or not the project is utilising dotnet.
 const USES_DOTNET: StringName = &"runtime/advanced/uses_dotnet"
 
@@ -50,6 +54,10 @@ static var SETTINGS_CONFIGURATION: Dictionary = {
 		hint = PROPERTY_HINT_MULTILINE_TEXT,
 	},
 
+	USE_STATIC_IDS_AS_TRANSLATION_KEYS: {
+		value = true,
+		type = TYPE_BOOL,
+	},
 	MISSING_TRANSLATIONS_ARE_ERRORS: {
 		value = false,
 		type = TYPE_BOOL,
@@ -111,6 +119,12 @@ static var SETTINGS_CONFIGURATION: Dictionary = {
 		type = TYPE_BOOL,
 		is_advanced = true
 	},
+	INCLUDE_RAW_TEXT_IN_DIALOGUE_RESOURCE_META_DATA: {
+		value = false,
+		type = TYPE_BOOL,
+		is_advanced = true
+	},
+
 	USES_DOTNET: {
 		value = false,
 		type = TYPE_BOOL,

--- a/addons/dialogue_manager/utilities/translations.gd
+++ b/addons/dialogue_manager/utilities/translations.gd
@@ -54,3 +54,116 @@ static func generate_static_line_ids_for_text(text: String, file_path: String) -
 ## Get a random-ish ID for a line.
 static func _generate_id(file_path: String) -> String:
 	return ResourceUID.path_to_uid(file_path).replace("uid://", "") + "_" + str(randi() % 1000000).sha1_text().substr(0, 6)
+
+
+## Export the dialogue and responses of every dialogue file in the project to a single CSV.
+static func export_all_translations_to_csv(to_path: String, default_locale: String, default_delimiter: String, include_character_names: bool, include_notes: bool) -> void:
+	var file: FileAccess
+
+	# If the file exists, read it first so we can keep any translations that are already in it and match its existing column layout
+	var existing_csv: Dictionary = {}
+	var headings: PackedStringArray = []
+	var delimiter: String = get_delimiter_for_csv(to_path, default_delimiter)
+	var column_count: int = 2
+	var default_locale_column: int = 1
+	var character_column: int = -1
+	var notes_column: int = -1
+	if FileAccess.file_exists(to_path):
+		file = FileAccess.open(to_path, FileAccess.READ)
+		var is_first_line: bool = true
+		var line: Array
+		while !file.eof_reached():
+			line = file.get_csv_line(delimiter)
+			if is_first_line:
+				is_first_line = false
+				headings = PackedStringArray(line)
+				column_count = line.size()
+				for i: int in range(1, line.size()):
+					if line[i] == default_locale:
+						default_locale_column = i
+					elif line[i] == "_character":
+						character_column = i
+					elif line[i] == "_notes":
+						notes_column = i
+				continue
+
+			# Make sure the line isn't empty before adding it
+			if line.size() > 0 and line[0].strip_edges() != "":
+				existing_csv[line[0]] = line
+		file.close()
+
+	# If there wasn't an existing file then start a fresh heading row
+	if headings.is_empty():
+		headings = ["keys", default_locale]
+		column_count = headings.size()
+
+	# Add the optional columns if their settings are turned on but they aren't in the file yet
+	if character_column == -1 and include_character_names:
+		character_column = column_count
+		column_count += 1
+		headings.append("_character")
+	if notes_column == -1 and include_notes:
+		notes_column = column_count
+		column_count += 1
+		headings.append("_notes")
+
+	# Gather every translatable line from every dialogue file in the project. Files are processed in a stable (sorted)
+	# order and their lines are kept in source order, so editing one file only ever changes that file's section of the
+	# CSV instead of shuffling rows around.
+	var files: Array = Array(DMCache.get_files())
+	files.sort()
+
+	var known_keys: PackedStringArray = []
+	var lines_to_save: Array = []
+	for file_path: String in files:
+		var dialogue: Dictionary = DMCompiler.compile_string(FileAccess.get_file_as_string(file_path), file_path).lines
+		for key: String in dialogue.keys():
+			var line: Dictionary = dialogue.get(key)
+
+			if not line.type in [DMConstants.TYPE_DIALOGUE, DMConstants.TYPE_RESPONSE]: continue
+
+			var translation_key: String = line.get(&"translation_key", line.text)
+
+			if translation_key in known_keys: continue
+
+			known_keys.append(translation_key)
+
+			var line_to_save: PackedStringArray = []
+			if existing_csv.has(translation_key):
+				line_to_save = existing_csv.get(translation_key)
+				line_to_save.resize(column_count)
+			else:
+				line_to_save.resize(column_count)
+				line_to_save[0] = translation_key
+
+			line_to_save[default_locale_column] = line.text
+			if character_column > -1:
+				line_to_save[character_column] = "(response)" if line.type == DMConstants.TYPE_RESPONSE else line.character
+			if notes_column > -1:
+				line_to_save[notes_column] = line.get("notes", "")
+
+			lines_to_save.append(line_to_save)
+
+	# Write the combined CSV. Any keys left in existing_csv are no longer used by any dialogue and are intentionally dropped.
+	file = FileAccess.open(to_path, FileAccess.WRITE)
+	file.store_csv_line(headings, delimiter)
+	for line: Array in lines_to_save:
+		file.store_csv_line(line, delimiter)
+	file.close()
+
+
+## Get the delimiter used for an existing CSV
+static func get_delimiter_for_csv(path: String, default_delimiter: String = ",") -> String:
+	if FileAccess.file_exists(path):
+		var import_path: String = "%s.%s" % [path, "import"]
+		var import_file: ConfigFile = ConfigFile.new()
+		if import_file.load(import_path) == OK:
+			match import_file.get_value("params", "delimiter", 0):
+				0:
+					return ","
+				1:
+					return ";"
+				2:
+					return "\t"
+
+	return default_delimiter

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -178,7 +178,7 @@ func _exit_tree() -> void:
 	DMSettings.set_user_value("most_recent_reopen_file", self.current_file_path)
 
 
-func _unhandled_input(event: InputEvent) -> void:
+func _input(event: InputEvent) -> void:
 	if not visible: return
 
 	if event is InputEventKey and event.is_pressed():


### PR DESCRIPTION
Update to Dialogue Manager 4.1.0

This was done with the in-engine tool.

https://github.com/nathanhoad/godot_dialogue_manager/releases/tag/v4.1.0
shows a handful of fixes compared to 4.0.3 plus a couple of things that
might be interesting to us:
https://github.com/nathanhoad/godot_dialogue_manager/pull/1300 says that
“If using gettext, then you probably want to disable [this new option]”.
I have not made that change in this commit.
