### PR TITLE
PlayerRepel: Use AudioStreamPlayer2D.play() not audio animation track

### DIFF
--- a/scenes/game_elements/characters/player/components/player_repel.tscn
+++ b/scenes/game_elements/characters/player/components/player_repel.tscn
@@ -136,21 +136,20 @@ tracks/4/keys = {
 "update": 0,
 "values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0.456), Color(1, 1, 1, 0)]
 }
-tracks/5/type = "audio"
+tracks/5/type = "method"
 tracks/5/imported = false
 tracks/5/enabled = true
 tracks/5/path = NodePath("AirStream/AudioStreamPlayer2D")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
-"clips": [{
-"end_offset": 0.0,
-"start_offset": 0.0,
-"stream": ExtResource("3_bvany")
-}],
-"times": PackedFloat32Array(0.3)
+"times": PackedFloat32Array(0.3),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [0.0],
+"method": &"play"
+}]
 }
-tracks/5/use_blend = true
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_ubfef"]
 _data = {
@@ -178,6 +177,7 @@ scale = Vector2(0.12577, 0.12577)
 texture = ExtResource("2_ochor")
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="AirStream" unique_id=1428086503]
+stream = ExtResource("3_bvany")
 bus = &"SFX"
 
 [node name="RepelAnimation" type="AnimationPlayer" parent="." unique_id=2103763625]


### PR DESCRIPTION
PlayerRepel: Use AudioStreamPlayer2D.play() not audio animation track

This works around a bug/limitation of the web build where spatial
attenuation does not work when using an audio animation track.

Without this change, in Dev Archipelago, the sheep's repel sound is
audible wherever you are in the map, at full volume. With this change,
it is attenuated in the same way as on desktop.

The consequence of this change is that, on the web, the player's own
repel sound is also now panned and attenuated when the player is not at
the centre of the viewport (i.e. when they move near the camera's limits
so the camera can't follow them). I think this is bad! But it's a
pre-existing problem on desktop: this change just makes it consistent
between platforms.

https://github.com/endlessm/threadbare/issues/2771#issuecomment-5598904910
