### PR TITLE
Dev Archipelago: Reduce the ping-pong sheep's frequency

### DIFF
--- a/scenes/dev/dev_archipelago.tscn
+++ b/scenes/dev/dev_archipelago.tscn
@@ -796,6 +796,7 @@ scale = Vector2(0.5, 0.5)
 player_controlled = false
 
 [node name="RepelTimer" type="Timer" parent="OnTheGround/Node2D/SheepVolleyball/Sheep/PlayerRepel" unique_id=2058953735]
+wait_time = 2.0
 
 [node name="Sheep2" parent="OnTheGround/Node2D/SheepVolleyball" unique_id=736452734 instance=ExtResource("20_o36d1")]
 position = Vector2(404, -256)
@@ -805,13 +806,13 @@ scale = Vector2(0.5, 0.5)
 player_controlled = false
 
 [node name="RepelTimer2" type="Timer" parent="OnTheGround/Node2D/SheepVolleyball/Sheep2/PlayerRepel2" unique_id=1364618044]
+wait_time = 2.0
 autostart = true
 
 [node name="RepellableBall" parent="OnTheGround/Node2D/SheepVolleyball" unique_id=916389317 instance=ExtResource("22_puqku")]
 position = Vector2(404, -180)
 
 [node name="Timer" type="Timer" parent="OnTheGround/Node2D/SheepVolleyball" unique_id=1063617327]
-wait_time = 0.5
 one_shot = true
 autostart = true
 


### PR DESCRIPTION
Previously they each repelled on a 1-second timer, with one offset by
0.5s.

Double these timeouts this so the ball is repelled once per second, not
twice. This makes the sound less annoying.
