### PR TITLE
ci: Build with Godot 4.7.2

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   PCK_NAME: threadbare
-  GODOT_VERSION: "4.7.1"
+  GODOT_VERSION: "4.7.2"
 
 jobs:
   web:

--- a/.github/workflows/make-storyquest-kit.yml
+++ b/.github/workflows/make-storyquest-kit.yml
@@ -23,7 +23,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  GODOT_VERSION: "4.7.1"
+  GODOT_VERSION: "4.7.2"
 
 jobs:
   make-storyquest-kit:


### PR DESCRIPTION
https://godotengine.org/article/maintenance-release-godot-4-7-2/

Nothing jumps out at me, but this is the editor version that I and
Manuel are running (thanks to Flathub auto-updates), so let's keep in
synch.
