### PR TITLE
PlayerRepel: Adjust attenuation of sound effect

### DIFF
--- a/scenes/game_elements/characters/player/components/player_repel.tscn
+++ b/scenes/game_elements/characters/player/components/player_repel.tscn
@@ -178,6 +178,9 @@ texture = ExtResource("2_ochor")
 
 [node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="AirStream" unique_id=1428086503]
 stream = ExtResource("3_bvany")
+max_distance = 1200.0
+attenuation = 0.25
+panning_strength = 0.5
 bus = &"SFX"
 
 [node name="RepelAnimation" type="AnimationPlayer" parent="." unique_id=2103763625]


### PR DESCRIPTION
Previously the max_distance was the default, 2000px, with linear
attenuation, and panning strength 1.0×.

For the normal instance in the player scene, this has the effect of
panning the sound quite noticably to the left and right if the player
reaches the edge of the screen (due to camera limits). It's somewhat
noticable at 16:9 aspect ratio but with a very wide screen it's very
obvious.

In Dev Archipelago, the problem with the 2000px max_distance is that we
can hear the ping-pong sheep throughout the scene.

Happily we have declared that the widest aspect ratio we care about is
2.2× (~20:9) so I am ignoring ultrawide viewports! At 2.2× aspect ratio,
the screen is 720px high and 1584px wide, so the furthest the player can
be from the centre of the screen is 792px.

Reduce the max distance to 1200px. Adjust the attenuation curve so that
it begins almost flat then falls off sharply. Reduce the panning. This
has the following effects:

- The volume reduction and panning when the player is near the edge of
  the screen is reduced
- The repelling sheep are not audible from so far away and so are much
  less annoying!

Resolves https://github.com/endlessm/threadbare/issues/2771

