### PR TITLE
Improve StoryQuest bootstrap dialogue appearance

### DIFF
--- a/addons/storyquest_bootstrap/new_storyquest_dialog.gd
+++ b/addons/storyquest_bootstrap/new_storyquest_dialog.gd
@@ -27,8 +27,7 @@ var _valid := false
 
 
 func _ready() -> void:
-	var style := StyleBoxFlat.new()
-	style.bg_color = get_theme_color("dark_color_2", "Editor")
+	var style := get_theme_stylebox("PanelForeground", "EditorStyles")
 	panel.add_theme_stylebox_override("panel", style)
 	title_edit.grab_focus()
 	errors_label.add_theme_color_override(
@@ -118,4 +117,5 @@ func _revalidate() -> void:
 
 	errors_label.text = "\n".join(errors)
 	_valid = errors.size() == 0
+	errors_label.visible = not _valid
 	create_button.disabled = not _valid

--- a/addons/storyquest_bootstrap/new_storyquest_dialog.tscn
+++ b/addons/storyquest_bootstrap/new_storyquest_dialog.tscn
@@ -2,9 +2,6 @@
 
 [ext_resource type="Script" uid="uid://bpu023hmmkkdp" path="res://addons/storyquest_bootstrap/new_storyquest_dialog.gd" id="1_1ir5d"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_euw8d"]
-bg_color = Color(0, 0, 0, 1)
-
 [node name="StoryQuestDialogue" type="Window" unique_id=1241427116]
 oversampling_override = 1.0
 title = "Create StoryQuest"
@@ -20,7 +17,6 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_euw8d")
 
 [node name="PanelContainer" type="MarginContainer" parent="." unique_id=1479415195]
 anchors_preset = 15
@@ -88,6 +84,7 @@ autowrap_mode = 1
 
 [node name="ErrorsLabel" type="RichTextLabel" parent="PanelContainer/VBoxContainer" unique_id=855513329]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 theme_override_colors/default_color = Color(0, 0, 0, 1)
 fit_content = true


### PR DESCRIPTION
Use a style for the background panel that better contrasts the text
color in light themes.

Hide the errors label when it is empty: since it has a different
background colour this looks better than showing the empty region.

Resolves https://github.com/endlessm/threadbare/issues/1893
