### PR TITLE
Make StoryQuest bootstrap dialog less final-sounding

### DIFF
--- a/addons/storyquest_bootstrap/new_storyquest_dialog.gd
+++ b/addons/storyquest_bootstrap/new_storyquest_dialog.gd
@@ -6,6 +6,8 @@ extends Window
 signal create_storyquest(title: String, description: String, filename: String)
 signal cancel
 
+const HELP_URL := "https://github.com/endlessm/threadbare/discussions/599"
+
 @export var storyquests_path: String
 @export var validate_title: Callable
 @export var validate_filename: Callable
@@ -20,13 +22,16 @@ var _valid := false
 @onready var panel: Panel = %Panel
 @onready var title_edit: LineEdit = %TitleEdit
 @onready var folder_edit: LineEdit = %FolderEdit
-@onready var full_path_label: Label = %FullPathLabel
+@onready var full_path_control: Control = %FullPath
 @onready var errors_label: RichTextLabel = %ErrorsLabel
 @onready var description_edit: TextEdit = %DescriptionEdit
+@onready var guide_button: Button = %GuideButton
 @onready var progress_bar: ProgressBar = %ProgressBar
 
 
 func _ready() -> void:
+	guide_button.icon = EditorInterface.get_editor_theme().get_icon("ExternalLink", "EditorIcons")
+
 	var style := get_theme_stylebox("PanelForeground", "EditorStyles")
 	panel.add_theme_stylebox_override("panel", style)
 	title_edit.grab_focus()
@@ -37,6 +42,16 @@ func _ready() -> void:
 	_invalid_char_regex = RegEx.new()
 	var error := _invalid_char_regex.compile("\\W+", true)
 	assert(error == OK, error_string(error))
+
+	full_path_control.text = storyquests_path
+
+
+func _notification(what: int) -> void:
+	match what:
+		NOTIFICATION_EDITOR_PRE_SAVE:
+			guide_button.icon = null
+			panel.remove_theme_stylebox_override("panel")
+			errors_label.remove_theme_color_override("default_color")
 
 
 func _input(event: InputEvent) -> void:
@@ -89,7 +104,7 @@ func _on_title_edit_text_changed(new_text: String) -> void:
 
 func _on_folder_edit_text_changed(new_text: String) -> void:
 	_filename = new_text
-	full_path_label.text = storyquests_path.path_join(_filename)
+	full_path_control.text = storyquests_path.path_join(_filename)
 	_revalidate()
 
 
@@ -119,3 +134,7 @@ func _revalidate() -> void:
 	_valid = errors.size() == 0
 	errors_label.visible = not _valid
 	create_button.disabled = not _valid
+
+
+func _on_guide_button_pressed() -> void:
+	OS.shell_open(HELP_URL)

--- a/addons/storyquest_bootstrap/new_storyquest_dialog.tscn
+++ b/addons/storyquest_bootstrap/new_storyquest_dialog.tscn
@@ -8,6 +8,7 @@ title = "Create StoryQuest"
 initial_position = 1
 size = Vector2i(600, 400)
 transient = true
+min_size = Vector2i(600, 400)
 script = ExtResource("1_1ir5d")
 
 [node name="Panel" type="Panel" parent="." unique_id=693475436]
@@ -34,64 +35,52 @@ theme_override_constants/margin_bottom = 10
 [node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer" unique_id=1753499528]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer" unique_id=482250441]
-layout_mode = 2
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="LinkButton" type="LinkButton" parent="PanelContainer/VBoxContainer/MarginContainer" unique_id=1232284304]
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 4
-text = "Open guide with instructions."
-uri = "https://github.com/endlessm/threadbare/discussions/599"
-
 [node name="GridContainer" type="GridContainer" parent="PanelContainer/VBoxContainer" unique_id=1146920114]
 layout_mode = 2
 columns = 2
 
 [node name="TitleLabel" type="Label" parent="PanelContainer/VBoxContainer/GridContainer" unique_id=2129724723]
 layout_mode = 2
-text = "Title:"
+text = "Working Title"
 
 [node name="TitleEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/GridContainer" unique_id=530857268]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-placeholder_text = "House of the Dragon"
+placeholder_text = "Project Green"
 
 [node name="FolderLabel" type="Label" parent="PanelContainer/VBoxContainer/GridContainer" unique_id=638259626]
 layout_mode = 2
-text = "Folder Name:"
+text = "Folder Name"
 
 [node name="FolderEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/GridContainer" unique_id=146935302]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-placeholder_text = "dragonhouse"
+placeholder_text = "project_green"
 max_length = 20
 emoji_menu_enabled = false
 
-[node name="FullPathLabelLabel" type="Label" parent="PanelContainer/VBoxContainer/GridContainer" unique_id=1324173742]
+[node name="FullPathLabel" type="Label" parent="PanelContainer/VBoxContainer/GridContainer" unique_id=1324173742]
 layout_mode = 2
-text = "Full Path:"
+text = "Full Path"
 
-[node name="FullPathLabel" type="Label" parent="PanelContainer/VBoxContainer/GridContainer" unique_id=1163985931]
+[node name="FullPath" type="LineEdit" parent="PanelContainer/VBoxContainer/GridContainer" unique_id=137652133]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(400, 0)
 layout_mode = 2
 size_flags_horizontal = 3
-autowrap_mode = 1
+editable = false
 
 [node name="ErrorsLabel" type="RichTextLabel" parent="PanelContainer/VBoxContainer" unique_id=855513329]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-theme_override_colors/default_color = Color(0, 0, 0, 1)
 fit_content = true
 
 [node name="DescriptionLabel" type="Label" parent="PanelContainer/VBoxContainer" unique_id=1242171709]
 layout_mode = 2
-text = "Description:"
+text = "Description"
 
 [node name="DescriptionEdit" type="TextEdit" parent="PanelContainer/VBoxContainer" unique_id=1383665589]
 unique_name_in_owner = true
@@ -102,6 +91,13 @@ placeholder_text = "This quest is about..."
 wrap_mode = 1
 tab_input_mode = false
 
+[node name="TipsLabel" type="Label" parent="PanelContainer/VBoxContainer" unique_id=1470208228]
+custom_minimum_size = Vector2(400, 0)
+layout_mode = 2
+text = "You can change your quest's title and description later!"
+horizontal_alignment = 1
+autowrap_mode = 2
+
 [node name="ProgressBar" type="ProgressBar" parent="PanelContainer/VBoxContainer" unique_id=110944402]
 unique_name_in_owner = true
 visible = false
@@ -111,7 +107,20 @@ layout_mode = 2
 layout_mode = 2
 theme_override_constants/margin_top = 10
 
-[node name="CreateButton" type="Button" parent="PanelContainer/VBoxContainer/MarginContainer2" unique_id=1336755490]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/MarginContainer2" unique_id=570432884]
+layout_mode = 2
+
+[node name="GuideButton" type="Button" parent="PanelContainer/VBoxContainer/MarginContainer2/HBoxContainer" unique_id=762514911]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+text = "Online Guide"
+
+[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/MarginContainer2/HBoxContainer" unique_id=1252825542]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="CreateButton" type="Button" parent="PanelContainer/VBoxContainer/MarginContainer2/HBoxContainer" unique_id=1336755490]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(90, 0)
 layout_mode = 2
@@ -127,4 +136,5 @@ text = "Create"
 [connection signal="text_submitted" from="PanelContainer/VBoxContainer/GridContainer/FolderEdit" to="." method="submit" unbinds=1]
 [connection signal="gui_input" from="PanelContainer/VBoxContainer/DescriptionEdit" to="." method="_on_description_edit_gui_input"]
 [connection signal="text_changed" from="PanelContainer/VBoxContainer/DescriptionEdit" to="." method="_on_description_edit_text_changed"]
-[connection signal="pressed" from="PanelContainer/VBoxContainer/MarginContainer2/CreateButton" to="." method="submit"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/MarginContainer2/HBoxContainer/GuideButton" to="." method="_on_guide_button_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/MarginContainer2/HBoxContainer/CreateButton" to="." method="submit"]


### PR DESCRIPTION
Change "Title" to "Working Title" and add a note that the title and
description can be changed later.

Improve the presentation in various ways.

Helps https://github.com/endlessm/threadbare/issues/2842
