### PR TITLE
Add pre-alpha label to main menu

### DIFF
--- a/addons/threadbare_git_describe/version_label.gd
+++ b/addons/threadbare_git_describe/version_label.gd
@@ -8,4 +8,4 @@ extends Label
 
 
 func _ready() -> void:
-	text = preload("./version.gd").get_full_version()
+	text = "PRE ALPHA · " + preload("./version.gd").get_full_version()


### PR DESCRIPTION
Adds a `PRE ALPHA` label to the main menu next to the current game version.

- Added the `PRE ALPHA` label before the current version number.
- Kept the existing version label, font, styling, and positioning.

Resolves #959 